### PR TITLE
kip-connector: staticModel "auto" (kill "no model configured")

### DIFF
--- a/scripts/lib/kip-connector.js
+++ b/scripts/lib/kip-connector.js
@@ -164,6 +164,10 @@ module.exports = {
   kipConnectorApi: CONNECTOR_API,
   id: 'kip',
   label: 'Kip (managed)',
+  // the backend picks the upstream model per workload — the client always
+  // sends model:"auto". Surfaced so describeProvider() doesn't print
+  // "(no model configured)" the way it does for a genuinely unset provider.
+  staticModel: 'auto',
   fields: [
     { key: 'apiKey', label: 'API key', type: 'password', required: true, placeholder: 'kip_…', help: 'From your Kip backend admin → Accounts → Keys.' },
     { key: 'baseUrl', label: 'Base URL', type: 'text', required: false, default: DEFAULT_BASE_URL, help: 'Leave as-is for the hosted service, or point it at a self-hosted Kip backend.' }

--- a/scripts/lib/llm.js
+++ b/scripts/lib/llm.js
@@ -162,8 +162,12 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label 
 
     const usage = extractUsage(result.raw)
     const reasoning = extractReasoning(result.raw)
+    // the connector may resolve the real model itself (the Kip backend routes
+    // "auto" to an upstream and returns which one) — prefer that for telemetry.
+    const realModel = (result.raw && typeof result.raw.model === 'string' && result.raw.model) || common.model
     telemetry.record({
       ...common,
+      model: realModel,
       ms: Date.now() - started,
       ok: true,
       systemChars: (system || '').length,


### PR DESCRIPTION
The Kip backend routes `model:"auto"` to an upstream per workload — the connector has no Model field. But `describeProvider()` printed **"Using provider: kip (no model configured)"**, and `handler/llm`'s error classifier maps `no model configured` → "provider isn't fully set up". `staticModel: "auto"` → "Using provider: kip (auto)". `callLLM` telemetry now records the real upstream model from the response. 206/206. 🤖