### PR TITLE
llm.js: refactor into a connector host (#55)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -71,7 +71,9 @@ scripts/
 │   │                # prevention logic, used by peck.js and hatch.js
 │   ├── llm.js      # callLLM() — the ONE provider-swappable LLM entry point —
 │   │                # plus loadLLMConfig/saveLLMConfig, see "LLM provider
-│   │                # config" below
+│   │                # config" below. Hosts lib/connectors.js.
+│   ├── connectors.js # the connector registry: each provider is a ProviderSpec
+│   │                # (fields + complete()); the 5 built-ins live here
 │   ├── telemetry.js # per-run LLM-call timing/token recorder every callLLM()
 │   │                # feeds; content-free summary() + opt-in full-text trace
 │   ├── prompts.js  # prompt content built on callLLM(): extractKeyTerms,
@@ -163,12 +165,15 @@ cp .env.example .env   # CLI-only path — fill in the section for your PROVIDER
 | `deepseek` | `DEEPSEEK_API_KEY` | `DEEPSEEK_MODEL` defaults to `deepseek-chat`. Fixed base URL. |
 | `local` | `LOCAL_MODEL` | No API key. `LOCAL_BASE_URL` defaults to `http://localhost:11434/v1` (Ollama). |
 
-`openai`/`deepseek`/`local` all share one generic OpenAI-compatible chat
-completions client — adding another provider that speaks that format (Kimi,
-Qwen via DashScope, most LocalAI setups) is a few lines in `PROVIDER_CONFIGS`
-in `llm.js`, not a new HTTP client. Every CLI script prints which
-provider/model is active at the start of its run (to stderr, so `groom.js
---json`'s stdout stays pure JSON).
+`openai`/`deepseek`/`local`/`other` all share one generic OpenAI-compatible
+chat completions client — adding another provider that speaks that format
+(Kimi, Qwen via DashScope, most LocalAI setups) is one more `ProviderSpec`
+in `lib/connectors.js`, not a new HTTP client. `llm.js` is the *host*: it
+picks the spec from the registry, resolves its `fields` (file over env over
+default), calls `spec.complete()`, and records telemetry. External
+connectors (the managed Kip backend) register through the same registry.
+Every CLI script prints which provider/model is active at the start of its
+run (to stderr, so `groom.js --json`'s stdout stays pure JSON).
 
 **Privacy note:** switching `PROVIDER` to a hosted third-party backend sends
 coop content (which may include health/personal data) to that provider,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "peck": "node scripts/peck.js",
     "groom": "node scripts/groom.js",
     "hatch": "node scripts/hatch.js",
-    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js"
+    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.70.0",

--- a/scripts/lib/connectors.js
+++ b/scripts/lib/connectors.js
@@ -1,0 +1,322 @@
+// Connector host for the LLM layer.
+//
+// A "connector" is a ProviderSpec (v1): the object that knows one
+// provider's configuration fields and how to turn a call into a completion.
+// llm.js is the *host* — it resolves config (file over env over defaults),
+// builds the call context, dispatches to spec.complete(), and records
+// telemetry. No provider-specific code (the Anthropic SDK, OpenAI-shaped
+// fetch calls) lives outside this file.
+//
+// The five built-ins (anthropic / openai / deepseek / local / other) are
+// ProviderSpecs defined below. External connectors — starting with the
+// managed Kip backend (@kip-ai/connector) — register through
+// loadConnectors() too; graph-local discovery and the install/allowlist
+// flow land in a follow-up (see kip-app#56). For now loadConnectors()
+// returns the built-ins only, and `vaultRoot` is accepted but unused.
+
+const CONNECTOR_API = 1
+
+const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6'
+const JSON_MODE_INSTRUCTION =
+  'Respond with ONLY valid JSON and no other text — no markdown code fences, no explanation.'
+
+// ---------------------------------------------------------------------------
+// Low-level provider calls — each built-in spec's complete() is a thin
+// wrapper over one of these. Moved verbatim from llm.js.
+// ---------------------------------------------------------------------------
+
+function stripCodeFences (text) {
+  const trimmed = text.trim()
+  const fenced = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/)
+  return fenced ? fenced[1].trim() : trimmed
+}
+
+/** Anthropic has no forced-JSON mode: for json:true, ask for it in the system prompt and strip fences after. */
+async function callAnthropic ({ system, prompt, json, maxTokens, apiKey }, AnthropicClient) {
+  const Anthropic = AnthropicClient || require('@anthropic-ai/sdk')
+  // Only pass an explicit apiKey when we have one (from the config file or
+  // ANTHROPIC_API_KEY) — an explicit undefined can short-circuit the SDK's
+  // own fallback chain (ant CLI profile, WIF, ...), which must keep working
+  // for anyone who hasn't set either.
+  const client = apiKey ? new Anthropic({ apiKey }) : new Anthropic()
+
+  const finalSystem = json
+    ? (system ? `${system}\n\n${JSON_MODE_INSTRUCTION}` : JSON_MODE_INSTRUCTION)
+    : system
+
+  const response = await client.messages.create({
+    model: DEFAULT_ANTHROPIC_MODEL,
+    max_tokens: maxTokens,
+    system: finalSystem,
+    messages: [{ role: 'user', content: prompt }]
+  })
+
+  const rawText = response.content
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text)
+    .join('\n')
+    .trim()
+
+  return { text: json ? stripCodeFences(rawText) : rawText, raw: response }
+}
+
+async function postChatCompletion (baseUrl, apiKey, body, doFetch) {
+  const headers = { 'Content-Type': 'application/json' }
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`
+
+  const response = await doFetch(`${baseUrl.replace(/\/$/, '')}/chat/completions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  })
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => response.status)
+    const err = new Error(`${baseUrl} request failed (${response.status}): ${errText}`)
+    err.status = response.status
+    throw err
+  }
+  return response.json()
+}
+
+/**
+ * One generic client for every OpenAI-compatible chat completions API
+ * (openai, deepseek, local/Ollama, "other", and future connectors) — only
+ * baseUrl/apiKey/model differ between them.
+ *
+ * For json:true, tries native response_format: {type: "json_object"} first;
+ * if the provider/model errors on that parameter, retries once without it,
+ * using the same prompt-and-strip approach as the Anthropic path.
+ */
+async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, json, maxTokens }, fetchImpl) {
+  const doFetch = fetchImpl || fetch
+
+  const buildMessages = (sys) => {
+    const messages = []
+    if (sys) messages.push({ role: 'system', content: sys })
+    messages.push({ role: 'user', content: prompt })
+    return messages
+  }
+
+  let data
+  if (json) {
+    try {
+      data = await postChatCompletion(baseUrl, apiKey, {
+        model,
+        max_tokens: maxTokens,
+        messages: buildMessages(system),
+        response_format: { type: 'json_object' }
+      }, doFetch)
+    } catch {
+      const jsonSystem = system ? `${system}\n\n${JSON_MODE_INSTRUCTION}` : JSON_MODE_INSTRUCTION
+      data = await postChatCompletion(baseUrl, apiKey, {
+        model,
+        max_tokens: maxTokens,
+        messages: buildMessages(jsonSystem)
+      }, doFetch)
+    }
+  } else {
+    data = await postChatCompletion(baseUrl, apiKey, {
+      model,
+      max_tokens: maxTokens,
+      messages: buildMessages(system)
+    }, doFetch)
+  }
+
+  const rawText = (data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content) || ''
+  return { text: json ? stripCodeFences(rawText) : rawText.trim(), raw: data }
+}
+
+// ---------------------------------------------------------------------------
+// Built-in ProviderSpecs
+//
+// `fields` drives config resolution and the (data-driven, kip-app#58)
+// settings form: { key, label, type, required, default, placeholder, help }.
+// `envDefaults` maps a field key to the env var it falls back to.
+// `staticModel` is a model the connector always uses and the user can't
+// change (Anthropic) — surfaced only for `describeProvider` / telemetry.
+// openai/deepseek/local/"other" all speak the OpenAI-compatible format and
+// share callOpenAICompatible; Anthropic's own shape is callAnthropic.
+// ---------------------------------------------------------------------------
+
+function builtinSpecs ({ anthropicClient, fetchImpl } = {}) {
+  const openAICompatibleComplete = (resolved, call, ctx) =>
+    callOpenAICompatible({
+      baseUrl: resolved.baseUrl,
+      apiKey: resolved.apiKey,
+      model: resolved.model,
+      system: call.system,
+      prompt: call.prompt,
+      json: call.json,
+      maxTokens: call.maxTokens
+    }, fetchImpl || (ctx && ctx.fetch))
+
+  return [
+    {
+      kipConnectorApi: CONNECTOR_API,
+      id: 'anthropic',
+      label: 'Anthropic (Claude)',
+      staticModel: DEFAULT_ANTHROPIC_MODEL,
+      fields: [
+        { key: 'apiKey', label: 'API key', type: 'password', required: false, placeholder: 'sk-ant-…', help: 'Optional — without one, the Anthropic SDK falls back to its own credential chain (ant CLI profile, etc.).' }
+      ],
+      envDefaults: { apiKey: 'ANTHROPIC_API_KEY' },
+      isReady: () => true,
+      async complete (resolved, call) {
+        return callAnthropic(
+          { system: call.system, prompt: call.prompt, json: call.json, maxTokens: call.maxTokens, apiKey: resolved.apiKey },
+          anthropicClient
+        )
+      }
+    },
+    {
+      kipConnectorApi: CONNECTOR_API,
+      id: 'openai',
+      label: 'OpenAI',
+      fields: [
+        { key: 'apiKey', label: 'API key', type: 'password', required: true, placeholder: 'sk-…' },
+        { key: 'model', label: 'Model', type: 'text', required: true, placeholder: 'e.g. gpt-4o-mini', help: 'e.g. gpt-4o-mini' },
+        { key: 'baseUrl', label: 'Base URL', type: 'text', required: false, default: 'https://api.openai.com/v1' }
+      ],
+      envDefaults: { apiKey: 'OPENAI_API_KEY', model: 'OPENAI_MODEL', baseUrl: 'OPENAI_BASE_URL' },
+      isReady: (cfg) => !!cfg.apiKey && !!cfg.model,
+      complete: openAICompatibleComplete
+    },
+    {
+      kipConnectorApi: CONNECTOR_API,
+      id: 'deepseek',
+      label: 'DeepSeek',
+      fields: [
+        { key: 'apiKey', label: 'API key', type: 'password', required: true, placeholder: 'sk-…' },
+        { key: 'model', label: 'Model', type: 'text', required: false, default: 'deepseek-chat' },
+        { key: 'baseUrl', label: 'Base URL', type: 'text', required: false, default: 'https://api.deepseek.com' }
+      ],
+      envDefaults: { apiKey: 'DEEPSEEK_API_KEY', model: 'DEEPSEEK_MODEL' },
+      isReady: (cfg) => !!cfg.apiKey,
+      complete: openAICompatibleComplete
+    },
+    {
+      kipConnectorApi: CONNECTOR_API,
+      id: 'local',
+      label: 'Local (Ollama)',
+      fields: [
+        { key: 'model', label: 'Model', type: 'text', required: true, placeholder: 'e.g. llama3.1', help: 'e.g. llama3.1 — the Ollama model tag you have pulled' },
+        { key: 'baseUrl', label: 'Base URL', type: 'text', required: false, default: 'http://localhost:11434/v1' }
+      ],
+      envDefaults: { model: 'LOCAL_MODEL', baseUrl: 'LOCAL_BASE_URL' },
+      isReady: (cfg) => !!cfg.model && !!cfg.baseUrl,
+      complete: openAICompatibleComplete
+    },
+    {
+      // Any other OpenAI-compatible endpoint (Kimi/Moonshot, Qwen via
+      // DashScope, a custom proxy, ...) — unlike "local" it has no
+      // Ollama-flavored default base URL and usually needs an API key.
+      kipConnectorApi: CONNECTOR_API,
+      id: 'other',
+      label: 'Other (OpenAI-compatible)',
+      fields: [
+        { key: 'baseUrl', label: 'Base URL', type: 'text', required: true, placeholder: 'https://…/v1' },
+        { key: 'model', label: 'Model', type: 'text', required: true, placeholder: 'the model name for your endpoint', help: 'the model name for your OpenAI-compatible endpoint' },
+        { key: 'apiKey', label: 'API key', type: 'password', required: false, placeholder: 'sk-…' }
+      ],
+      envDefaults: { baseUrl: 'OTHER_BASE_URL', model: 'OTHER_MODEL', apiKey: 'OTHER_API_KEY' },
+      isReady: (cfg) => !!cfg.baseUrl && !!cfg.model,
+      complete: openAICompatibleComplete
+    }
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural check of a ProviderSpec. Returns a reason string when the spec
+ * is unusable (so the registry can skip it with a warning instead of
+ * throwing into callLLM), or null when it's fine.
+ */
+function validateSpec (spec) {
+  if (!spec || typeof spec !== 'object') return 'not an object'
+  if (spec.kipConnectorApi !== CONNECTOR_API) {
+    return `unsupported kipConnectorApi ${JSON.stringify(spec.kipConnectorApi)} (host speaks ${CONNECTOR_API})`
+  }
+  if (!spec.id || typeof spec.id !== 'string') return 'missing id'
+  if (!spec.label || typeof spec.label !== 'string') return 'missing label'
+  if (typeof spec.complete !== 'function') return 'missing complete()'
+  if (!Array.isArray(spec.fields)) return 'missing fields[]'
+  return null
+}
+
+/**
+ * Builds a registry from a list of specs. A spec that fails validation, or
+ * whose id collides with one already registered, is skipped with a logged
+ * warning — a broken connector must never break `callLLM()` for the others.
+ */
+function createRegistry (specs, { logger = console } = {}) {
+  const byId = new Map()
+  for (const spec of specs || []) {
+    const problem = validateSpec(spec)
+    if (problem) {
+      logger.warn(`[connectors] skipping a connector: ${problem}`)
+      continue
+    }
+    if (byId.has(spec.id)) {
+      logger.warn(`[connectors] skipping connector "${spec.id}": id already registered`)
+      continue
+    }
+    byId.set(spec.id, spec)
+  }
+  return {
+    get: (id) => byId.get(id) || null,
+    has: (id) => byId.has(id),
+    list: () => [...byId.values()],
+    ids: () => [...byId.keys()]
+  }
+}
+
+/**
+ * The registry of every connector available to this graph: the five
+ * built-ins today. `opts.anthropicClient` / `opts.fetchImpl` are test seams
+ * for the built-ins — real callers never pass them. `vaultRoot` is reserved
+ * for graph-local connector discovery (kip-app#56).
+ */
+function loadConnectors (vaultRoot, opts = {}) {
+  return createRegistry(builtinSpecs(opts), { logger: opts.logger })
+}
+
+/**
+ * Resolves a spec's config values: for each field, the config file wins,
+ * then the field's env var, then the field's declared default. `env` is
+ * injectable for tests.
+ */
+function resolveConfig (spec, fileProviderConfig = {}, env = process.env) {
+  const keys = new Set([
+    ...(spec.fields || []).map((f) => f.key),
+    ...Object.keys(spec.envDefaults || {})
+  ])
+  const resolved = {}
+  for (const key of keys) {
+    const field = (spec.fields || []).find((f) => f.key === key)
+    const envVar = spec.envDefaults && spec.envDefaults[key]
+    resolved[key] =
+      (fileProviderConfig && fileProviderConfig[key]) ||
+      (envVar ? env[envVar] : undefined) ||
+      (field ? field.default : undefined) ||
+      undefined
+  }
+  return resolved
+}
+
+/** The first required field left blank after resolution, or null. */
+function missingRequiredField (spec, resolved) {
+  return (spec.fields || []).find((f) => f.required && !resolved[f.key]) || null
+}
+
+module.exports = {
+  CONNECTOR_API,
+  loadConnectors,
+  createRegistry,
+  validateSpec,
+  resolveConfig,
+  missingRequiredField
+}

--- a/scripts/lib/llm.js
+++ b/scripts/lib/llm.js
@@ -1,62 +1,17 @@
 // Provider-swappable LLM abstraction. Every caller in scripts/lib/ and the
 // CLI scripts goes through callLLM() — no provider-specific code (Anthropic
-// SDK, OpenAI-shaped fetch calls) belongs anywhere else. Which backend runs,
-// and its credentials/model, come from coop/.henhouse/llm.json if present
-// (loadLLMConfig/saveLLMConfig below — read/written by a GUI app without
-// touching shell env vars), falling back per-field to the PROVIDER/
-// *_API_KEY/*_MODEL env vars. See .env.example.
+// SDK, OpenAI-shaped fetch calls) belongs anywhere else; that lives in
+// lib/connectors.js, which this module hosts.
+//
+// Which backend runs, and its credentials/model, come from
+// coop/.henhouse/llm.json if present (loadLLMConfig/saveLLMConfig below —
+// read/written by a GUI app without touching shell env vars), falling back
+// per-field to the PROVIDER / *_API_KEY / *_MODEL env vars. See .env.example.
 const fs = require('node:fs')
 const path = require('node:path')
 const { DEFAULT_VAULT_ROOT, configPath } = require('./paths')
 const telemetry = require('./telemetry')
-
-const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6'
-
-// Env-var defaults for each supported PROVIDER value — the fallback when
-// coop/.henhouse/llm.json doesn't exist or doesn't set a given field.
-// openai/deepseek/local all speak the same OpenAI-compatible chat
-// completions format and share callOpenAICompatible — only their base URL,
-// API key, and model differ. Anthropic's own request/response shape is
-// handled separately, in callAnthropic.
-const PROVIDER_CONFIGS = {
-  anthropic: () => ({
-    apiKey: process.env.ANTHROPIC_API_KEY, // undefined is fine — the SDK
-    model: DEFAULT_ANTHROPIC_MODEL         // falls back to its own credential
-  }),                                      // chain (ant CLI profile, etc.)
-  openai: () => ({
-    baseUrl: process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1',
-    apiKey: process.env.OPENAI_API_KEY,
-    apiKeyEnvVar: 'OPENAI_API_KEY',
-    model: process.env.OPENAI_MODEL,
-    modelEnvVar: 'OPENAI_MODEL',
-    modelHint: 'e.g. gpt-4o-mini'
-  }),
-  deepseek: () => ({
-    baseUrl: 'https://api.deepseek.com',
-    apiKey: process.env.DEEPSEEK_API_KEY,
-    apiKeyEnvVar: 'DEEPSEEK_API_KEY',
-    model: process.env.DEEPSEEK_MODEL || 'deepseek-chat'
-  }),
-  local: () => ({
-    baseUrl: process.env.LOCAL_BASE_URL || 'http://localhost:11434/v1',
-    apiKey: undefined, // no API key required
-    model: process.env.LOCAL_MODEL,
-    modelEnvVar: 'LOCAL_MODEL',
-    modelHint: 'e.g. llama3.1 — the Ollama model tag you have pulled'
-  }),
-  // Any other OpenAI-compatible endpoint (Kimi/Moonshot, Qwen via DashScope,
-  // a custom proxy, ...) — unlike "local" this has no Ollama-flavored
-  // default base URL and does support an API key, since a remote
-  // "other" endpoint usually needs one.
-  other: () => ({
-    baseUrl: process.env.OTHER_BASE_URL,
-    baseUrlEnvVar: 'OTHER_BASE_URL',
-    apiKey: process.env.OTHER_API_KEY,
-    model: process.env.OTHER_MODEL,
-    modelEnvVar: 'OTHER_MODEL',
-    modelHint: 'the model name for your OpenAI-compatible endpoint'
-  })
-}
+const { loadConnectors, resolveConfig, missingRequiredField } = require('./connectors')
 
 /**
  * Reads coop/.henhouse/llm.json. Returns null if it doesn't exist (callers
@@ -85,33 +40,42 @@ function getProviderName () {
   return (process.env.PROVIDER || 'anthropic').toLowerCase()
 }
 
+function requireSpec (registry, providerId) {
+  const spec = registry.get(providerId)
+  if (!spec) {
+    throw new Error(`Unknown PROVIDER "${providerId}". Supported: ${registry.ids().join(', ')}.`)
+  }
+  return spec
+}
+
 /**
- * Resolves the active provider's config, merging coop/.henhouse/llm.json
- * (if present) over the PROVIDER_CONFIGS env-var defaults, field by field —
- * a field missing from the file (or the file itself missing) falls back to
- * its env var.
+ * Reads coop/.henhouse/llm.json once and works out the active provider: its
+ * id (file's `provider`, else $PROVIDER, else "anthropic"), its spec from
+ * the connector registry, and its config resolved file-over-env-over-default.
  */
-function getProviderConfig (vaultRoot = DEFAULT_VAULT_ROOT) {
+function resolveActive (vaultRoot, registryOpts = {}) {
   const fileConfig = loadLLMConfig(vaultRoot)
   const provider = (fileConfig && fileConfig.provider) || getProviderName()
+  const registry = loadConnectors(vaultRoot, registryOpts)
+  const spec = requireSpec(registry, provider)
+  const block = (fileConfig && fileConfig.providers && fileConfig.providers[provider]) || {}
+  return { provider, spec, resolved: resolveConfig(spec, block), registry }
+}
 
-  const configFn = PROVIDER_CONFIGS[provider]
-  if (!configFn) {
-    throw new Error(`Unknown PROVIDER "${provider}". Supported: ${Object.keys(PROVIDER_CONFIGS).join(', ')}.`)
-  }
-
-  const envDefaults = configFn()
-  const fileProviderConfig = (fileConfig && fileConfig.providers && fileConfig.providers[provider]) || {}
-
+/**
+ * Resolves the active provider's config, merging coop/.henhouse/llm.json
+ * (if present) over the connector's env-var / default fallbacks, field by
+ * field. Kept for the CLI scripts' startup line (describeProvider); the
+ * settings UI goes through the electron IPC layer instead.
+ */
+function getProviderConfig (vaultRoot = DEFAULT_VAULT_ROOT) {
+  const { provider, spec, resolved } = resolveActive(vaultRoot)
   return {
     provider,
-    baseUrl: fileProviderConfig.baseUrl || envDefaults.baseUrl,
-    baseUrlEnvVar: envDefaults.baseUrlEnvVar,
-    apiKey: fileProviderConfig.apiKey || envDefaults.apiKey,
-    apiKeyEnvVar: envDefaults.apiKeyEnvVar,
-    model: fileProviderConfig.model || envDefaults.model,
-    modelEnvVar: envDefaults.modelEnvVar,
-    modelHint: envDefaults.modelHint
+    label: spec.label,
+    baseUrl: resolved.baseUrl,
+    apiKey: resolved.apiKey,
+    model: resolved.model || spec.staticModel
   }
 }
 
@@ -119,12 +83,6 @@ function getProviderConfig (vaultRoot = DEFAULT_VAULT_ROOT) {
 function describeProvider (vaultRoot = DEFAULT_VAULT_ROOT) {
   const { provider, model } = getProviderConfig(vaultRoot)
   return `Using provider: ${provider}${model ? ` (${model})` : ' (no model configured)'}`
-}
-
-function stripCodeFences (text) {
-  const trimmed = text.trim()
-  const fenced = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/)
-  return fenced ? fenced[1].trim() : trimmed
 }
 
 /** Token counts from a raw provider response — Anthropic or OpenAI-compatible shapes; 0 when absent. */
@@ -153,106 +111,20 @@ function extractReasoning (raw) {
   return ''
 }
 
-const JSON_MODE_INSTRUCTION = 'Respond with ONLY valid JSON and no other text — no markdown code fences, no explanation.'
-
-/** Anthropic has no forced-JSON mode: for json:true, ask for it in the system prompt and strip fences after. */
-async function callAnthropic ({ system, prompt, json, maxTokens, apiKey }, AnthropicClient) {
-  const Anthropic = AnthropicClient || require('@anthropic-ai/sdk')
-  // Only pass an explicit apiKey when we have one (from the config file or
-  // ANTHROPIC_API_KEY) — an explicit undefined can short-circuit the SDK's
-  // own fallback chain (ant CLI profile, WIF, ...), which must keep working
-  // for anyone who hasn't set either.
-  const client = apiKey ? new Anthropic({ apiKey }) : new Anthropic()
-
-  const finalSystem = json
-    ? (system ? `${system}\n\n${JSON_MODE_INSTRUCTION}` : JSON_MODE_INSTRUCTION)
-    : system
-
-  const response = await client.messages.create({
-    model: DEFAULT_ANTHROPIC_MODEL,
-    max_tokens: maxTokens,
-    system: finalSystem,
-    messages: [{ role: 'user', content: prompt }]
-  })
-
-  const rawText = response.content
-    .filter((b) => b.type === 'text')
-    .map((b) => b.text)
-    .join('\n')
-    .trim()
-
-  return { text: json ? stripCodeFences(rawText) : rawText, raw: response }
-}
-
-async function postChatCompletion (baseUrl, apiKey, body, doFetch) {
-  const headers = { 'Content-Type': 'application/json' }
-  if (apiKey) headers.Authorization = `Bearer ${apiKey}`
-
-  const response = await doFetch(`${baseUrl.replace(/\/$/, '')}/chat/completions`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(body)
-  })
-
-  if (!response.ok) {
-    const errText = await response.text().catch(() => response.status)
-    const err = new Error(`${baseUrl} request failed (${response.status}): ${errText}`)
-    err.status = response.status
-    throw err
-  }
-  return response.json()
+/** Throws the same "<ENV_VAR> is required when PROVIDER=..." error the old code did. */
+function assertConfigured (spec, resolved) {
+  const missing = missingRequiredField(spec, resolved)
+  if (!missing) return
+  const envVar = (spec.envDefaults && spec.envDefaults[missing.key]) || missing.label
+  const hint = missing.help ? ` (${missing.help})` : ''
+  throw new Error(
+    `${envVar} is required when PROVIDER=${spec.id}${hint} ` +
+    '(set it in coop/.henhouse/llm.json or the environment).'
+  )
 }
 
 /**
- * One generic client for every OpenAI-compatible chat completions API
- * (openai, deepseek, local/Ollama, and future providers like kimi/qwen) —
- * only baseUrl/apiKey/model differ between them.
- *
- * For json:true, tries native response_format: {type: "json_object"} first;
- * if the provider/model errors on that parameter, retries once without it,
- * using the same prompt-and-strip approach as the Anthropic path.
- */
-async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, json, maxTokens }, fetchImpl) {
-  const doFetch = fetchImpl || fetch
-
-  const buildMessages = (sys) => {
-    const messages = []
-    if (sys) messages.push({ role: 'system', content: sys })
-    messages.push({ role: 'user', content: prompt })
-    return messages
-  }
-
-  let data
-  if (json) {
-    try {
-      data = await postChatCompletion(baseUrl, apiKey, {
-        model,
-        max_tokens: maxTokens,
-        messages: buildMessages(system),
-        response_format: { type: 'json_object' }
-      }, doFetch)
-    } catch {
-      const jsonSystem = system ? `${system}\n\n${JSON_MODE_INSTRUCTION}` : JSON_MODE_INSTRUCTION
-      data = await postChatCompletion(baseUrl, apiKey, {
-        model,
-        max_tokens: maxTokens,
-        messages: buildMessages(jsonSystem)
-      }, doFetch)
-    }
-  } else {
-    data = await postChatCompletion(baseUrl, apiKey, {
-      model,
-      max_tokens: maxTokens,
-      messages: buildMessages(system)
-    }, doFetch)
-  }
-
-  const rawText = (data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content) || ''
-  return { text: json ? stripCodeFences(rawText) : rawText.trim(), raw: data }
-}
-
-/**
- * The one entry point every caller uses. Routes to the provider named by
+ * The one entry point every caller uses. Routes to the connector named by
  * coop/.henhouse/llm.json / the PROVIDER env var (default "anthropic");
  * always resolves to the same shape: { text, raw }.
  *
@@ -266,35 +138,27 @@ async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, j
  */
 async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label }, overrides = {}) {
   const vaultRoot = overrides.vaultRoot || DEFAULT_VAULT_ROOT
-  const config = getProviderConfig(vaultRoot)
+  const { spec, resolved } = resolveActive(vaultRoot, {
+    anthropicClient: overrides.AnthropicClient,
+    fetchImpl: overrides.fetchImpl
+  })
+  assertConfigured(spec, resolved)
 
-  if (config.apiKeyEnvVar && !config.apiKey) {
-    throw new Error(`${config.apiKeyEnvVar} is required when PROVIDER=${config.provider} ` +
-      '(set it in coop/.henhouse/llm.json or the environment).')
-  }
-  if (config.modelEnvVar && !config.model) {
-    throw new Error(`${config.modelEnvVar} is required when PROVIDER=${config.provider}` +
-      `${config.modelHint ? ` (${config.modelHint})` : ''} (set it in coop/.henhouse/llm.json or the environment).`)
-  }
-  if (config.baseUrlEnvVar && !config.baseUrl) {
-    throw new Error(`${config.baseUrlEnvVar} is required when PROVIDER=${config.provider} ` +
-      '(set it in coop/.henhouse/llm.json or the environment).')
+  const call = { system, prompt, json, maxTokens, label: label || null }
+  const ctx = {
+    fetch: overrides.fetchImpl || fetch,
+    signal: overrides.signal,
+    logger: overrides.logger || console
   }
 
   const started = Date.now()
-  const common = { label: label || null, provider: config.provider, model: config.model || null }
+  const common = {
+    label: label || null,
+    provider: spec.id,
+    model: resolved.model || spec.staticModel || null
+  }
   try {
-    const result = config.provider === 'anthropic'
-      ? await callAnthropic({ system, prompt, json, maxTokens, apiKey: config.apiKey }, overrides.AnthropicClient)
-      : await callOpenAICompatible({
-        baseUrl: config.baseUrl,
-        apiKey: config.apiKey,
-        model: config.model,
-        system,
-        prompt,
-        json,
-        maxTokens
-      }, overrides.fetchImpl)
+    const result = await spec.complete(resolved, call, ctx)
 
     const usage = extractUsage(result.raw)
     const reasoning = extractReasoning(result.raw)
@@ -331,46 +195,49 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label 
  * Fires a trivial LLM call against an explicit provider config — for the
  * settings UI's "test connection" button, which needs to test the form's
  * *current, possibly unsaved* values, not whatever's in
- * coop/.henhouse/llm.json. Bypasses getProviderConfig()'s file/env
- * resolution for provider/apiKey/model/baseUrl, but still falls back to the
- * env-var defaults for any of those the candidate leaves blank (so testing
- * with an empty API key field still picks up an env var if one is set,
- * matching what a real call would actually do).
+ * coop/.henhouse/llm.json. Bypasses the file/env resolution for the
+ * candidate's own fields, but still falls back to the env-var / default for
+ * any the candidate leaves blank (so testing with an empty API-key field
+ * still picks up an env var if one is set, matching a real call).
  *
  * Never throws — returns { success: true, reply } or { success: false, error }.
  *
  * `overrides` (optional, second arg) is for tests only, same as callLLM's.
  */
 async function testConnection ({ provider, apiKey, model, baseUrl } = {}, overrides = {}) {
-  const configFn = PROVIDER_CONFIGS[provider]
-  if (!configFn) return { success: false, error: `Unknown provider "${provider}".` }
+  const registry = loadConnectors(overrides.vaultRoot, {
+    anthropicClient: overrides.AnthropicClient,
+    fetchImpl: overrides.fetchImpl
+  })
+  const spec = registry.get(provider)
+  if (!spec) return { success: false, error: `Unknown provider "${provider}".` }
 
-  const envDefaults = configFn()
-  const resolved = {
-    apiKey: apiKey || envDefaults.apiKey,
-    model: model || envDefaults.model,
-    baseUrl: baseUrl || envDefaults.baseUrl
+  // Only the fields the connector actually declares; undefined candidate
+  // values fall through resolveConfig to the env var / default.
+  const candidate = {}
+  for (const [k, v] of Object.entries({ apiKey, model, baseUrl })) {
+    if (v !== undefined) candidate[k] = v
+  }
+  const resolved = resolveConfig(spec, candidate)
+
+  const missing = missingRequiredField(spec, resolved)
+  if (missing) return { success: false, error: `${missing.label} is required.` }
+
+  const ctx = {
+    fetch: overrides.fetchImpl || fetch,
+    signal: overrides.signal,
+    logger: overrides.logger || console
   }
 
   try {
-    let result
-    if (provider === 'anthropic') {
-      result = await callAnthropic(
-        { system: '', prompt: 'Reply with exactly: OK', maxTokens: 10, apiKey: resolved.apiKey },
-        overrides.AnthropicClient
-      )
-    } else {
-      if (!resolved.model) throw new Error('Model is required.')
-      if (!resolved.baseUrl) throw new Error('Base URL is required.')
-      result = await callOpenAICompatible({
-        baseUrl: resolved.baseUrl,
-        apiKey: resolved.apiKey,
-        model: resolved.model,
-        system: '',
-        prompt: 'Reply with exactly: OK',
-        maxTokens: 10
-      }, overrides.fetchImpl)
+    if (typeof spec.testConnection === 'function') {
+      return await spec.testConnection(resolved, ctx)
     }
+    const result = await spec.complete(
+      resolved,
+      { system: '', prompt: 'Reply with exactly: OK', json: false, maxTokens: 10, label: 'test:connection' },
+      ctx
+    )
     return { success: true, reply: result.text }
   } catch (err) {
     return { success: false, error: err.message || String(err) }

--- a/scripts/test/connectors.test.js
+++ b/scripts/test/connectors.test.js
@@ -1,0 +1,94 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  CONNECTOR_API,
+  loadConnectors,
+  createRegistry,
+  validateSpec,
+  resolveConfig,
+  missingRequiredField
+} = require('../lib/connectors')
+
+const okSpec = (over = {}) => ({
+  kipConnectorApi: CONNECTOR_API,
+  id: 'x',
+  label: 'X',
+  fields: [],
+  complete: async () => ({ text: '', raw: {} }),
+  ...over
+})
+
+test('validateSpec', async (t) => {
+  await t.test('accepts a well-formed v1 spec', () => {
+    assert.equal(validateSpec(okSpec()), null)
+  })
+  await t.test('rejects a non-object', () => {
+    assert.match(validateSpec(null), /not an object/)
+  })
+  await t.test('rejects an unknown / missing api major', () => {
+    assert.match(validateSpec(okSpec({ kipConnectorApi: 2 })), /unsupported kipConnectorApi/)
+    assert.match(validateSpec(okSpec({ kipConnectorApi: undefined })), /unsupported kipConnectorApi/)
+  })
+  await t.test('rejects missing id / label / complete / fields', () => {
+    assert.match(validateSpec(okSpec({ id: undefined })), /missing id/)
+    assert.match(validateSpec(okSpec({ label: undefined })), /missing label/)
+    assert.match(validateSpec(okSpec({ complete: undefined })), /missing complete/)
+    assert.match(validateSpec(okSpec({ fields: undefined })), /missing fields/)
+  })
+})
+
+test('createRegistry: skips invalid specs and id collisions with a warning, keeps the rest', () => {
+  const warnings = []
+  const reg = createRegistry(
+    [okSpec({ id: 'a' }), okSpec({ id: 'a', label: 'dup' }), okSpec({ id: 'b', kipConnectorApi: 9 }), okSpec({ id: 'c' })],
+    { logger: { warn: (m) => warnings.push(m) } }
+  )
+  assert.deepEqual(reg.ids(), ['a', 'c'])
+  assert.equal(reg.get('a').label, 'X', 'first registration wins the id')
+  assert.equal(reg.get('b'), null)
+  assert.equal(reg.has('c'), true)
+  assert.equal(warnings.length, 2)
+})
+
+test('resolveConfig: file over env over field default', () => {
+  const spec = {
+    fields: [
+      { key: 'apiKey' },
+      { key: 'model', default: 'default-model' },
+      { key: 'baseUrl', default: 'https://default' }
+    ],
+    envDefaults: { apiKey: 'X_KEY', model: 'X_MODEL', baseUrl: 'X_URL' }
+  }
+  const env = { X_KEY: 'env-key', X_MODEL: 'env-model' }
+  const resolved = resolveConfig(spec, { model: 'file-model' }, env)
+  assert.equal(resolved.apiKey, 'env-key', 'no file value -> env')
+  assert.equal(resolved.model, 'file-model', 'file wins over env and default')
+  assert.equal(resolved.baseUrl, 'https://default', 'no file/env -> field default')
+})
+
+test('missingRequiredField: first blank required field, else null', () => {
+  const spec = { fields: [{ key: 'a', required: true }, { key: 'b', label: 'B', required: true }] }
+  assert.equal(missingRequiredField(spec, { a: 'set', b: 'set' }), null)
+  assert.equal(missingRequiredField(spec, { a: 'set' }).key, 'b')
+  assert.equal(missingRequiredField(spec, {}).key, 'a')
+})
+
+test('loadConnectors: returns the five built-ins, all valid v1 specs', () => {
+  const reg = loadConnectors()
+  assert.deepEqual(reg.ids().sort(), ['anthropic', 'deepseek', 'local', 'openai', 'other'])
+  for (const spec of reg.list()) {
+    assert.equal(validateSpec(spec), null, `${spec.id} is a valid spec`)
+    assert.equal(typeof spec.isReady, 'function')
+    assert.equal(spec.kipConnectorApi, CONNECTOR_API)
+  }
+})
+
+test('loadConnectors: built-in readiness matches its resolved config', () => {
+  const reg = loadConnectors()
+  assert.equal(reg.get('anthropic').isReady({}), true, 'anthropic is always ready (SDK cred chain)')
+  assert.equal(reg.get('openai').isReady({ apiKey: 'k' }), false, 'openai needs a model too')
+  assert.equal(reg.get('openai').isReady({ apiKey: 'k', model: 'm' }), true)
+  assert.equal(reg.get('other').isReady({ model: 'm' }), false, 'other needs a base URL')
+  assert.equal(reg.get('other').isReady({ baseUrl: 'u', model: 'm' }), true)
+})


### PR DESCRIPTION
First step of the connector epic (**kip-app#62**) — land alone, no behaviour change.

## What

`scripts/lib/llm.js` hardcoded `PROVIDER_CONFIGS` + `if (provider === 'anthropic') … else callOpenAICompatible(…)`. It's now a **connector host**:

- **`scripts/lib/connectors.js`** (new) — a `ProviderSpec` v1 registry. Each provider = `{ kipConnectorApi: 1, id, label, fields[], envDefaults, isReady(cfg), complete(resolved, call, ctx) }`. `ctx` = `{ fetch, signal, logger }` only. `createRegistry` skips an invalid or id-colliding spec with a logged warning (never throws into `callLLM`).
- The 5 built-ins (`anthropic`, `openai`, `deepseek`, `local`, `other`) are converted specs. `callAnthropic` / `callOpenAICompatible` / `postChatCompletion` moved here as the built-ins' `complete()`.
- `llm.js` keeps its exports (`callLLM`, `describeProvider`, `getProviderConfig`, `loadLLMConfig`, `saveLLMConfig`, `testConnection`) and does the hosting: resolve config (file → env → field default), assert required fields (same `<ENV_VAR> is required when PROVIDER=…` errors), thread `label` into `complete()`, dispatch, record telemetry.

## Acceptance

- ✅ No new provider. No behaviour change.
- ✅ All existing `llm.test.js` pass unchanged, including `overrides.fetchImpl` / `overrides.AnthropicClient`.
- ✅ Full script suite green: **175/175** (`llm` 27 unchanged + `connectors` 10 new).

## Next

#56 adds graph-local discovery (`<graph>/.henhouse/connectors/`) + the pure-JS tarball install + `@kip-ai/*` allowlist to `connectors.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)