### PR TITLE
hatch: propose/commit split for in-app plan review

### DIFF
--- a/scripts/hatch-all.js
+++ b/scripts/hatch-all.js
@@ -26,7 +26,7 @@ require('dotenv').config()
 const fs = require('node:fs')
 const path = require('node:path')
 const { describeProvider } = require('./lib/llm')
-const { pendingSourcesSummary, hatchAllSources } = require('./lib/hatch')
+const { pendingSourcesSummary, hatchAllSources, proposeNextPending, commitReviewedPlan } = require('./lib/hatch')
 const { DEFAULT_VAULT_ROOT } = require('./lib/paths')
 const telemetry = require('./lib/telemetry')
 const { createRunReporter } = require('./lib/run-progress')
@@ -70,6 +70,17 @@ function parseLimit () {
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : undefined
 }
 
+function parseKeep () {
+  const i = process.argv.indexOf('--keep')
+  if (i === -1) return null
+  try { const v = JSON.parse(process.argv[i + 1]); return Array.isArray(v) ? v : null } catch { return null }
+}
+function parseSkip () {
+  const i = process.argv.indexOf('--skip')
+  const n = i === -1 ? 0 : Number(process.argv[i + 1])
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0
+}
+
 async function main () {
   if (process.argv.includes('--preview')) {
     console.log(JSON.stringify(pendingSourcesSummary(DEFAULT_VAULT_ROOT)))
@@ -79,6 +90,28 @@ async function main () {
   if (!acquireLock()) {
     console.error('Another hatch run is already in progress for this coop.')
     process.exitCode = 1
+    return
+  }
+
+  // "Review before writing" — one file at a time. Each call does a single
+  // step (propose OR commit) and exits; the app drives the loop.
+  if (process.argv.includes('--propose-next')) {
+    try {
+      console.error(describeProvider())
+      const out = await proposeNextPending(DEFAULT_VAULT_ROOT, {
+        ...(parseLimit() ? { limit: parseLimit() } : {}),
+        skip: parseSkip(),
+        combined
+      })
+      console.log(JSON.stringify(out))
+    } finally { releaseLock() }
+    return
+  }
+  if (process.argv.includes('--commit-next')) {
+    try {
+      const out = await commitReviewedPlan(DEFAULT_VAULT_ROOT, { keepSlugs: parseKeep() })
+      console.log(JSON.stringify(out))
+    } finally { releaseLock() }
     return
   }
 

--- a/scripts/lib/hatch.js
+++ b/scripts/lib/hatch.js
@@ -425,9 +425,98 @@ async function hatchAllSources (vaultRoot = DEFAULT_VAULT_ROOT,
   }
 }
 
+/**
+ * "Review before writing" mode, one file at a time. Proposes pages for the
+ * first pending source (skipping the first `skip`, so the caller can step
+ * past files it has already handled this session) but writes nothing. The
+ * full plan — bodies and all — is stashed at <coop>/.roost/hatch-plan.json
+ * for commitReviewedPlan() to pick up; the return value is slim (no bodies,
+ * no source text) for the UI.
+ *
+ * @returns {{done: true} | {source, relPath, kind, remaining,
+ *            plan: Array<{slug, title, type, action, summary}>,
+ *            whiteboard?: true}}
+ */
+async function proposeNextPending (vaultRoot = DEFAULT_VAULT_ROOT,
+  { roots = SOURCE_ROOTS, limit = DEFAULT_BATCH_SIZE, skip = 0, combined = true } = {}) {
+  const { pending } = collectPendingSources(vaultRoot, { roots })
+  const capped = pending.slice(0, limit)
+  const file = capped[skip]
+  if (!file) return { done: true }
+
+  const source = humanizeFilename(file.absPath)
+  const remaining = capped.length - skip - 1
+  const hash = hashContent(fs.readFileSync(file.absPath, 'utf8'))
+  const planFile = path.join(vaultRoot, '.roost', 'hatch-plan.json')
+  fs.mkdirSync(path.dirname(planFile), { recursive: true })
+
+  if (file.kind === 'whiteboard') {
+    // A board becomes one deterministic outline page — nothing to pick from.
+    fs.writeFileSync(planFile, JSON.stringify({ relPath: file.relPath, kind: 'whiteboard', hash, at: Date.now() }))
+    return { source, relPath: file.relPath, kind: 'whiteboard', whiteboard: true, remaining }
+  }
+
+  const p = await proposeHatchPlan(file.absPath, vaultRoot, { copyToEggs: file.kind === 'eggs', combined })
+  fs.writeFileSync(planFile, JSON.stringify({
+    relPath: file.relPath, kind: file.kind, hash,
+    sourceTitle: p.sourceTitle, sourceContent: p.sourceContent, plan: p.plan, at: Date.now()
+  }))
+  return {
+    source, relPath: file.relPath, kind: file.kind, remaining,
+    plan: p.plan.map((c) => ({ slug: c.slug, title: c.title, type: c.type, action: c.action, summary: c.summary || '' }))
+  }
+}
+
+/**
+ * Commits the plan stashed by proposeNextPending(), keeping only the pages
+ * whose slug is in `keepSlugs` (null / undefined = keep all). Records the
+ * source's content hash so it isn't re-proposed — including when the user
+ * kept nothing (a deliberate "skip this file"). Regenerates index.md.
+ *
+ * @returns {{source, results?, skipped?, error?, keptNone?: true}}
+ */
+async function commitReviewedPlan (vaultRoot = DEFAULT_VAULT_ROOT, { keepSlugs = null } = {}) {
+  const planFile = path.join(vaultRoot, '.roost', 'hatch-plan.json')
+  const stash = JSON.parse(fs.readFileSync(planFile, 'utf8'))
+  const source = humanizeFilename(path.join(vaultRoot, stash.relPath))
+  const startedAt = Date.now()
+
+  try {
+    if (stash.kind === 'whiteboard') {
+      const result = await hatchWhiteboard(path.join(vaultRoot, stash.relPath), vaultRoot)
+      recordHatchedSource(stash.relPath, stash.hash, vaultRoot)
+      regenerateIndexMd(vaultRoot)
+      return { source, kind: 'whiteboard', results: [result], skipped: [], ms: Date.now() - startedAt }
+    }
+
+    const keep = Array.isArray(keepSlugs) ? new Set(keepSlugs) : null
+    const kept = keep ? stash.plan.filter((c) => keep.has(c.slug)) : stash.plan
+
+    if (kept.length === 0) {
+      recordHatchedSource(stash.relPath, stash.hash, vaultRoot)
+      return { source, keptNone: true, ms: Date.now() - startedAt }
+    }
+
+    const { results, skipped } = await commitHatchPlan(
+      { plan: kept, sourceTitle: stash.sourceTitle, sourceContent: stash.sourceContent },
+      vaultRoot, { regenIndex: true })
+    if (results.length === 0) {
+      return { source, error: 'every kept page came back empty — try again', ms: Date.now() - startedAt }
+    }
+    recordHatchedSource(stash.relPath, stash.hash, vaultRoot)
+    return { source, kind: stash.kind, results, skipped, ms: Date.now() - startedAt }
+  } catch (err) {
+    return { source, error: (err && err.message) || String(err), ms: Date.now() - startedAt }
+  } finally {
+    try { fs.rmSync(planFile, { force: true }) } catch { /* best-effort */ }
+  }
+}
+
 module.exports = {
   proposeHatchPlan,
   commitHatchPlan,
+  proposeNextPending,
+  commitReviewedPlan,
   ensureInEggs,
   planCandidates,
   humanizeFilename,

--- a/scripts/test/hatch.test.js
+++ b/scripts/test/hatch.test.js
@@ -5,7 +5,7 @@ const os = require('node:os')
 const path = require('node:path')
 
 const { rebuildRoost } = require('../rebuild-roost')
-const { planCandidates, ensureInEggs, humanizeFilename, collectPendingSources, meaningfulTextLength, mapLimit, commitHatchPlan, hatchAllSources, hatchWhiteboard } = require('../lib/hatch')
+const { planCandidates, ensureInEggs, humanizeFilename, collectPendingSources, meaningfulTextLength, mapLimit, commitHatchPlan, hatchAllSources, hatchWhiteboard, proposeNextPending, commitReviewedPlan } = require('../lib/hatch')
 const { recordHatchedSource, getPage } = require('../lib/roost')
 const { saveLLMConfig } = require('../lib/llm')
 const { proposeAndDraftPages } = require('../lib/prompts')
@@ -282,6 +282,68 @@ test('hatchAllSources — classic mode makes one propose call plus one generate 
     assert.equal(summary.hatched.length, 1)
     assert.equal(kinds.filter((k) => k === 'propose').length, 1)
     assert.equal(kinds.filter((k) => k === 'generate').length, 2, 'one generate call per proposed page')
+  } finally {
+    restore()
+  }
+})
+
+test('review mode: proposeNextPending stashes a plan and writes nothing; commitReviewedPlan honours keepSlugs', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  rebuildRoost(root)
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+
+  fs.writeFileSync(path.join(root, 'eggs', 'clinic-visit.md'),
+    'Saw Dr. Alvarez on 2026-08-20 about sleep. Resting heart rate is trending down.')
+
+  const { calls, restore } = stubFetch(() => JSON.stringify({
+    pages: [
+      { title: 'Clinic Visit', type: 'source', tags: ['health'], summary: 's', body: 'Visit notes. See [[dr-alvarez]].' },
+      { title: 'Dr. Alvarez', type: 'entity', tags: ['doctor'], summary: 's', body: 'A physician the user sees.' }
+    ]
+  }))
+
+  try {
+    const proposal = await proposeNextPending(root, {})
+    assert.equal(proposal.source, 'Clinic Visit')
+    assert.equal(proposal.remaining, 0)
+    assert.deepEqual(proposal.plan.map((p) => p.slug).sort(), ['clinic-visit', 'dr-alvarez'])
+    assert.equal(calls.length, 1, 'one propose+draft call')
+    // nothing written yet
+    assert.ok(!fs.existsSync(path.join(root, 'nest', 'entities', 'dr-alvarez.md')))
+    assert.ok(fs.existsSync(path.join(root, '.roost', 'hatch-plan.json')), 'plan stashed')
+
+    // keep only the entity page
+    const result = await commitReviewedPlan(root, { keepSlugs: ['dr-alvarez'] })
+    assert.deepEqual(result.results.map((r) => r.slug), ['dr-alvarez'])
+    assert.ok(fs.existsSync(path.join(root, 'nest', 'entities', 'dr-alvarez.md')))
+    assert.ok(!fs.existsSync(path.join(root, 'nest', 'sources', 'clinic-visit.md')), 'unchecked page not written')
+    assert.ok(!fs.existsSync(path.join(root, '.roost', 'hatch-plan.json')), 'stash cleaned up')
+
+    // the source is recorded as hatched -> not proposed again
+    const next = await proposeNextPending(root, {})
+    assert.equal(next.done, true)
+  } finally {
+    restore()
+  }
+})
+
+test('review mode: commitReviewedPlan with an empty keep list still records the source as handled', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  rebuildRoost(root)
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  fs.writeFileSync(path.join(root, 'eggs', 'skip-me.md'), 'A short note that the user decides not to hatch after all.')
+
+  const { restore } = stubFetch(() => JSON.stringify({
+    pages: [{ title: 'Skip Me', type: 'source', tags: [], summary: 's', body: 'Body.' }]
+  }))
+  try {
+    await proposeNextPending(root, {})
+    const result = await commitReviewedPlan(root, { keepSlugs: [] })
+    assert.equal(result.keptNone, true)
+    assert.ok(!fs.existsSync(path.join(root, 'nest', 'sources', 'skip-me.md')))
+    assert.equal((await proposeNextPending(root, {})).done, true, 'not re-proposed')
   } finally {
     restore()
   }


### PR DESCRIPTION
The retrieval-layer half of JWE24-code/kip-app#41 ("Optional in-app Hatch plan review").

The single-file CLI (`npm run hatch <file>`) already shows the proposed pages and asks y/n. The in-app "Hatch sources" batch just writes. This adds a one-file-at-a-time review path the app can drive, on top of the existing `proposeHatchPlan` / `commitHatchPlan`:

- **`proposeNextPending(vaultRoot, {limit, skip, combined})`** — proposes pages for the first pending source (past `skip`), stashes the full plan (bodies and all) at `<coop>/.roost/hatch-plan.json`, and returns a slim `{source, relPath, kind, plan: [{slug, title, type, action, summary}], remaining}`. **Writes nothing.**
- **`commitReviewedPlan(vaultRoot, {keepSlugs})`** — commits the stashed plan keeping only the listed slugs (`null` = keep all), records the source's content hash so it isn't re-proposed — *including* when `keepSlugs` is `[]`, a deliberate "skip this file" — regenerates `index.md`, clears the stash.

CLI: `hatch-all.js --propose-next [--limit N] [--skip N] [--classic]` and `--commit-next [--keep '["slug-a"]']`.

Batch mode (`hatchAllSources`) is untouched. +2 tests; full suite green (163).