### PR TITLE
connectors.js: bundled + graph-local discovery, tarball install (#56)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -73,7 +73,9 @@ scripts/
 │   │                # plus loadLLMConfig/saveLLMConfig, see "LLM provider
 │   │                # config" below. Hosts lib/connectors.js.
 │   ├── connectors.js # the connector registry: each provider is a ProviderSpec
-│   │                # (fields + complete()); the 5 built-ins live here
+│   │                # (fields + complete()); 5 built-ins + bundled/graph-local
+│   │                # connectors (install from a .tgz, @kip-ai/* allowlist)
+│   ├── untar.js    # zero-dep npm-tarball (.tgz) extractor for connector install
 │   ├── telemetry.js # per-run LLM-call timing/token recorder every callLLM()
 │   │                # feeds; content-free summary() + opt-in full-text trace
 │   ├── prompts.js  # prompt content built on callLLM(): extractKeyTerms,
@@ -289,6 +291,33 @@ skill call, full I/O, to `<coop>/.roost/peck-trace.jsonl`; the content-free
 `peck-metrics.json` is always written. Trust model: a skill is arbitrary
 Node code, unsandboxed — built-ins are reviewed here, a user skill is like
 adding a shell script. Tested in `scripts/test/skills.test.js`.
+
+#### LLM connectors
+
+`lib/connectors.js` is the provider registry `llm.js` hosts. A connector is
+a `ProviderSpec` v1 (`{ kipConnectorApi:1, id, label, fields[], envDefaults,
+isReady, complete(resolved, call, ctx) }`; `ctx` = `{ fetch, signal, logger }`
+only). Three sources:
+
+- **built-in** — `anthropic` / `openai` / `deepseek` / `local` / `other`, in
+  `connectors.js`. Their ids can never be shadowed.
+- **bundled** — an allowlisted package shipped as an app dependency
+  (`BUNDLED_CONNECTORS`). Rides the normal app auto-update.
+- **graph-local** — installed from an npm `.tgz` into
+  `<graph>/.henhouse/connectors/<dir>/`, listed in
+  `<graph>/.henhouse/connectors.json` (`[{ id, name, version, dir }]`).
+  Overrides a *bundled* connector of the same id.
+
+`installConnectorFromTarball(tgz, vaultRoot)` extracts with `lib/untar.js`
+(zero-dep, path-traversal/size guarded — **no `npm` shell-out**), checks the
+package name against `ALLOWLIST` (`@kip-ai/*` — a host constant, not
+user-editable), validates the `ProviderSpec`, and refuses an id that
+collides with a built-in or an already-installed connector.
+`removeConnector(id, vaultRoot)` deletes the dir + the config entry. A
+connector that fails to load is skipped with a warning — it never throws
+into `callLLM()`. Trust boundary: a graph-local connector is `require`d
+into the process with `fetch`, so the allowlist is the gate. Tested in
+`scripts/test/connectors.test.js` + `untar.test.js`.
 
 #### `groom.js` — coop health checks
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "peck": "node scripts/peck.js",
     "groom": "node scripts/groom.js",
     "hatch": "node scripts/hatch.js",
-    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js"
+    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.70.0",

--- a/scripts/lib/connectors.js
+++ b/scripts/lib/connectors.js
@@ -8,13 +8,38 @@
 // fetch calls) lives outside this file.
 //
 // The five built-ins (anthropic / openai / deepseek / local / other) are
-// ProviderSpecs defined below. External connectors — starting with the
-// managed Kip backend (@kip-ai/connector) — register through
-// loadConnectors() too; graph-local discovery and the install/allowlist
-// flow land in a follow-up (see kip-app#56). For now loadConnectors()
-// returns the built-ins only, and `vaultRoot` is accepted but unused.
+// ProviderSpecs defined below. External connectors register through
+// loadConnectors() too, from two sources:
+//
+//   * bundled  — an allowlisted package that ships as a dependency of the
+//                app (BUNDLED_CONNECTORS). It rides the normal app auto-
+//                update, so everyone who has it stays current for free.
+//   * graph-local — a package installed into
+//                <graph>/.henhouse/connectors/<dir>/ from a .tgz, listed in
+//                <graph>/.henhouse/connectors.json. Mirrors .henhouse/skills/.
+//                A graph-local connector overrides a bundled one with the
+//                same id (the "ship a fix ahead of an app release" path).
+//
+// Trust: an installable connector is arbitrary JS `require`d into this
+// process with `fetch`. The only gate is ALLOWLIST — a constant here, not
+// user-editable. Built-in ids can never be shadowed.
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { connectorsPath, connectorsConfigPath } = require('./paths')
+const { extractNpmTarball } = require('./untar')
 
 const CONNECTOR_API = 1
+
+// Package-name patterns an installable connector must match. `@scope/*`
+// matches anything under that scope; a bare name matches exactly.
+const ALLOWLIST = ['@kip-ai/connector', '@kip-ai/*']
+
+// Allowlisted packages the app ships as its own dependency. Absent until
+// @kip-ai/connector is published + added to scripts/package.json — until
+// then loadBundledConnectors() just finds nothing.
+const BUNDLED_CONNECTORS = ['@kip-ai/connector']
 
 const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6'
 const JSON_MODE_INSTRUCTION =
@@ -274,14 +299,224 @@ function createRegistry (specs, { logger = console } = {}) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// External connector discovery + install
+// ---------------------------------------------------------------------------
+
+/** `@kip-ai/connector` -> true; `@kip-ai/anything` -> true; anything else -> false. */
+function isAllowlisted (name) {
+  if (typeof name !== 'string' || !name) return false
+  return ALLOWLIST.some((pat) =>
+    pat.endsWith('/*') ? name.startsWith(pat.slice(0, -1)) : name === pat
+  )
+}
+
+/** A module may export the spec directly or as `default` (esm interop). */
+function normalizeExport (mod) {
+  return mod && typeof mod === 'object' && mod.default ? mod.default : mod
+}
+
+/** Drop a dir (and everything under it) from the require cache. */
+function evictFromRequireCache (dir) {
+  const resolved = path.resolve(dir)
+  for (const key of Object.keys(require.cache)) {
+    if (key === resolved || key.startsWith(resolved + path.sep)) delete require.cache[key]
+  }
+}
+
+/** require() a connector's entry point (package.json main / index.js). */
+function requireDir (dir) {
+  try {
+    return require(require.resolve(dir))
+  } catch (err) {
+    err.message = `cannot load connector (${err.message})`
+    throw err
+  }
+}
+
+/** `@kip-ai/connector` -> `kip-ai__connector` — a filesystem-safe dir name. */
+function connectorDirName (pkgName) {
+  return pkgName.replace(/^@/, '').replace(/\//g, '__').replace(/[^\w.-]/g, '_')
+}
+
+/** Specs from BUNDLED_CONNECTORS that are actually installed as app deps. */
+function loadBundledConnectors ({ logger = console } = {}) {
+  const specs = []
+  for (const name of BUNDLED_CONNECTORS) {
+    try {
+      require.resolve(name)
+    } catch {
+      continue // not shipped in this build — expected
+    }
+    try {
+      specs.push(normalizeExport(require(name)))
+    } catch (err) {
+      logger.warn(`[connectors] bundled "${name}" failed to load: ${err.message}`)
+    }
+  }
+  return specs
+}
+
+/** The raw connectors.json array ([{ id, name, version, dir }]), or []. */
+function readConnectorsConfig (vaultRoot) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(connectorsConfigPath(vaultRoot), 'utf8'))
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+function writeConnectorsConfig (vaultRoot, entries) {
+  const file = connectorsConfigPath(vaultRoot)
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, JSON.stringify(entries, null, 2) + '\n')
+}
+
+/** Specs for the graph-local connectors listed in connectors.json. */
+function loadGraphConnectors (vaultRoot, { logger = console } = {}) {
+  if (!vaultRoot) return []
+  const base = connectorsPath(vaultRoot)
+  const specs = []
+  for (const entry of readConnectorsConfig(vaultRoot)) {
+    if (!entry || !entry.dir) continue
+    const dir = path.join(base, entry.dir)
+    if (!fs.existsSync(path.join(dir, 'package.json'))) {
+      logger.warn(`[connectors] "${entry.id || entry.dir}" is in connectors.json but ${entry.dir}/ is missing`)
+      continue
+    }
+    try {
+      specs.push(normalizeExport(requireDir(dir)))
+    } catch (err) {
+      logger.warn(`[connectors] "${entry.id || entry.dir}" failed to load: ${err.message}`)
+    }
+  }
+  return specs
+}
+
+/**
+ * Installs a connector from an npm tarball (a local .tgz path or an
+ * https URL) into <graph>/.henhouse/connectors/. Pure-JS extraction, no
+ * `npm`. Resolves { ok: true, id, name, version } or rejects with a
+ * user-facing Error.
+ *
+ * Refuses: a package whose name isn't on ALLOWLIST; a tarball that isn't a
+ * valid ProviderSpec; an id that collides with a built-in or an
+ * already-installed connector. (An id that matches a *bundled* connector is
+ * allowed — that's how a graph-local build overrides it.)
+ */
+async function installConnectorFromTarball (tgzPathOrUrl, vaultRoot, opts = {}) {
+  const doFetch = opts.fetch || fetch
+  if (!vaultRoot) throw new Error('Open a folder first — a connector installs into the current graph.')
+
+  let bytes
+  if (/^https?:\/\//i.test(tgzPathOrUrl)) {
+    const res = await doFetch(tgzPathOrUrl)
+    if (!res.ok) throw new Error(`Couldn't download the connector (${res.status}).`)
+    bytes = Buffer.from(await res.arrayBuffer())
+  } else {
+    try {
+      bytes = fs.readFileSync(tgzPathOrUrl)
+    } catch {
+      throw new Error(`Can't read ${tgzPathOrUrl}.`)
+    }
+  }
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kip-connector-'))
+  try {
+    try {
+      extractNpmTarball(bytes, tmp)
+    } catch (err) {
+      throw new Error(`That doesn't look like a connector package: ${err.message}.`)
+    }
+
+    let pkg
+    try {
+      pkg = JSON.parse(fs.readFileSync(path.join(tmp, 'package.json'), 'utf8'))
+    } catch {
+      throw new Error('The tarball has no readable package.json.')
+    }
+    if (!isAllowlisted(pkg.name)) {
+      throw new Error(`"${pkg.name || 'this package'}" is not an allowed connector — Kip only installs @kip-ai/* connectors.`)
+    }
+
+    const spec = normalizeExport(requireDir(tmp))
+    const problem = validateSpec(spec)
+    if (problem) throw new Error(`"${pkg.name}" isn't a valid connector: ${problem}.`)
+
+    if (builtinSpecs().some((s) => s.id === spec.id)) {
+      throw new Error(`"${spec.id}" is a built-in provider — this connector can't use that id.`)
+    }
+    const installed = readConnectorsConfig(vaultRoot)
+    if (installed.some((e) => e.id === spec.id)) {
+      throw new Error(`A "${spec.id}" connector is already installed — remove it first.`)
+    }
+
+    const dir = connectorDirName(pkg.name)
+    const dest = path.join(connectorsPath(vaultRoot), dir)
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.rmSync(dest, { recursive: true, force: true })
+    evictFromRequireCache(dest) // a prior version of this dir may be cached
+    fs.cpSync(tmp, dest, { recursive: true })
+
+    const version = typeof pkg.version === 'string' ? pkg.version : null
+    writeConnectorsConfig(vaultRoot, [...installed, { id: spec.id, name: pkg.name, version, dir }])
+    return { ok: true, id: spec.id, name: pkg.name, version }
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+/** Removes a graph-local connector: its dir + its connectors.json entry. */
+function removeConnector (id, vaultRoot) {
+  if (!vaultRoot) throw new Error('No graph open.')
+  const installed = readConnectorsConfig(vaultRoot)
+  const entry = installed.find((e) => e.id === id)
+  if (!entry) return { ok: false, error: `No installed connector "${id}".` }
+  const dir = path.join(connectorsPath(vaultRoot), entry.dir)
+  fs.rmSync(dir, { recursive: true, force: true })
+  evictFromRequireCache(dir)
+  writeConnectorsConfig(vaultRoot, installed.filter((e) => e.id !== id))
+  return { ok: true, id }
+}
+
+// ---------------------------------------------------------------------------
+// The registry
+// ---------------------------------------------------------------------------
+
 /**
  * The registry of every connector available to this graph: the five
- * built-ins today. `opts.anthropicClient` / `opts.fetchImpl` are test seams
- * for the built-ins — real callers never pass them. `vaultRoot` is reserved
- * for graph-local connector discovery (kip-app#56).
+ * built-ins, plus any bundled and graph-local connectors. Precedence for a
+ * shared id: built-in (locked) > graph-local > bundled.
+ *
+ * `opts.anthropicClient` / `opts.fetchImpl` are test seams for the
+ * built-ins — real callers never pass them.
  */
 function loadConnectors (vaultRoot, opts = {}) {
-  return createRegistry(builtinSpecs(opts), { logger: opts.logger })
+  const logger = opts.logger || console
+  const builtins = builtinSpecs(opts)
+  const locked = new Set(builtins.map((s) => s.id))
+
+  // bundled first, graph-local second: a later valid spec with the same id
+  // wins, so graph-local overrides bundled.
+  const externalById = new Map()
+  for (const spec of [
+    ...loadBundledConnectors({ logger }),
+    ...loadGraphConnectors(vaultRoot, { logger })
+  ]) {
+    const problem = validateSpec(spec)
+    if (problem) {
+      logger.warn(`[connectors] ignoring a connector: ${problem}`)
+      continue
+    }
+    if (locked.has(spec.id)) {
+      logger.warn(`[connectors] ignoring connector "${spec.id}": a built-in owns that id`)
+      continue
+    }
+    externalById.set(spec.id, spec)
+  }
+
+  return createRegistry([...builtins, ...externalById.values()], { logger })
 }
 
 /**
@@ -314,9 +549,14 @@ function missingRequiredField (spec, resolved) {
 
 module.exports = {
   CONNECTOR_API,
+  ALLOWLIST,
   loadConnectors,
   createRegistry,
   validateSpec,
   resolveConfig,
-  missingRequiredField
+  missingRequiredField,
+  isAllowlisted,
+  readConnectorsConfig,
+  installConnectorFromTarball,
+  removeConnector
 }

--- a/scripts/lib/paths.js
+++ b/scripts/lib/paths.js
@@ -46,6 +46,17 @@ function skillsConfigPath (vaultRoot = DEFAULT_VAULT_ROOT) {
   return path.join(henhousePath(vaultRoot), 'skills.json')
 }
 
+// Graph-local LLM connectors: an installed connector package lives in its
+// own dir under connectors/, and connectors.json lists which ones are
+// active ([{ id, name, version, dir }]). Mirrors skills/ + skills.json.
+function connectorsPath (vaultRoot = DEFAULT_VAULT_ROOT) {
+  return path.join(henhousePath(vaultRoot), 'connectors')
+}
+
+function connectorsConfigPath (vaultRoot = DEFAULT_VAULT_ROOT) {
+  return path.join(henhousePath(vaultRoot), 'connectors.json')
+}
+
 // Where skills drop generated files (a deck, a doc, a chart). Visible, not
 // hidden — "where did my export go" should be answerable by looking.
 function exportsPath (vaultRoot = DEFAULT_VAULT_ROOT) {
@@ -76,6 +87,8 @@ module.exports = {
   configPath,
   skillsPath,
   skillsConfigPath,
+  connectorsPath,
+  connectorsConfigPath,
   exportsPath,
   remindersPath,
   TYPE_DIRS,

--- a/scripts/lib/untar.js
+++ b/scripts/lib/untar.js
@@ -1,0 +1,93 @@
+// Minimal npm-tarball (.tgz) extractor — pure Node, zero deps.
+//
+// An npm package tarball is gzip(tar(...)) where every path is under a
+// single top-level "package/" directory (npm convention). This reads that
+// format well enough to unpack a connector package (a package.json + a
+// small JS entry, no binaries): ustar headers, regular files only, the
+// leading dir stripped. Everything else (dirs, symlinks, pax/GNU extension
+// records) is skipped.
+//
+// It is deliberately strict about where bytes land — path traversal, absolute
+// paths, oversized or too-many entries all throw. The connector allowlist in
+// connectors.js is the trust boundary; this is defence in depth.
+
+const zlib = require('node:zlib')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const BLOCK = 512
+const MAX_FILES = 500
+const MAX_TOTAL_BYTES = 32 * 1024 * 1024
+const MAX_FILE_BYTES = 16 * 1024 * 1024
+
+const TYPE_REGULAR = new Set([0, 0x30]) // '\0' (old tar) or '0' (ustar) = regular file
+
+function readString (buf, off, len) {
+  return buf.toString('utf8', off, off + len).replace(/\0.*$/s, '')
+}
+
+function readOctal (buf, off, len) {
+  const s = buf.toString('ascii', off, off + len).replace(/\0.*$/s, '').trim()
+  return s ? parseInt(s, 8) || 0 : 0
+}
+
+/**
+ * Unpacks `tgzBuffer` into `destDir`, stripping the leading path component
+ * ("package/"). Returns the list of relative paths written. Throws on a
+ * malformed archive, a path that would escape destDir, or size/count caps.
+ */
+function extractNpmTarball (tgzBuffer, destDir) {
+  let tar
+  try {
+    tar = zlib.gunzipSync(tgzBuffer)
+  } catch {
+    throw new Error('not a gzipped tarball (.tgz expected)')
+  }
+
+  const root = path.resolve(destDir)
+  const written = []
+  let offset = 0
+  let total = 0
+
+  while (offset + BLOCK <= tar.length) {
+    const header = tar.subarray(offset, offset + BLOCK)
+    if (header.every((b) => b === 0)) break // end-of-archive marker
+
+    const rawName = readString(header, 0, 100)
+    const prefix = readString(header, 345, 155)
+    const name = prefix ? `${prefix}/${rawName}` : rawName
+    const size = readOctal(header, 124, 12)
+    const typeflag = header[156]
+
+    offset += BLOCK
+    const dataStart = offset
+    offset += Math.ceil(size / BLOCK) * BLOCK
+
+    if (!TYPE_REGULAR.has(typeflag) || !name) continue
+
+    // strip the single leading directory (npm's "package/")
+    const rel = name.replace(/^[^/]+\//, '')
+    if (!rel) continue
+    if (rel.split('/').includes('..') || path.isAbsolute(rel)) {
+      throw new Error(`unsafe path in tarball: ${name}`)
+    }
+
+    if (written.length + 1 > MAX_FILES) throw new Error('tarball has too many files')
+    total += size
+    if (size > MAX_FILE_BYTES || total > MAX_TOTAL_BYTES) throw new Error('tarball is too large')
+
+    const dest = path.resolve(root, rel)
+    if (dest !== root && !dest.startsWith(root + path.sep)) {
+      throw new Error(`unsafe path in tarball: ${name}`)
+    }
+
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.writeFileSync(dest, tar.subarray(dataStart, dataStart + size))
+    written.push(rel)
+  }
+
+  if (written.length === 0) throw new Error('tarball contained no files')
+  return written
+}
+
+module.exports = { extractNpmTarball }

--- a/scripts/test/_tarball.js
+++ b/scripts/test/_tarball.js
@@ -1,0 +1,58 @@
+// Test helper: build a valid npm-style .tgz in memory (gzip + ustar tar,
+// every path under a top-level "package/"). Not a test file — the `_`
+// prefix and the explicit file list in package.json keep the runner off it.
+const zlib = require('node:zlib')
+
+function tarHeader (name, size) {
+  const h = Buffer.alloc(512)
+  h.write(name.slice(0, 100), 0, 'utf8')
+  h.write('0000644\0', 100)
+  h.write('0000000\0', 108)
+  h.write('0000000\0', 116)
+  h.write(size.toString(8).padStart(11, '0') + '\0', 124)
+  h.write('00000000000\0', 136)
+  h.write('        ', 148) // checksum field starts as spaces
+  h.write('0', 156) // typeflag: regular file
+  h.write('ustar\0', 257)
+  h.write('00', 263)
+  let sum = 0
+  for (const b of h) sum += b
+  h.write(sum.toString(8).padStart(6, '0') + '\0 ', 148)
+  return h
+}
+
+/**
+ * files: { 'package/package.json': '{...}', 'package/index.js': '…', … }
+ * Returns a Buffer (the .tgz bytes).
+ */
+function makeTgz (files) {
+  const parts = []
+  for (const [name, content] of Object.entries(files)) {
+    const body = Buffer.from(content)
+    parts.push(tarHeader(name, body.length))
+    const padded = Buffer.alloc(Math.ceil(body.length / 512) * 512)
+    body.copy(padded)
+    parts.push(padded)
+  }
+  parts.push(Buffer.alloc(1024)) // two zero blocks = end of archive
+  return zlib.gzipSync(Buffer.concat(parts))
+}
+
+/** A minimal, valid connector package as a .tgz. */
+function connectorTgz ({ name = '@kip-ai/connector', version = '1.0.0', id = 'kip', extra = {} } = {}) {
+  const spec = `module.exports = {
+    kipConnectorApi: 1,
+    id: ${JSON.stringify(id)},
+    label: 'Kip (managed)',
+    fields: [{ key: 'apiKey', label: 'API key', type: 'password', required: true }],
+    envDefaults: { apiKey: 'KIP_API_KEY' },
+    isReady: (cfg) => !!cfg.apiKey,
+    complete: async () => ({ text: 'ok', raw: {} })
+  }`
+  return makeTgz({
+    'package/package.json': JSON.stringify({ name, version, main: 'index.js', ...extra }),
+    'package/index.js': spec
+  })
+}
+
+module.exports = { makeTgz, connectorTgz }

--- a/scripts/test/connectors.test.js
+++ b/scripts/test/connectors.test.js
@@ -1,5 +1,8 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 
 const {
   CONNECTOR_API,
@@ -7,8 +10,26 @@ const {
   createRegistry,
   validateSpec,
   resolveConfig,
-  missingRequiredField
+  missingRequiredField,
+  isAllowlisted,
+  readConnectorsConfig,
+  installConnectorFromTarball,
+  removeConnector
 } = require('../lib/connectors')
+const { makeTgz, connectorTgz } = require('./_tarball')
+
+function tmpVault () {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'connectors-test-'))
+  test.after(() => fs.rmSync(d, { recursive: true, force: true }))
+  return d
+}
+
+/** Write a .tgz buffer to a file inside the vault and return its path. */
+function tgzFile (vault, buf, name = 'pkg.tgz') {
+  const p = path.join(vault, name)
+  fs.writeFileSync(p, buf)
+  return p
+}
 
 const okSpec = (over = {}) => ({
   kipConnectorApi: CONNECTOR_API,
@@ -91,4 +112,88 @@ test('loadConnectors: built-in readiness matches its resolved config', () => {
   assert.equal(reg.get('openai').isReady({ apiKey: 'k', model: 'm' }), true)
   assert.equal(reg.get('other').isReady({ model: 'm' }), false, 'other needs a base URL')
   assert.equal(reg.get('other').isReady({ baseUrl: 'u', model: 'm' }), true)
+})
+
+// ---------------------------------------------------------------------------
+// Graph-local connector install / discovery / remove (kip-app#56)
+// ---------------------------------------------------------------------------
+
+const quiet = { logger: { warn () {} } }
+
+test('isAllowlisted: only @kip-ai/* passes', () => {
+  assert.equal(isAllowlisted('@kip-ai/connector'), true)
+  assert.equal(isAllowlisted('@kip-ai/experimental'), true)
+  assert.equal(isAllowlisted('@evil/kip-ai'), false)
+  assert.equal(isAllowlisted('kip-connector'), false)
+  assert.equal(isAllowlisted(''), false)
+  assert.equal(isAllowlisted(undefined), false)
+})
+
+test('installConnectorFromTarball: refuses a non-allowlisted package', async () => {
+  const v = tmpVault()
+  const tgz = tgzFile(v, connectorTgz({ name: 'totally-legit-connector' }))
+  await assert.rejects(() => installConnectorFromTarball(tgz, v, quiet), /not an allowed connector/)
+  assert.deepEqual(readConnectorsConfig(v), [], 'nothing recorded')
+})
+
+test('installConnectorFromTarball: refuses a tarball that is not a valid ProviderSpec', async () => {
+  const v = tmpVault()
+  const bad = makeTgz({
+    'package/package.json': JSON.stringify({ name: '@kip-ai/broken', version: '1.0.0', main: 'index.js' }),
+    'package/index.js': 'module.exports = { id: "x" }' // no kipConnectorApi, no complete
+  })
+  await assert.rejects(() => installConnectorFromTarball(tgzFile(v, bad), v, quiet), /isn't a valid connector/)
+})
+
+test('installConnectorFromTarball: refuses an id that collides with a built-in', async () => {
+  const v = tmpVault()
+  const tgz = tgzFile(v, connectorTgz({ id: 'openai' }))
+  await assert.rejects(() => installConnectorFromTarball(tgz, v, quiet), /built-in provider/)
+})
+
+test('connector lifecycle: install -> load -> remove', async () => {
+  const v = tmpVault()
+  const res = await installConnectorFromTarball(tgzFile(v, connectorTgz()), v, quiet)
+  assert.deepEqual(res, { ok: true, id: 'kip', name: '@kip-ai/connector', version: '1.0.0' })
+
+  // recorded in connectors.json + on disk
+  assert.deepEqual(readConnectorsConfig(v), [
+    { id: 'kip', name: '@kip-ai/connector', version: '1.0.0', dir: 'kip-ai__connector' }
+  ])
+  assert.ok(fs.existsSync(path.join(v, '.henhouse', 'connectors', 'kip-ai__connector', 'index.js')))
+
+  // shows up in the registry, usable
+  const reg = loadConnectors(v, quiet)
+  assert.ok(reg.has('kip'))
+  assert.equal(reg.get('kip').label, 'Kip (managed)')
+  assert.equal(reg.get('kip').isReady({ apiKey: 'kip_x' }), true)
+  assert.equal(reg.get('kip').isReady({}), false)
+
+  // second install of the same id is refused
+  await assert.rejects(() => installConnectorFromTarball(tgzFile(v, connectorTgz()), v, quiet), /already installed/)
+
+  // remove: gone from disk, config, and the registry
+  assert.deepEqual(removeConnector('kip', v), { ok: true, id: 'kip' })
+  assert.deepEqual(readConnectorsConfig(v), [])
+  assert.equal(fs.existsSync(path.join(v, '.henhouse', 'connectors', 'kip-ai__connector')), false)
+  assert.equal(loadConnectors(v, quiet).has('kip'), false)
+
+  assert.deepEqual(removeConnector('kip', v), { ok: false, error: 'No installed connector "kip".' })
+})
+
+test('loadConnectors: a graph-local connector listed but missing from disk is skipped, not fatal', () => {
+  const v = tmpVault()
+  fs.mkdirSync(path.join(v, '.henhouse'), { recursive: true })
+  fs.writeFileSync(
+    path.join(v, '.henhouse', 'connectors.json'),
+    JSON.stringify([{ id: 'ghost', name: '@kip-ai/ghost', version: '1.0.0', dir: 'kip-ai__ghost' }])
+  )
+  const warnings = []
+  const reg = loadConnectors(v, { logger: { warn: (m) => warnings.push(m) } })
+  assert.deepEqual(reg.ids().sort(), ['anthropic', 'deepseek', 'local', 'openai', 'other'])
+  assert.match(warnings.join('\n'), /ghost/)
+})
+
+test('installConnectorFromTarball: needs an open graph', async () => {
+  await assert.rejects(() => installConnectorFromTarball('/tmp/x.tgz', undefined, quiet), /Open a folder first/)
 })

--- a/scripts/test/untar.test.js
+++ b/scripts/test/untar.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const zlib = require('node:zlib')
+
+const { extractNpmTarball } = require('../lib/untar')
+const { makeTgz } = require('./_tarball')
+
+function tmpDir () {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'untar-test-'))
+  test.after(() => fs.rmSync(d, { recursive: true, force: true }))
+  return d
+}
+
+test('extractNpmTarball: unpacks files, stripping the leading package/ dir', () => {
+  const dir = tmpDir()
+  const written = extractNpmTarball(makeTgz({
+    'package/package.json': '{"name":"x"}',
+    'package/lib/a.js': 'module.exports = 1'
+  }), dir)
+  assert.deepEqual(written.sort(), ['lib/a.js', 'package.json'])
+  assert.equal(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'), '{"name":"x"}')
+  assert.equal(fs.readFileSync(path.join(dir, 'lib', 'a.js'), 'utf8'), 'module.exports = 1')
+})
+
+test('extractNpmTarball: rejects a non-gzip buffer', () => {
+  assert.throws(() => extractNpmTarball(Buffer.from('not a gzip'), tmpDir()), /gzipped tarball/)
+})
+
+test('extractNpmTarball: rejects path traversal', () => {
+  const evil = makeTgz({ 'package/../../escape.js': 'pwned' })
+  assert.throws(() => extractNpmTarball(evil, tmpDir()), /unsafe path/)
+})
+
+test('extractNpmTarball: rejects an absolute path', () => {
+  const evil = makeTgz({ 'package//etc/passwd': 'x' })
+  assert.throws(() => extractNpmTarball(evil, tmpDir()), /unsafe path/)
+})
+
+test('extractNpmTarball: rejects an archive with no files', () => {
+  assert.throws(() => extractNpmTarball(zlib.gzipSync(Buffer.alloc(1024)), tmpDir()), /no files/)
+})
+
+test('extractNpmTarball: enforces the per-file size cap', () => {
+  // one 17 MB entry — over MAX_FILE_BYTES (16 MB)
+  const big = makeTgz({ 'package/big.bin': 'a'.repeat(17 * 1024 * 1024) })
+  assert.throws(() => extractNpmTarball(big, tmpDir()), /too large/)
+})


### PR DESCRIPTION
Second step of the connector epic (**kip-app#62**), on top of #55 (#8).

## What

`loadConnectors()` now composes three tiers — **built-in (locked) > graph-local > bundled**:

- **bundled** — `BUNDLED_CONNECTORS` (allowlisted packages shipped as app deps, found via `require.resolve`). Absent until `@kip-ai/connector` is published + added to `scripts/package.json`; then it rides the normal app auto-update, so the select group stays current for free.
- **graph-local** — `<graph>/.henhouse/connectors/<dir>/` reconciled against `connectors.json` (`[{id,name,version,dir}]`), mirroring `.henhouse/skills/`. A graph-local connector **overrides a bundled one of the same id** — the "ship a fix ahead of an app release" path.

### Install / remove

- `installConnectorFromTarball(tgz | https-url, vaultRoot)` — fetch/read the `.tgz`, extract with **`lib/untar.js`** (new; zero-dep, strips the leading `package/`, rejects path traversal / absolute paths / oversized / too-many-files — **no `npm` shell-out**), check the package name against **`ALLOWLIST`** (`@kip-ai/*`, a host constant, not user-editable), validate the `ProviderSpec`, refuse an id colliding with a built-in or an already-installed connector, copy into place, record in `connectors.json`.
- `removeConnector(id, vaultRoot)` — delete the dir + entry, evict the require cache.
- A connector that fails to load is skipped with a warning — never throws into `callLLM()`.

## Access model (agreed with @JWE24-code)

The connector is invite-only *for now* without blocking auto-updates: bundle it (everyone gets the bytes + every update), hide it in the UI unless opted in (#58), and gate real use on the backend `kip_` key. This PR is the discovery/install layer that makes that possible; the allowlist already permits `@kip-ai/*` for the private-tarball escape hatch.

## Acceptance

- ✅ allowlist rejection · invalid-spec rejection · id-collision (built-in) rejection · full install → load → remove cycle · missing-dir tolerance · needs-a-graph
- ✅ `untar.js`: unpack + strip, non-gzip, path traversal, absolute path, empty archive, size cap
- ✅ Full scripts suite **188/188** (+7 connectors, +6 untar)

## Next

#57 — electron IPC (`listLlmProviders` / `installConnector` / `removeConnector`), threading `vaultRoot` through so graph-local connectors are visible to the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)