### PR TITLE
connectors: the managed "kip" backend connector (#61)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@
 # doesn't exist or doesn't set a given field.
 
 # Which LLM backend scripts/lib/llm.js routes calls to. One of:
-# anthropic (default) | openai | deepseek | local | other
+# anthropic (default) | openai | deepseek | local | other | kip
 PROVIDER=anthropic
 
 # --- anthropic (PROVIDER=anthropic) ---
@@ -44,6 +44,14 @@ LOCAL_MODEL=
 OTHER_BASE_URL=
 OTHER_API_KEY=
 OTHER_MODEL=
+
+# --- kip (PROVIDER=kip) ---
+# The managed Kip backend: one kip_ key instead of per-provider keys; the
+# backend picks the model per workload, enforces your plan, and meters usage.
+# KIP_BASE_URL defaults to the hosted endpoint — override it to point at a
+# self-hosted Kip backend. Get a key from your backend admin (Accounts → Keys).
+KIP_API_KEY=
+KIP_BASE_URL=https://api.kip-ai.be
 
 # --- hatch tracing (optional) ---
 # Set to 1 to make scripts/hatch-all.js stream every LLM call — full prompt

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -73,8 +73,9 @@ scripts/
 │   │                # plus loadLLMConfig/saveLLMConfig, see "LLM provider
 │   │                # config" below. Hosts lib/connectors.js.
 │   ├── connectors.js # the connector registry: each provider is a ProviderSpec
-│   │                # (fields + complete()); 5 built-ins + bundled/graph-local
+│   │                # (fields + complete()); built-ins + bundled/graph-local
 │   │                # connectors (install from a .tgz, @kip-ai/* allowlist)
+│   ├── kip-connector.js # the managed-backend "kip" connector (AGPL, built-in)
 │   ├── untar.js    # zero-dep npm-tarball (.tgz) extractor for connector install
 │   ├── telemetry.js # per-run LLM-call timing/token recorder every callLLM()
 │   │                # feeds; content-free summary() + opt-in full-text trace
@@ -300,7 +301,10 @@ isReady, complete(resolved, call, ctx) }`; `ctx` = `{ fetch, signal, logger }`
 only). Three sources:
 
 - **built-in** — `anthropic` / `openai` / `deepseek` / `local` / `other`, in
-  `connectors.js`. Their ids can never be shadowed.
+  `connectors.js`, plus **`kip`** — the managed-backend connector
+  (`lib/kip-connector.js`; AGPL-3.0, first-party). Their ids can never be
+  shadowed. The settings UI hides `kip` from the dropdown until the user
+  opts in (kip-app#58).
 - **bundled** — an allowlisted package shipped as an app dependency
   (`BUNDLED_CONNECTORS`). Rides the normal app auto-update.
 - **graph-local** — installed from an npm `.tgz` into
@@ -318,6 +322,14 @@ connector that fails to load is skipped with a warning — it never throws
 into `callLLM()`. Trust boundary: a graph-local connector is `require`d
 into the process with `fetch`, so the allowlist is the gate. Tested in
 `scripts/test/connectors.test.js` + `untar.test.js`.
+
+**The `kip` connector** (`lib/kip-connector.js`) POSTs to
+`{baseUrl}/v1/chat/completions` with `Authorization: Bearer kip_…` and
+`X-Kip-Workload` (the full call label) / `X-Kip-Phase` (its first
+`:`-segment) routing headers; body is `{ model: "auto", max_tokens,
+messages }`. `baseUrl` defaults to `https://api.kip-ai.be`, overridable to
+a self-hosted backend. Contract: `JWE24-code/kip-backend` → `KIP-BACKEND.md`.
+Tested against a mocked `fetch` in `scripts/test/kip-connector.test.js`.
 
 #### `groom.js` — coop health checks
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "peck": "node scripts/peck.js",
     "groom": "node scripts/groom.js",
     "hatch": "node scripts/hatch.js",
-    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js"
+    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.70.0",

--- a/scripts/lib/connectors.js
+++ b/scripts/lib/connectors.js
@@ -7,8 +7,9 @@
 // telemetry. No provider-specific code (the Anthropic SDK, OpenAI-shaped
 // fetch calls) lives outside this file.
 //
-// The five built-ins (anthropic / openai / deepseek / local / other) are
-// ProviderSpecs defined below. External connectors register through
+// The built-ins (anthropic / openai / deepseek / local / other, plus the
+// managed "kip" backend connector from ./kip-connector.js) are ProviderSpecs
+// defined below. External connectors register through
 // loadConnectors() too, from two sources:
 //
 //   * bundled  — an allowlisted package that ships as a dependency of the
@@ -247,7 +248,11 @@ function builtinSpecs ({ anthropicClient, fetchImpl } = {}) {
       envDefaults: { baseUrl: 'OTHER_BASE_URL', model: 'OTHER_MODEL', apiKey: 'OTHER_API_KEY' },
       isReady: (cfg) => !!cfg.baseUrl && !!cfg.model,
       complete: openAICompatibleComplete
-    }
+    },
+    // The managed Kip backend — a first-party connector that ships with the
+    // app (AGPL-3.0, ./kip-connector.js). The settings UI keeps it out of
+    // the provider dropdown until the user opts in (kip-app#58).
+    require('./kip-connector')
   ]
 }
 

--- a/scripts/lib/kip-connector.js
+++ b/scripts/lib/kip-connector.js
@@ -1,0 +1,159 @@
+// The "Kip (managed)" connector — routes every LLM call through the managed
+// Kip backend (api.kip-ai.be or a self-hosted equivalent) instead of a
+// per-provider key. One `kip_` key; the backend picks the model per
+// workload, enforces the plan, and meters usage.
+//
+// This is an AGPL-3.0 ProviderSpec that ships with Kip (see kip-app#62 and
+// kip-backend/KIP-BACKEND.md §15-16 for why an AGPL client leaves the
+// backend proprietary). It's registered as a built-in in connectors.js but
+// hidden from the settings dropdown until the user opts in (kip-app#58) —
+// invite-only for now, gated by whether the backend issues you a key.
+//
+// Contract (KIP-BACKEND.md §3):
+//   POST {baseUrl}/v1/chat/completions
+//   Authorization: Bearer kip_…
+//   X-Kip-Workload: <full call label>      e.g. "hatch:generate:entity"
+//   X-Kip-Phase:    <first ":"-segment>    e.g. "hatch"
+//   body { model: "auto", max_tokens, messages: [system?, user], response_format? }
+//   -> OpenAI-shaped response; `model` is the real upstream model (telemetry),
+//      `usage` carries the token counts.
+//   errors: 401 bad key · 402 plan/budget · 429 rate limit · 5xx upstream,
+//           OpenAI-shaped { error: { message, type, code } }.
+
+const CONNECTOR_API = 1
+const DEFAULT_BASE_URL = 'https://api.kip-ai.be'
+const JSON_MODE_INSTRUCTION =
+  'Respond with ONLY valid JSON and no other text — no markdown code fences, no explanation.'
+
+function stripCodeFences (text) {
+  const trimmed = String(text).trim()
+  const fenced = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/)
+  return fenced ? fenced[1].trim() : trimmed
+}
+
+/** "hatch:generate:entity" -> "hatch"; "" / no label -> null (header omitted). */
+function phaseOf (label) {
+  if (!label || typeof label !== 'string') return null
+  const first = label.split(':')[0].trim()
+  return first || null
+}
+
+function buildMessages (system, prompt) {
+  const messages = []
+  if (system) messages.push({ role: 'system', content: system })
+  messages.push({ role: 'user', content: prompt })
+  return messages
+}
+
+async function post (baseUrl, apiKey, body, headers, doFetch, signal) {
+  const res = await doFetch(`${baseUrl.replace(/\/+$/, '')}/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      ...headers
+    },
+    body: JSON.stringify(body),
+    signal
+  })
+  if (!res.ok) {
+    let detail
+    try {
+      const j = await res.json()
+      detail = j && j.error && j.error.message
+    } catch { /* non-JSON error body */ }
+    if (!detail) detail = await res.text().catch(() => '')
+    const err = new Error(`Kip backend request failed (${res.status})${detail ? `: ${detail}` : ''}`)
+    err.status = res.status
+    throw err
+  }
+  return res.json()
+}
+
+/** Shared by complete() and testConnection(): one call, returns { text, raw }. */
+async function callBackend (resolved, call, ctx) {
+  const doFetch = (ctx && ctx.fetch) || fetch
+  const signal = ctx && ctx.signal
+  const baseUrl = resolved.baseUrl || DEFAULT_BASE_URL
+
+  const routingHeaders = {}
+  if (call.label) {
+    routingHeaders['X-Kip-Workload'] = call.label
+    const phase = phaseOf(call.label)
+    if (phase) routingHeaders['X-Kip-Phase'] = phase
+  }
+
+  const base = {
+    model: 'auto',
+    max_tokens: call.maxTokens,
+    messages: buildMessages(call.system, call.prompt)
+  }
+
+  let data
+  if (call.json) {
+    try {
+      data = await post(baseUrl, resolved.apiKey, { ...base, response_format: { type: 'json_object' } }, routingHeaders, doFetch, signal)
+    } catch (err) {
+      // a routing/plan/auth error is real — only retry a plain 400 (upstream
+      // rejected response_format), matching the OpenAI-compatible path.
+      if (err.status !== 400) throw err
+      const sys = call.system ? `${call.system}\n\n${JSON_MODE_INSTRUCTION}` : JSON_MODE_INSTRUCTION
+      data = await post(baseUrl, resolved.apiKey, { ...base, messages: buildMessages(sys, call.prompt) }, routingHeaders, doFetch, signal)
+    }
+  } else {
+    data = await post(baseUrl, resolved.apiKey, base, routingHeaders, doFetch, signal)
+  }
+
+  const raw = (data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content) || ''
+  return { text: call.json ? stripCodeFences(raw) : String(raw).trim(), raw: data }
+}
+
+/** @type {import('./connectors').ProviderSpec} */
+module.exports = {
+  kipConnectorApi: CONNECTOR_API,
+  id: 'kip',
+  label: 'Kip (managed)',
+  fields: [
+    { key: 'apiKey', label: 'API key', type: 'password', required: true, placeholder: 'kip_…', help: 'From your Kip backend admin → Accounts → Keys.' },
+    { key: 'baseUrl', label: 'Base URL', type: 'text', required: false, default: DEFAULT_BASE_URL, help: 'Leave as-is for the hosted service, or point it at a self-hosted Kip backend.' }
+  ],
+  envDefaults: { apiKey: 'KIP_API_KEY', baseUrl: 'KIP_BASE_URL' },
+  isReady: (cfg) => !!(cfg && cfg.apiKey),
+
+  async complete (resolved, call, ctx) {
+    return callBackend(resolved, call, ctx)
+  },
+
+  async testConnection (resolved, ctx) {
+    try {
+      const { text } = await callBackend(
+        resolved,
+        { system: '', prompt: 'Reply with exactly: OK', json: false, maxTokens: 10, label: 'test:connection' },
+        ctx
+      )
+      return { success: true, reply: text }
+    } catch (err) {
+      return { success: false, error: err.message || String(err) }
+    }
+  },
+
+  humanizeError (raw) {
+    const s = String(raw)
+    if (/\(401\)|invalid.{0,12}api.?key|bad.?api.?key/i.test(s)) {
+      return { title: 'The Kip backend rejected your key.', hint: 'Check the kip_ key in Settings → LLM, or ask your backend admin for a new one.' }
+    }
+    if (/\(402\)|plan limit|payment required|insufficient_quota|budget/i.test(s)) {
+      return { title: "You've hit your Kip plan limit.", hint: "You've used this period's included tokens or calls. Ask your backend admin to raise the budget." }
+    }
+    if (/\(429\)|rate.?limit|too many requests/i.test(s)) {
+      return { title: 'The Kip backend is rate-limiting you.', hint: 'Wait a moment and try again — or ask for a higher rate limit.' }
+    }
+    if (/\(503\)|no_route|no route/i.test(s)) {
+      return { title: 'The Kip backend has no route for this call.', hint: 'The backend admin needs a routing rule for this workload — send them the error details.' }
+    }
+    return null
+  },
+
+  // exported for tests
+  _internals: { phaseOf, DEFAULT_BASE_URL }
+}

--- a/scripts/test/_tarball.js
+++ b/scripts/test/_tarball.js
@@ -39,11 +39,11 @@ function makeTgz (files) {
 }
 
 /** A minimal, valid connector package as a .tgz. */
-function connectorTgz ({ name = '@kip-ai/connector', version = '1.0.0', id = 'kip', extra = {} } = {}) {
+function connectorTgz ({ name = '@kip-ai/experimental', version = '1.0.0', id = 'kip-exp', extra = {} } = {}) {
   const spec = `module.exports = {
     kipConnectorApi: 1,
     id: ${JSON.stringify(id)},
-    label: 'Kip (managed)',
+    label: 'Kip experimental',
     fields: [{ key: 'apiKey', label: 'API key', type: 'password', required: true }],
     envDefaults: { apiKey: 'KIP_API_KEY' },
     isReady: (cfg) => !!cfg.apiKey,

--- a/scripts/test/connectors.test.js
+++ b/scripts/test/connectors.test.js
@@ -95,9 +95,11 @@ test('missingRequiredField: first blank required field, else null', () => {
   assert.equal(missingRequiredField(spec, {}).key, 'a')
 })
 
-test('loadConnectors: returns the five built-ins, all valid v1 specs', () => {
+const BUILTIN_IDS = ['anthropic', 'deepseek', 'kip', 'local', 'openai', 'other']
+
+test('loadConnectors: returns the built-ins (incl. the managed kip connector), all valid v1 specs', () => {
   const reg = loadConnectors()
-  assert.deepEqual(reg.ids().sort(), ['anthropic', 'deepseek', 'local', 'openai', 'other'])
+  assert.deepEqual(reg.ids().sort(), BUILTIN_IDS)
   for (const spec of reg.list()) {
     assert.equal(validateSpec(spec), null, `${spec.id} is a valid spec`)
     assert.equal(typeof spec.isReady, 'function')
@@ -112,6 +114,8 @@ test('loadConnectors: built-in readiness matches its resolved config', () => {
   assert.equal(reg.get('openai').isReady({ apiKey: 'k', model: 'm' }), true)
   assert.equal(reg.get('other').isReady({ model: 'm' }), false, 'other needs a base URL')
   assert.equal(reg.get('other').isReady({ baseUrl: 'u', model: 'm' }), true)
+  assert.equal(reg.get('kip').isReady({}), false, 'the managed connector needs a kip_ key')
+  assert.equal(reg.get('kip').isReady({ apiKey: 'kip_x' }), true)
 })
 
 // ---------------------------------------------------------------------------
@@ -154,31 +158,39 @@ test('installConnectorFromTarball: refuses an id that collides with a built-in',
 test('connector lifecycle: install -> load -> remove', async () => {
   const v = tmpVault()
   const res = await installConnectorFromTarball(tgzFile(v, connectorTgz()), v, quiet)
-  assert.deepEqual(res, { ok: true, id: 'kip', name: '@kip-ai/connector', version: '1.0.0' })
+  assert.deepEqual(res, { ok: true, id: 'kip-exp', name: '@kip-ai/experimental', version: '1.0.0' })
 
   // recorded in connectors.json + on disk
   assert.deepEqual(readConnectorsConfig(v), [
-    { id: 'kip', name: '@kip-ai/connector', version: '1.0.0', dir: 'kip-ai__connector' }
+    { id: 'kip-exp', name: '@kip-ai/experimental', version: '1.0.0', dir: 'kip-ai__experimental' }
   ])
-  assert.ok(fs.existsSync(path.join(v, '.henhouse', 'connectors', 'kip-ai__connector', 'index.js')))
+  assert.ok(fs.existsSync(path.join(v, '.henhouse', 'connectors', 'kip-ai__experimental', 'index.js')))
 
   // shows up in the registry, usable
   const reg = loadConnectors(v, quiet)
-  assert.ok(reg.has('kip'))
-  assert.equal(reg.get('kip').label, 'Kip (managed)')
-  assert.equal(reg.get('kip').isReady({ apiKey: 'kip_x' }), true)
-  assert.equal(reg.get('kip').isReady({}), false)
+  assert.ok(reg.has('kip-exp'))
+  assert.equal(reg.get('kip-exp').label, 'Kip experimental')
+  assert.equal(reg.get('kip-exp').isReady({ apiKey: 'kip_x' }), true)
+  assert.equal(reg.get('kip-exp').isReady({}), false)
 
   // second install of the same id is refused
   await assert.rejects(() => installConnectorFromTarball(tgzFile(v, connectorTgz()), v, quiet), /already installed/)
 
   // remove: gone from disk, config, and the registry
-  assert.deepEqual(removeConnector('kip', v), { ok: true, id: 'kip' })
+  assert.deepEqual(removeConnector('kip-exp', v), { ok: true, id: 'kip-exp' })
   assert.deepEqual(readConnectorsConfig(v), [])
-  assert.equal(fs.existsSync(path.join(v, '.henhouse', 'connectors', 'kip-ai__connector')), false)
-  assert.equal(loadConnectors(v, quiet).has('kip'), false)
+  assert.equal(fs.existsSync(path.join(v, '.henhouse', 'connectors', 'kip-ai__experimental')), false)
+  assert.equal(loadConnectors(v, quiet).has('kip-exp'), false)
 
-  assert.deepEqual(removeConnector('kip', v), { ok: false, error: 'No installed connector "kip".' })
+  assert.deepEqual(removeConnector('kip-exp', v), { ok: false, error: 'No installed connector "kip-exp".' })
+})
+
+test('installConnectorFromTarball: refuses an id that collides with the built-in kip connector', async () => {
+  const v = tmpVault()
+  await assert.rejects(
+    () => installConnectorFromTarball(tgzFile(v, connectorTgz({ id: 'kip' })), v, quiet),
+    /built-in provider/
+  )
 })
 
 test('loadConnectors: a graph-local connector listed but missing from disk is skipped, not fatal', () => {
@@ -190,7 +202,7 @@ test('loadConnectors: a graph-local connector listed but missing from disk is sk
   )
   const warnings = []
   const reg = loadConnectors(v, { logger: { warn: (m) => warnings.push(m) } })
-  assert.deepEqual(reg.ids().sort(), ['anthropic', 'deepseek', 'local', 'openai', 'other'])
+  assert.deepEqual(reg.ids().sort(), BUILTIN_IDS)
   assert.match(warnings.join('\n'), /ghost/)
 })
 

--- a/scripts/test/kip-connector.test.js
+++ b/scripts/test/kip-connector.test.js
@@ -1,0 +1,149 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const kip = require('../lib/kip-connector')
+const { validateSpec } = require('../lib/connectors')
+
+const RESOLVED = { apiKey: 'kip_testkey', baseUrl: 'http://lan.test:8080' }
+
+/** A fake fetch that records the last call and returns `body` (200 unless overridden). */
+function fakeFetch (body, { ok = true, status = 200 } = {}) {
+  let last = null
+  const impl = async (url, init) => {
+    last = { url, init, headers: init.headers, body: JSON.parse(init.body) }
+    return {
+      ok,
+      status,
+      json: async () => body,
+      text: async () => (typeof body === 'string' ? body : JSON.stringify(body))
+    }
+  }
+  return { impl, last: () => last }
+}
+
+const reply = (content, usage) => ({
+  id: 'chatcmpl-x',
+  model: 'claude-sonnet-4-6',
+  choices: [{ message: { content } }],
+  ...(usage ? { usage } : {})
+})
+
+test('kip-connector is a valid v1 ProviderSpec', () => {
+  assert.equal(validateSpec(kip), null)
+  assert.equal(kip.id, 'kip')
+  assert.equal(kip.isReady({ apiKey: 'kip_x' }), true)
+  assert.equal(kip.isReady({}), false)
+  assert.equal(kip.isReady(null), false)
+})
+
+test('phaseOf: first ":"-segment, or null', () => {
+  const { phaseOf } = kip._internals
+  assert.equal(phaseOf('hatch:generate:entity'), 'hatch')
+  assert.equal(phaseOf('peck:answer'), 'peck')
+  assert.equal(phaseOf('skill:docx'), 'skill')
+  assert.equal(phaseOf('groom'), 'groom')
+  assert.equal(phaseOf(''), null)
+  assert.equal(phaseOf(undefined), null)
+})
+
+test('complete: sends auth + routing headers + model:"auto"', async () => {
+  const { impl, last } = fakeFetch(reply('hi from kip'))
+  const res = await kip.complete(RESOLVED,
+    { system: 'sys', prompt: 'q', json: false, maxTokens: 4096, label: 'hatch:generate:entity' },
+    { fetch: impl })
+
+  assert.equal(res.text, 'hi from kip')
+  assert.ok(res.raw)
+  assert.equal(last().url, 'http://lan.test:8080/v1/chat/completions')
+  assert.equal(last().headers.Authorization, 'Bearer kip_testkey')
+  assert.equal(last().headers['X-Kip-Workload'], 'hatch:generate:entity')
+  assert.equal(last().headers['X-Kip-Phase'], 'hatch')
+  assert.equal(last().body.model, 'auto')
+  assert.equal(last().body.max_tokens, 4096)
+  assert.deepEqual(last().body.messages, [
+    { role: 'system', content: 'sys' },
+    { role: 'user', content: 'q' }
+  ])
+})
+
+test('complete: no label -> no routing headers', async () => {
+  const { impl, last } = fakeFetch(reply('ok'))
+  await kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10 }, { fetch: impl })
+  assert.equal(last().headers['X-Kip-Workload'], undefined)
+  assert.equal(last().headers['X-Kip-Phase'], undefined)
+})
+
+test('complete: default base URL when the field is blank', async () => {
+  const { impl, last } = fakeFetch(reply('ok'))
+  await kip.complete({ apiKey: 'kip_x' }, { prompt: 'q', maxTokens: 10 }, { fetch: impl })
+  assert.ok(last().url.startsWith(kip._internals.DEFAULT_BASE_URL + '/v1/chat/completions'))
+})
+
+test('complete json:true -> response_format, and strips code fences', async () => {
+  const { impl, last } = fakeFetch(reply('```json\n{"a":1}\n```'))
+  const res = await kip.complete(RESOLVED, { prompt: 'q', json: true, maxTokens: 100 }, { fetch: impl })
+  assert.deepEqual(last().body.response_format, { type: 'json_object' })
+  assert.equal(res.text, '{"a":1}')
+})
+
+test('complete json:true -> retries prompt-and-strip on a 400 only', async () => {
+  let n = 0
+  const impl = async (_url, init) => {
+    n++
+    const body = JSON.parse(init.body)
+    if (body.response_format) {
+      return { ok: false, status: 400, json: async () => ({ error: { message: 'response_format unsupported' } }), text: async () => '' }
+    }
+    assert.ok(body.messages[0].content.includes('ONLY valid JSON'))
+    return { ok: true, status: 200, json: async () => reply('{"ok":true}'), text: async () => '' }
+  }
+  const res = await kip.complete(RESOLVED, { system: 's', prompt: 'q', json: true, maxTokens: 100 }, { fetch: impl })
+  assert.equal(n, 2)
+  assert.equal(res.text, '{"ok":true}')
+})
+
+test('complete json:true -> does NOT retry a 402 (plan limit is real)', async () => {
+  let n = 0
+  const impl = async () => {
+    n++
+    return { ok: false, status: 402, json: async () => ({ error: { message: 'plan limit reached' } }), text: async () => '' }
+  }
+  await assert.rejects(
+    () => kip.complete(RESOLVED, { prompt: 'q', json: true, maxTokens: 10 }, { fetch: impl }),
+    (err) => err.status === 402 && /plan limit reached/.test(err.message)
+  )
+  assert.equal(n, 1)
+})
+
+test('complete: non-2xx throws an Error with .status and the backend message', async () => {
+  const { impl } = fakeFetch({ error: { message: 'Invalid API key', type: 'invalid_api_key', code: 'invalid_api_key' } }, { ok: false, status: 401 })
+  await assert.rejects(
+    () => kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10 }, { fetch: impl }),
+    (err) => err.status === 401 && /\(401\)/.test(err.message) && /Invalid API key/.test(err.message)
+  )
+})
+
+test('complete: raw carries the resolved model + usage for telemetry', async () => {
+  const { impl } = fakeFetch(reply('x', { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 }))
+  const { raw } = await kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10 }, { fetch: impl })
+  assert.equal(raw.model, 'claude-sonnet-4-6')
+  assert.equal(raw.usage.total_tokens, 15)
+})
+
+test('testConnection: { success:true, reply } on a good call, never throws on a bad one', async () => {
+  const ok = fakeFetch(reply('OK'))
+  assert.deepEqual(await kip.testConnection(RESOLVED, { fetch: ok.impl }), { success: true, reply: 'OK' })
+
+  const bad = fakeFetch({ error: { message: 'nope' } }, { ok: false, status: 401 })
+  const r = await kip.testConnection(RESOLVED, { fetch: bad.impl })
+  assert.equal(r.success, false)
+  assert.match(r.error, /401/)
+})
+
+test('humanizeError: maps the documented backend errors', () => {
+  assert.match(kip.humanizeError('Kip backend request failed (401): bad key').title, /rejected your key/)
+  assert.match(kip.humanizeError('Kip backend request failed (402): plan limit reached').title, /plan limit/)
+  assert.match(kip.humanizeError('request failed (429): rate limit').title, /rate-limiting/)
+  assert.match(kip.humanizeError('(503): no_route for (hatch, hatch:whiteboard)').title, /no route/i)
+  assert.equal(kip.humanizeError('something unrelated'), null)
+})

--- a/scripts/test/llm.test.js
+++ b/scripts/test/llm.test.js
@@ -294,6 +294,25 @@ test('callLLM: "other" provider works like any OpenAI-compatible endpoint once c
   })
 })
 
+test('callLLM: "kip" provider routes through the managed backend with routing headers', async () => {
+  await withEnv({ PROVIDER: 'kip', KIP_API_KEY: 'kip_env', KIP_BASE_URL: 'http://lan.test:8080' }, async () => {
+    const { impl, getLastCall } = fakeFetch({ model: 'claude-sonnet-4-6', choices: [{ message: { content: 'from kip' } }] })
+    const result = await callLLM({ system: 's', prompt: 'p', label: 'peck:answer' }, { fetchImpl: impl, vaultRoot: EMPTY_VAULT })
+    assert.equal(result.text, 'from kip')
+    assert.equal(getLastCall().url, 'http://lan.test:8080/v1/chat/completions')
+    assert.equal(getLastCall().init.headers.Authorization, 'Bearer kip_env')
+    assert.equal(getLastCall().init.headers['X-Kip-Workload'], 'peck:answer')
+    assert.equal(getLastCall().init.headers['X-Kip-Phase'], 'peck')
+    assert.equal(JSON.parse(getLastCall().init.body).model, 'auto')
+  })
+})
+
+test('callLLM: "kip" provider needs a key', async () => {
+  await withEnv({ PROVIDER: 'kip', KIP_API_KEY: undefined }, async () => {
+    await assert.rejects(() => callLLM({ system: 's', prompt: 'p' }, { vaultRoot: EMPTY_VAULT }), /KIP_API_KEY/)
+  })
+})
+
 test('testConnection', async (t) => {
   await t.test('reports success with the reply text on a good call', async () => {
     const { FakeAnthropic } = fakeAnthropicClient('OK')


### PR DESCRIPTION
The `kip` connector — closes the client side of the epic (**kip-app#62**). Also folds in **#60** (`KIP_API_KEY` / `KIP_BASE_URL`).

Per @JWE24-code: built **inside the client, AGPL-3.0**, not a separate npm package (the backend stays proprietary — see `kip-backend/KIP-BACKEND.md` §15–16).

## What

**`lib/kip-connector.js`** — a `ProviderSpec` that routes every call through the managed backend:

```
POST {baseUrl}/v1/chat/completions
Authorization: Bearer kip_…
X-Kip-Workload: <full call label>     X-Kip-Phase: <first ":"-segment>
body { model: "auto", max_tokens, messages: [system?, user], response_format? }
```

- fields: `apiKey` (required, `kip_…`) + `baseUrl` (default `https://api.kip-ai.be`, **overridable** for a self-hosted / LAN backend)
- `envDefaults`: `KIP_API_KEY` / `KIP_BASE_URL`
- json mode → `response_format`, retries prompt-and-strip **on a 400 only** (a 402/429/401 is real)
- non-2xx → `Error` with `.status` + the backend's `error.message`
- `testConnection` never throws; `humanizeError` maps 401 / 402 / 429 / 503-no_route

**Registered as a built-in** in `connectors.js` (`require('./kip-connector')`): always shipped, rides the app auto-update; the settings UI (kip-app#58) hides it from the dropdown until the user opts in. Its id can't be shadowed by a graph-local install.

## Tests

`scripts/test/kip-connector.test.js` (mocked `fetch`) — headers, `model:"auto"`, json mode + the 400-only retry, non-2xx error shape, `testConnection` both outcomes, `humanizeError`, phase derivation — plus a `callLLM` `PROVIDER=kip` integration test. **Full suite 203/203.**

## ⚠️ Phase-derivation note (the epic's open question)

`KIP-BACKEND.md`'s routing table lists phase **`whiteboard`** for the `hatch:whiteboard` workload, but the client sends phase **`hatch`** (first `:`-segment, as the issue specifies). The backend operator should either key that routing rule as `(hatch, hatch:whiteboard)` or move the workload under phase `hatch`. Every other label (`hatch:generate:entity` → `hatch`, `peck:answer` → `peck`, `groom:*`, `skill:*`) lines up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)