### PR TITLE
Add issue templates (idea / bug report / config)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: A retrieval-layer script is broken or behaves unexpectedly
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Kip is v0.1 — thanks for helping shake it out. For questions or "does
+        anyone else…", use [Discussions](https://github.com/JWE24-code/kip/discussions).
+        If you hit this **through the desktop app**, [kip-app](https://github.com/JWE24-code/kip-app/issues)
+        is the place — but a CLI repro here helps a lot.
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you ran, what you expected, what you got.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. node scripts/hatch.js path/to/file.md
+        2. …
+      render: shell
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Kip version
+      description: A release tag or a commit sha
+    validations:
+      required: true
+  - type: input
+    id: node
+    attributes:
+      label: Node version
+      description: "`node --version`"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Hatch
+        - Peck
+        - Groom
+        - Reminders
+        - Skills
+        - LLM providers
+        - Roost / index
+        - Something else
+    validations:
+      required: false
+  - type: dropdown
+    id: provider
+    attributes:
+      label: LLM provider
+      options:
+        - Not relevant (deterministic bug)
+        - Anthropic
+        - OpenAI
+        - DeepSeek
+        - Local / Ollama
+        - Other OpenAI-compatible
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Output / trace
+      description: >
+        The error output. For an LLM-path bug, re-run with `--trace` (or
+        `KIP_HATCH_TRACE=1` / `KIP_PECK_TRACE=1`) and attach the relevant
+        `<coop>/.roost/*-trace.jsonl`. These contain your content — redact first.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & general feedback
+    url: https://github.com/JWE24-code/kip/discussions
+    about: For "how do I…", "does anyone else…", and open-ended feedback.
+  - name: Desktop app (UI, packaging, the Logseq fork)
+    url: https://github.com/JWE24-code/kip-app/issues
+    about: Anything about the app shell rather than the retrieval scripts.
+  - name: Security vulnerability
+    url: https://github.com/JWE24-code/kip/security/advisories/new
+    about: Report privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/idea.yml
+++ b/.github/ISSUE_TEMPLATE/idea.yml
@@ -1,0 +1,40 @@
+name: Idea / feature request
+description: Suggest something the retrieval layer should do
+labels: [idea]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This repo is the retrieval layer (`scripts/` — Hatch, Peck, Groom,
+        Reminders, Skills). For the desktop app's UI or packaging, use
+        [kip-app](https://github.com/JWE24-code/kip-app/issues). For open-ended
+        "what if…", [Discussions](https://github.com/JWE24-code/kip/discussions)
+        is a better fit.
+  - type: textarea
+    id: idea
+    attributes:
+      label: The idea
+      description: What should it do, and what problem does it solve for you?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Hatch
+        - Peck
+        - Groom
+        - Reminders
+        - Skills
+        - LLM providers
+        - Roost / index
+        - Not sure
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: How you work around it now
+    validations:
+      required: false


### PR DESCRIPTION
The retrieval repo had no issue templates. This adds three, mirroring kip-app's set and house style:

- **idea.yml** — feature suggestions (`idea` label), Area dropdown (Hatch / Peck / Groom / Reminders / Skills / LLM providers / Roost).
- **bug_report.yml** — Node version instead of app version, a provider dropdown, and `--trace` / `*-trace.jsonl` guidance (with a redaction warning) instead of a `main.log` path.
- **config.yml** — blank issues off; links to Discussions, kip-app (app-shell issues), and the private security-advisory form.

The `idea` label (#fbca04) was also created in both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)