### PR TITLE
skills: approval gate for user skills

### DIFF
--- a/scripts/lib/skills.js
+++ b/scripts/lib/skills.js
@@ -15,7 +15,9 @@
 // user skill under .henhouse/skills/ is like adding a shell script. The
 // runner limits blast radius (timeout, output cap, cwd scoped to the skill
 // dir, entry is a .js file — never an arbitrary shell string) but does not
-// contain it.
+// contain it. As a first gate, a *user* skill is not offered to Peck and
+// will not run until it's been approved once (skills.json `approved`) — see
+// setSkillApproval / isUserSkillApproved.
 const fs = require('node:fs')
 const path = require('node:path')
 const { execFile } = require('node:child_process')
@@ -64,7 +66,10 @@ function loadSkillsConfig (vaultRoot = DEFAULT_VAULT_ROOT) {
   return {
     disabled: Array.isArray(parsed.disabled) ? parsed.disabled : [],
     secrets: obj(parsed.secrets),
-    config: obj(parsed.config)
+    config: obj(parsed.config),
+    // { "<skill-name>": "always" | "never" } — a user skill with no entry
+    // here has never been reviewed and is treated as blocked.
+    approved: obj(parsed.approved)
   }
 }
 
@@ -77,6 +82,34 @@ function setSkillEnabled (vaultRoot, name, enabled) {
   cfg.disabled = [...disabled]
   saveSkillsConfig(cfg, vaultRoot)
   return { name, enabled: !disabled.has(name) }
+}
+
+/**
+ * Records a review decision for a *user* skill. `decision` is 'always',
+ * 'never', or null (forget — back to unreviewed). Built-ins are always
+ * allowed and ignore this. Returns { name, approval }.
+ */
+function setSkillApproval (vaultRoot, name, decision) {
+  const cfg = readSkillsConfigRaw(vaultRoot)
+  const approved = (cfg.approved && typeof cfg.approved === 'object') ? cfg.approved : {}
+  if (decision === 'always' || decision === 'never') approved[name] = decision
+  else delete approved[name]
+  cfg.approved = approved
+  saveSkillsConfig(cfg, vaultRoot)
+  return { name, approval: approved[name] || 'pending' }
+}
+
+/** '' for built-ins; 'always' | 'never' | 'pending' for a user skill. */
+function approvalState (skill, approved) {
+  if (skill.source !== 'user') return ''
+  return approved[skill.name] === 'always' ? 'always'
+    : approved[skill.name] === 'never' ? 'never'
+      : 'pending'
+}
+
+/** May this skill be offered to Peck / run? Built-ins yes; user skills only when approved. */
+function isSkillAllowed (skill, approved) {
+  return skill.source !== 'user' || approved[skill.name] === 'always'
 }
 
 function normalizeParameters (params) {
@@ -133,6 +166,11 @@ function readManifest (dir, source) {
     parameters: normalizeParameters(data.parameters),
     instructions: String(content || '').trim().slice(0, INSTRUCTIONS_CAP),
     network: !!data.network,
+    // Free-text capability claims from the manifest, shown at approval time.
+    // Advisory only — nothing enforces them yet.
+    permissions: Array.isArray(data.permissions)
+      ? data.permissions.filter((p) => typeof p === 'string' && p.trim()).map((p) => p.trim().slice(0, 80)).slice(0, 8)
+      : [],
     source,
     dir,
     entryPath,
@@ -174,11 +212,14 @@ function discoverSkills (vaultRoot = DEFAULT_VAULT_ROOT, { includeDisabled = fal
     if (s) byName.set(s.name, s)
   }
 
-  const { disabled } = loadSkillsConfig(vaultRoot)
+  const { disabled, approved } = loadSkillsConfig(vaultRoot)
   const out = []
   for (const s of byName.values()) {
     const enabled = !disabled.includes(s.name)
-    if (enabled || includeDisabled) out.push({ ...s, enabled })
+    // A user skill that hasn't been approved is not runnable — keep it out of
+    // the list Peck sees (Settings still shows it via describeSkills).
+    if (!includeDisabled && !isSkillAllowed(s, approved)) continue
+    if (enabled || includeDisabled) out.push({ ...s, enabled, approval: approvalState(s, approved) })
   }
   return out
 }
@@ -189,12 +230,15 @@ function discoverSkills (vaultRoot = DEFAULT_VAULT_ROOT, { includeDisabled = fal
  * no filesystem paths.
  */
 function describeSkills (vaultRoot = DEFAULT_VAULT_ROOT) {
+  const { approved } = loadSkillsConfig(vaultRoot)
   return discoverSkills(vaultRoot, { includeDisabled: true }).map((s) => ({
     name: s.name,
     description: s.description,
     whenToUse: s.whenToUse,
     source: s.source,
     network: s.network,
+    permissions: s.permissions || [],
+    approval: approvalState(s, approved),   // '' for built-ins
     enabled: s.enabled,
     parameters: s.parameters
   }))
@@ -285,7 +329,13 @@ function cap (s, n) {
  */
 function runSkill (skill, input, vaultRoot = DEFAULT_VAULT_ROOT, { timeoutMs, outputCapBytes, execFileFn = execFile, env: envOverride } = {}) {
   const started = Date.now()
-  const { secrets, config } = loadSkillsConfig(vaultRoot)
+  const { secrets, config, approved } = loadSkillsConfig(vaultRoot)
+
+  if (!isSkillAllowed(skill, approved)) {
+    const r = { ok: false, output: '', error: `skill "${skill.name}" hasn't been approved — approve it in Settings → Skills`, ms: 0, timedOut: false }
+    record(skill, input, r)
+    return Promise.resolve(r)
+  }
   const env = {
     ...process.env,
     NODE_NO_WARNINGS: '1', // skill deps (docx, pptx-automizer) trip Node's localStorage ExperimentalWarning on v26
@@ -383,6 +433,7 @@ module.exports = {
   loadSkillsConfig,
   saveSkillsConfig,
   setSkillEnabled,
+  setSkillApproval,
   loadSearchSettings,
   saveSearchSettings,
   SEARCH_BACKENDS,

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -36,6 +36,7 @@ function writeFixtureSkill (root, name, run, frontmatter = {}) {
   fs.writeFileSync(path.join(dir, 'SKILL.md'),
     '---\n' + Object.entries(fm).map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join('\n') + '\n---\n')
   fs.writeFileSync(path.join(dir, 'run.js'), run)
+  require('../lib/skills').setSkillApproval(root, name, 'always') // user skills are gated until approved
 }
 
 /** Peck's tests must not see the repo's real bundled skills — disable every

--- a/scripts/test/skills.test.js
+++ b/scripts/test/skills.test.js
@@ -6,7 +6,7 @@ const path = require('node:path')
 
 const {
   discoverSkills, describeSkills, runSkill, loadSkillsConfig, saveSkillsConfig,
-  setSkillEnabled, loadSearchSettings, saveSearchSettings, parseSkillCall, scrubInput
+  setSkillEnabled, setSkillApproval, loadSearchSettings, saveSearchSettings, parseSkillCall, scrubInput
 } = require('../lib/skills')
 const telemetry = require('../lib/telemetry')
 
@@ -17,19 +17,26 @@ function makeTempCoop () {
   return root
 }
 
-/** Writes <coop>/.henhouse/skills/<name>/{SKILL.md, run.js}. */
-function writeSkill (root, name, { frontmatter = {}, body = '', run = 'process.exit(0)' } = {}) {
+/** Writes <coop>/.henhouse/skills/<name>/{SKILL.md, run.js}. Auto-approves the
+ *  skill so existing runnability tests are unaffected; pass approve:false to
+ *  test the approval gate itself. */
+function writeSkill (root, name, { frontmatter = {}, body = '', run = 'process.exit(0)', approve = true } = {}) {
   const dir = path.join(root, '.henhouse', 'skills', name)
   fs.mkdirSync(dir, { recursive: true })
   const fm = Object.assign({ name, description: `test skill ${name}`, entry: 'run.js' }, frontmatter)
   const yaml = Object.entries(fm).map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join('\n')
   fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\n${yaml}\n---\n${body}\n`)
   fs.writeFileSync(path.join(dir, 'run.js'), run)
+  if (approve) setSkillApproval(root, name, 'always')
   return dir
 }
 
 function setSkillsConfig (root, cfg) {
-  fs.writeFileSync(path.join(root, '.henhouse', 'skills.json'), JSON.stringify(cfg))
+  // keep whatever writeSkill() approved unless the test sets `approved` itself
+  const p = path.join(root, '.henhouse', 'skills.json')
+  let prev = {}
+  try { prev = JSON.parse(fs.readFileSync(p, 'utf8')) } catch { /* none yet */ }
+  fs.writeFileSync(p, JSON.stringify({ ...(prev.approved ? { approved: prev.approved } : {}), ...cfg }))
 }
 
 // ---------------------------------------------------------------------------
@@ -52,6 +59,50 @@ test('discoverSkills: includes the built-ins, then user skills; user wins on nam
   const overridden = skills.find((s) => s.name === 'xlsx-csv')
   assert.equal(overridden.source, 'user')
   assert.equal(overridden.description, 'my override')
+})
+
+test('approval gate: a user skill is not runnable until approved; the choice sticks', async (t) => {
+  const root = makeTempCoop()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  writeSkill(root, 'custom', { frontmatter: { network: true, permissions: ['read files', 'network'] }, run: 'console.log("ran")', approve: false })
+
+  // not offered to Peck
+  assert.ok(!discoverSkills(root).some((s) => s.name === 'custom'))
+
+  // but visible in Settings, marked pending, with its declared permissions
+  const listed = describeSkills(root).find((s) => s.name === 'custom')
+  assert.equal(listed.approval, 'pending')
+  assert.deepEqual(listed.permissions, ['read files', 'network'])
+
+  // and it refuses to run
+  const skill = discoverSkills(root, { includeDisabled: true }).find((s) => s.name === 'custom')
+  const blocked = await runSkill(skill, {}, root)
+  assert.equal(blocked.ok, false)
+  assert.match(blocked.error, /approved/i)
+
+  // approve -> runnable + offered, and persisted to skills.json
+  assert.equal(setSkillApproval(root, 'custom', 'always').approval, 'always')
+  assert.equal(loadSkillsConfig(root).approved.custom, 'always')
+  assert.ok(discoverSkills(root).some((s) => s.name === 'custom'))
+  assert.equal((await runSkill(skill, {}, root)).ok, true)
+
+  // block -> not runnable again
+  setSkillApproval(root, 'custom', 'never')
+  assert.equal(describeSkills(root).find((s) => s.name === 'custom').approval, 'never')
+  assert.equal((await runSkill(skill, {}, root)).ok, false)
+
+  // forget -> back to pending
+  setSkillApproval(root, 'custom', null)
+  assert.equal(describeSkills(root).find((s) => s.name === 'custom').approval, 'pending')
+})
+
+test('approval gate: built-ins are always allowed and ignore approval', (t) => {
+  const root = makeTempCoop()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  const bi = describeSkills(root).find((s) => s.name === 'xlsx-csv')
+  assert.equal(bi.source, 'builtin')
+  assert.equal(bi.approval, '')
+  assert.ok(discoverSkills(root).some((s) => s.name === 'xlsx-csv'))
 })
 
 test('discoverSkills: skills.json "disabled" hides a skill unless includeDisabled', (t) => {
@@ -188,9 +239,9 @@ test('scrubInput redacts secret-ish keys', () => {
 test('loadSkillsConfig: safe default on a missing/broken file', (t) => {
   const root = makeTempCoop()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
-  assert.deepEqual(loadSkillsConfig(root), { disabled: [], secrets: {}, config: {} })
+  assert.deepEqual(loadSkillsConfig(root), { disabled: [], secrets: {}, config: {}, approved: {} })
   fs.writeFileSync(path.join(root, '.henhouse', 'skills.json'), '{ not json')
-  assert.deepEqual(loadSkillsConfig(root), { disabled: [], secrets: {}, config: {} })
+  assert.deepEqual(loadSkillsConfig(root), { disabled: [], secrets: {}, config: {}, approved: {} })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Retrieval-layer half of JWE24-code/kip-app#42 (phase 1).

A skill under `<coop>/.henhouse/skills/` is arbitrary Node code running with the user's privileges — no sandbox. This gates the *user* skills (built-ins, reviewed in this repo, are unchanged):

- **`discoverSkills()`** drops any user skill not `approved: "always"` in `skills.json` — Peck never sees it or proposes it
- **`runSkill()`** refuses one regardless, as defense in depth (`{ok: false, error: "…hasn't been approved…"}`)
- **`describeSkills()`** still lists it — `approval: "always" | "never" | "pending"`, plus the free-text `permissions:` array it declares in `SKILL.md` (advisory; nothing enforces it yet) — so the app can render an approval prompt
- new **`setSkillApproval(vaultRoot, name, "always" | "never" | null)`**

`skills.json` gains an `approved` object. +4 tests, full suite green (165). The mid-Peck-turn "allow once" prompt is a phase-2 follow-up.