### PR TITLE
peck: don't crash on a stale meta.db row (missing .md file)

### DIFF
--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -43,11 +43,29 @@ function classifyPeckInput (input) {
   return (t.endsWith('?') || QUESTION_START_RE.test(t)) ? 'question' : 'statement'
 }
 
+/**
+ * Reads a candidate nest page. Returns null when its file is gone or
+ * unreadable — meta.db can point at a page whose .md was deleted, moved, or
+ * (on OneDrive/iCloud) not yet materialized. A stale index row must not
+ * crash the whole turn; callers filter the nulls. `rebuild-roost` cleans
+ * meta.db back up.
+ */
 function readPageBody (vaultRoot, candidate) {
   const filePath = path.join(vaultRoot, candidate.path)
-  const raw = fs.readFileSync(filePath, 'utf8')
+  let raw
+  try {
+    raw = fs.readFileSync(filePath, 'utf8')
+  } catch (err) {
+    console.error(`Warning: nest page ${candidate.path} is in the index but not on disk (${err.code || err.message}); skipping. Run rebuild-roost.`)
+    return null
+  }
   const { data, content } = matter(raw)
   return { slug: candidate.slug, path: candidate.path, type: data.type, content: content.trim() }
+}
+
+/** map candidates -> page bodies, dropping any whose file is missing. */
+function readPageBodies (vaultRoot, candidates) {
+  return candidates.map((c) => readPageBody(vaultRoot, c)).filter(Boolean)
 }
 
 /** True when the coop has at least one enabled skill — a question with no
@@ -193,7 +211,7 @@ async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_V
   if (candidates.length === 0 && !anySkills(vaultRoot)) {
     return { answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
   }
-  const pages = candidates.map((c) => readPageBody(vaultRoot, c))
+  const pages = readPageBodies(vaultRoot, candidates)
   return answerFromPages(question, pages, { fileToNest, vaultRoot })
 }
 
@@ -218,7 +236,7 @@ async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = f
   }
 
   const candidates = await retrieveCandidates(input, vaultRoot)
-  const pages = candidates.map((c) => readPageBody(vaultRoot, c))
+  const pages = readPageBodies(vaultRoot, candidates)
   const candidateSlugs = pages.map((p) => p.slug)
 
   if (classifyPeckInput(input) === 'statement') {

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -230,6 +230,27 @@ test('peckTurn — a statement is filed onto a matching page and logged as `told
   } finally { s.restore() }
 })
 
+test('peckTurn — a stale index row (file deleted) is skipped, not fatal', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+
+  writePage(root, 'concepts', 'sleep-hygiene', { type: 'concept', tags: ['health'], body: 'Consistent bedtime.' })
+  writePage(root, 'sources', 'orphan-doc', { type: 'source', body: 'A source that will vanish.' })
+  rebuildRoost(root)
+  // meta.db now has orphan-doc; delete its file behind the index's back
+  fs.rmSync(path.join(root, 'nest', 'sources', 'orphan-doc.md'))
+
+  const s = stubPeckFetch({ keyTerms: '{"terms": ["sleep", "source"]}', answer: 'Keep a consistent bedtime. [[sleep-hygiene]]' })
+  try {
+    const r = await peckTurn('what helps my sleep?', { vaultRoot: root })
+    assert.equal(r.intent, 'question')
+    assert.match(r.answer, /consistent bedtime/i)
+    assert.ok(!r.candidateSlugs.includes('orphan-doc'), 'the missing page is dropped from candidates')
+    assert.ok(r.candidateSlugs.includes('sleep-hygiene'))
+  } finally { s.restore() }
+})
+
 test('peckTurn — a statement with nothing new writes nothing and still logs `told []`', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))


### PR DESCRIPTION
**Field report (v0.3.3):** every Peck turn — question, "tell it something new", web-search-to-nest — died with

```
ENOENT: no such file or directory, open '…\New folder\nest\sources\6a91e1e6-….md'
  at readPageBody (peck.js:48)
  at peckTurn (peck.js:221)
```

`meta.db` had a row for a nest page whose `.md` was gone (deleted/moved, or a OneDrive file not materialized). `readPageBody` did a bare `fs.readFileSync`, so the ENOENT threw straight out of `peckTurn`'s `candidates.map(...)` and took the whole turn with it — nothing to do with the connector or the backend.

Now `readPageBody` catches it, warns ("… in the index but not on disk; run rebuild-roost"), and returns `null`; both call sites go through `readPageBodies()` which filters the nulls. `rebuild-roost` still cleans `meta.db`.

+1 test (`peckTurn — a stale index row (file deleted) is skipped, not fatal`). 207/207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)