### PR TITLE
kip-connector: real transport errors + testConnection via /v1/usage

### DIFF
--- a/scripts/lib/kip-connector.js
+++ b/scripts/lib/kip-connector.js
@@ -19,6 +19,7 @@
 //      `usage` carries the token counts.
 //   errors: 401 bad key · 402 plan/budget · 429 rate limit · 5xx upstream,
 //           OpenAI-shaped { error: { message, type, code } }.
+//   testConnection() uses GET {baseUrl}/v1/usage — auth-only, not routed.
 
 const CONNECTOR_API = 1
 const DEFAULT_BASE_URL = 'https://api.kip-ai.be'
@@ -133,6 +134,31 @@ async function callBackend (resolved, call, ctx) {
   return { text: call.json ? stripCodeFences(raw) : String(raw).trim(), raw: data }
 }
 
+/** GET {baseUrl}/v1/usage — auth-only, not routed, not plan-checked. The
+ *  cheapest way to prove "key + connectivity work" for testConnection. */
+async function getUsage (resolved, ctx) {
+  const doFetch = (ctx && ctx.fetch) || fetch
+  const baseUrl = (resolved.baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '')
+  const url = `${baseUrl}/v1/usage`
+  let res
+  try {
+    res = await doFetch(url, {
+      headers: { Authorization: `Bearer ${resolved.apiKey}` },
+      signal: ctx && ctx.signal
+    })
+  } catch (err) {
+    throw networkError(url, err)
+  }
+  if (!res.ok) {
+    let detail
+    try { const j = await res.json(); detail = j && j.error && j.error.message } catch { /* non-JSON */ }
+    const err = new Error(`Kip backend request failed (${res.status})${detail ? `: ${detail}` : ''}`)
+    err.status = res.status
+    throw err
+  }
+  return res.json()
+}
+
 /** @type {import('./connectors').ProviderSpec} */
 module.exports = {
   kipConnectorApi: CONNECTOR_API,
@@ -150,13 +176,13 @@ module.exports = {
   },
 
   async testConnection (resolved, ctx) {
+    // GET /v1/usage, not a completion: it needs only a valid key + a
+    // reachable backend — no routing rule, no configured upstream, no tokens.
     try {
-      const { text } = await callBackend(
-        resolved,
-        { system: '', prompt: 'Reply with exactly: OK', json: false, maxTokens: 10, label: 'test:connection' },
-        ctx
-      )
-      return { success: true, reply: text }
+      const u = await getUsage(resolved, ctx)
+      const plan = u && u.plan ? `${u.plan} plan` : 'connected'
+      const cap = u && u.limits && u.limits.monthly_token_cap
+      return { success: true, reply: cap ? `${plan} · ${Math.round(cap / 1000)}k tokens/mo` : plan }
     } catch (err) {
       return { success: false, error: err.message || String(err) }
     }

--- a/scripts/lib/kip-connector.js
+++ b/scripts/lib/kip-connector.js
@@ -45,17 +45,42 @@ function buildMessages (system, prompt) {
   return messages
 }
 
+/** node/undici `fetch` reports every transport failure as a bare "fetch failed"
+ *  and buries the real reason in err.cause — surface it. */
+function networkError (url, err) {
+  const code = err && err.cause && err.cause.code
+  const hint = {
+    ECONNREFUSED: `Nothing is listening at ${url} — check the backend is running and the host/port are right.`,
+    ETIMEDOUT: `No response from ${url} — check the address, and that this machine can reach it (firewall / VPN / wrong network / a system proxy).`,
+    ENOTFOUND: `Can't resolve the host in ${url}.`,
+    EAI_AGAIN: `Can't resolve the host in ${url} (DNS).`,
+    ECONNRESET: `The connection to ${url} was reset.`,
+    CERT_HAS_EXPIRED: 'The backend\'s TLS certificate has expired.',
+    DEPTH_ZERO_SELF_SIGNED_CERT: 'The backend\'s TLS certificate isn\'t trusted — use http:// for a LAN backend, or install its certificate.'
+  }[code]
+  const e = new Error(hint || `Couldn't reach the Kip backend at ${url}${code ? ` (${code})` : ''}.`)
+  if (code) e.code = code
+  e.cause = err
+  return e
+}
+
 async function post (baseUrl, apiKey, body, headers, doFetch, signal) {
-  const res = await doFetch(`${baseUrl.replace(/\/+$/, '')}/v1/chat/completions`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
-      ...headers
-    },
-    body: JSON.stringify(body),
-    signal
-  })
+  const url = `${baseUrl.replace(/\/+$/, '')}/v1/chat/completions`
+  let res
+  try {
+    res = await doFetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+        ...headers
+      },
+      body: JSON.stringify(body),
+      signal
+    })
+  } catch (err) {
+    throw networkError(url, err)
+  }
   if (!res.ok) {
     let detail
     try {
@@ -148,12 +173,15 @@ module.exports = {
     if (/\(429\)|rate.?limit|too many requests/i.test(s)) {
       return { title: 'The Kip backend is rate-limiting you.', hint: 'Wait a moment and try again — or ask for a higher rate limit.' }
     }
-    if (/\(503\)|no_route|no route/i.test(s)) {
-      return { title: 'The Kip backend has no route for this call.', hint: 'The backend admin needs a routing rule for this workload — send them the error details.' }
+    if (/\(503\)|no_route|no route|provider_not_configured/i.test(s)) {
+      return { title: 'The Kip backend can\'t route this call yet.', hint: 'Its admin needs a routing rule pointing at a configured provider — send them the error details.' }
+    }
+    if (/nothing is listening|couldn't reach|no response from|ECONNREFUSED|ETIMEDOUT|can't resolve/i.test(s)) {
+      return { title: 'Can\'t reach the Kip backend.', hint: 'Check the Base URL in Settings → LLM, that the backend is running, and that this machine can reach it.' }
     }
     return null
   },
 
   // exported for tests
-  _internals: { phaseOf, DEFAULT_BASE_URL }
+  _internals: { phaseOf, networkError, DEFAULT_BASE_URL }
 }

--- a/scripts/test/kip-connector.test.js
+++ b/scripts/test/kip-connector.test.js
@@ -146,6 +146,21 @@ test('testConnection: surfaces the transport reason too', async () => {
   assert.doesNotMatch(r.error, /^fetch failed$/)
 })
 
+test('testConnection: hits GET /v1/usage (auth only), reports the plan', async () => {
+  let calledUrl, authHeader
+  const impl = async (url, init) => {
+    calledUrl = url
+    authHeader = init && init.headers && init.headers.Authorization
+    return { ok: true, status: 200, json: async () => ({ plan: 'pro', limits: { monthly_token_cap: 5000000 } }) }
+  }
+  const r = await kip.testConnection(RESOLVED, { fetch: impl })
+  assert.equal(calledUrl, 'http://lan.test:8080/v1/usage')
+  assert.equal(authHeader, 'Bearer kip_testkey')
+  assert.equal(r.success, true)
+  assert.match(r.reply, /pro plan/)
+  assert.match(r.reply, /5000k tokens/)
+})
+
 test('complete: raw carries the resolved model + usage for telemetry', async () => {
   const { impl } = fakeFetch(reply('x', { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 }))
   const { raw } = await kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10 }, { fetch: impl })
@@ -153,14 +168,12 @@ test('complete: raw carries the resolved model + usage for telemetry', async () 
   assert.equal(raw.usage.total_tokens, 15)
 })
 
-test('testConnection: { success:true, reply } on a good call, never throws on a bad one', async () => {
-  const ok = fakeFetch(reply('OK'))
-  assert.deepEqual(await kip.testConnection(RESOLVED, { fetch: ok.impl }), { success: true, reply: 'OK' })
-
-  const bad = fakeFetch({ error: { message: 'nope' } }, { ok: false, status: 401 })
-  const r = await kip.testConnection(RESOLVED, { fetch: bad.impl })
+test('testConnection: a bad key -> { success:false, error }, never throws', async () => {
+  const impl = async () => ({ ok: false, status: 401, json: async () => ({ error: { message: 'invalid api key' } }) })
+  const r = await kip.testConnection(RESOLVED, { fetch: impl })
   assert.equal(r.success, false)
-  assert.match(r.error, /401/)
+  assert.match(r.error, /\(401\)/)
+  assert.match(r.error, /invalid api key/)
 })
 
 test('humanizeError: maps the documented backend errors', () => {

--- a/scripts/test/kip-connector.test.js
+++ b/scripts/test/kip-connector.test.js
@@ -123,6 +123,29 @@ test('complete: non-2xx throws an Error with .status and the backend message', a
   )
 })
 
+test('complete: a transport failure becomes a specific message, not "fetch failed"', async () => {
+  const cases = [
+    ['ECONNREFUSED', /nothing is listening/i],
+    ['ETIMEDOUT', /no response|reach it/i],
+    ['ENOTFOUND', /can't resolve/i]
+  ]
+  for (const [code, re] of cases) {
+    const impl = async () => { const e = new TypeError('fetch failed'); e.cause = { code }; throw e }
+    await assert.rejects(
+      () => kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10 }, { fetch: impl }),
+      (err) => err.code === code && re.test(err.message) && !/^fetch failed$/.test(err.message)
+    )
+  }
+})
+
+test('testConnection: surfaces the transport reason too', async () => {
+  const impl = async () => { const e = new TypeError('fetch failed'); e.cause = { code: 'ECONNREFUSED' }; throw e }
+  const r = await kip.testConnection(RESOLVED, { fetch: impl })
+  assert.equal(r.success, false)
+  assert.match(r.error, /nothing is listening/i)
+  assert.doesNotMatch(r.error, /^fetch failed$/)
+})
+
 test('complete: raw carries the resolved model + usage for telemetry', async () => {
   const { impl } = fakeFetch(reply('x', { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 }))
   const { raw } = await kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10 }, { fetch: impl })
@@ -144,6 +167,8 @@ test('humanizeError: maps the documented backend errors', () => {
   assert.match(kip.humanizeError('Kip backend request failed (401): bad key').title, /rejected your key/)
   assert.match(kip.humanizeError('Kip backend request failed (402): plan limit reached').title, /plan limit/)
   assert.match(kip.humanizeError('request failed (429): rate limit').title, /rate-limiting/)
-  assert.match(kip.humanizeError('(503): no_route for (hatch, hatch:whiteboard)').title, /no route/i)
+  assert.match(kip.humanizeError('(503): no_route for (hatch, hatch:whiteboard)').title, /route this call/i)
+  assert.match(kip.humanizeError('Kip backend request failed (503): provider_not_configured').title, /route this call/i)
+  assert.match(kip.humanizeError("Nothing is listening at http://x/v1/chat/completions").title, /reach the Kip backend/i)
   assert.equal(kip.humanizeError('something unrelated'), null)
 })


### PR DESCRIPTION
Two fixes from testing the connector against the LAN backend.

**1. "fetch failed" → the real reason.** node/undici collapses every transport failure into `TypeError("fetch failed")` with the code buried in `err.cause`. The connector now says what to check — "Nothing is listening at …", "No response from … (firewall / VPN / wrong network / a system proxy)", "Can't resolve the host …", TLS-cert cases. `humanizeError` maps these + `provider_not_configured`.

**2. `testConnection` → `GET /v1/usage`.** The old test sent a completion with `X-Kip-Phase: test` — a phase with no routing rule, so "Test connection" would 503 against a *healthy* backend. `/v1/usage` is auth-only, not routed, not plan-checked: it proves key + connectivity and reports the plan + monthly cap. Nothing to configure on the backend for it to work.

206/206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)