### PR TITLE
Reasoning models without the JSON-mode retry tax; connector docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ OPENAI_MODEL=
 
 # --- deepseek (PROVIDER=deepseek) ---
 # DeepSeek's OpenAI-compatible endpoint (fixed base URL, not configurable).
+# deepseek-reasoner works too — Kip detects reasoning models (also OpenAI
+# o1/o3) and asks for JSON in the prompt instead of the response_format
+# parameter they reject, so there's no wasted round-trip. They're slower on
+# every call, though, so setting one as your only model taxes Hatch/Peck.
 DEEPSEEK_API_KEY=
 DEEPSEEK_MODEL=deepseek-chat
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to Kip. Format loosely follows
 The retrieval layer (this repo) and the desktop app
 ([kip-app](https://github.com/JWE24-code/kip-app)) are released together.
 
+## [0.3.5] — 2026-08-29
+
+### The retrieval layer (`scripts/`)
+
+- **Reasoning models without the JSON-mode retry tax** — `deepseek-reasoner`
+  and OpenAI `o1` / `o3` / `o4-mini` reject the `response_format` parameter
+  most Kip calls use. The OpenAI-compatible client now recognises them by
+  name and asks for JSON in the prompt from the start, instead of sending
+  `response_format`, taking a 400, and retrying — one upstream call per
+  step, not two. `gpt-4o` and similar names are not affected.
+
+### Docs
+
+- **Connectors + the managed backend are documented for users** —
+  `GETTING-STARTED.md` covers the "Kip (managed)" provider, the
+  **Add a connector** flow (`@kip-ai/*` `.tgz`, why the allowlist exists,
+  where installed connectors live), and a note on reasoning-model
+  trade-offs. `.env.example` already carried `KIP_API_KEY` / `KIP_BASE_URL`.
+
 ## [0.3.4] — 2026-08-29
 
 ### The retrieval layer (`scripts/`)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -323,6 +323,14 @@ into `callLLM()`. Trust boundary: a graph-local connector is `require`d
 into the process with `fetch`, so the allowlist is the gate. Tested in
 `scripts/test/connectors.test.js` + `untar.test.js`.
 
+`callOpenAICompatible` for `json:true` tries native `response_format:
+{type:"json_object"}` and falls back to prompt-and-strip on any error —
+except for a **reasoning model** (`isReasoningModel(model)` — name match on
+`deepseek-reasoner`, `o1`/`o3`/`o4-mini`, …), which skips straight to
+prompt-and-strip since it always rejects that parameter. One round-trip, not
+two (kip-app#68). The managed backend does the equivalent server-side for
+`model:"auto"` picks.
+
 **The `kip` connector** (`lib/kip-connector.js`) POSTs to
 `{baseUrl}/v1/chat/completions` with `Authorization: Bearer kip_…` and
 `X-Kip-Workload` (the full call label) / `X-Kip-Phase` (its first

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -117,9 +117,17 @@ they're not listed here.)
 - Never auto-fixes — every finding is a suggestion.
 
 ### Infrastructure
-- **Provider-swappable LLM** — Anthropic, OpenAI, DeepSeek, local/Ollama, or
-  any OpenAI-compatible endpoint. One config file
-  (`<graph>/.henhouse/llm.json`) or env vars.
+- **Provider-swappable LLM** — Anthropic, OpenAI, DeepSeek, local/Ollama,
+  any OpenAI-compatible endpoint, or a managed [Kip
+  backend](https://github.com/JWE24-code/kip-backend) (one `kip_` key, the
+  backend picks the model per task). One config file
+  (`<graph>/.henhouse/llm.json`) or env vars. Reasoning models
+  (`deepseek-reasoner`, `o1`/`o3`) are used without the JSON-mode retry
+  round-trip.
+- **Installable connectors** — an `@kip-ai/*` provider package can be added
+  from a `.tgz` or URL (Settings → LLM → Add a connector), extracted into
+  `<graph>/.henhouse/connectors/`; the name allowlist is the trust gate
+  since a connector runs in-process.
 - **`rebuild-roost`** — rebuild the whole SQLite index + generated catalog
   from the Markdown files; safe to run any time.
 - **`recent-clucks`** — tail the activity log.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -42,13 +42,43 @@ Kip needs an LLM to hatch sources and answer questions.
    - **OpenAI** — any OpenAI-compatible endpoint.
    - **DeepSeek** — DeepSeek's chat API.
    - **Local** — a model running on your machine via Ollama.
+   - **Other (OpenAI-compatible)** — any other endpoint that speaks the
+     OpenAI chat-completions format (Kimi/Moonshot, Qwen via DashScope, a
+     custom proxy).
+   - **Kip (managed)** — one `kip_` key routes every call through a managed
+     [Kip backend](https://github.com/JWE24-code/kip-backend), which picks
+     the model per task, enforces your plan, and meters usage. Hidden until
+     you pick **"Have a Kip backend key?"**; enter the key (and a **Base
+     URL** if you run your own backend). Invite-only for now.
 3. Enter your API key, model name, and base URL if needed.
 4. Click **Test connection** to verify.
 5. Click **Save**.
 
-The settings are written to `<coop>/.henhouse/llm.json`. That file is **plain text** and contains your key, so keep your coop folder private.
+The settings are written to `<coop>/.henhouse/llm.json`. That file is **plain text** and contains your key, so keep your coop folder private. Without a GUI you can set the same values as environment variables — see [`.env.example`](../.env.example).
 
-> **Privacy note:** Hosted providers (Anthropic, OpenAI, DeepSeek) receive the contents of your sources and questions. Choose **Local** if you want everything to stay on your machine.
+> **Privacy note:** Hosted providers (Anthropic, OpenAI, DeepSeek, a managed Kip backend) receive the contents of your sources and questions. Choose **Local** if you want everything to stay on your machine.
+
+### Reasoning models
+
+`deepseek-reasoner` and OpenAI's `o1` / `o3` / `o4-mini` are supported. Kip
+detects them by name and asks for JSON in the prompt instead of the
+`response_format` parameter they reject — so there's no wasted round-trip.
+They think before answering, so they're slower; if you set one as your only
+model, *every* Hatch and Peck step pays that cost. A managed Kip backend
+avoids this by routing only the workloads that benefit (the deep-groom
+coherence and contradiction passes) to a reasoning model.
+
+### Add a connector
+
+**Settings → LLM → Add a connector** installs an extra provider from an npm
+package (`.tgz` file or URL). Only packages named `@kip-ai/*` are accepted:
+a connector is JavaScript that runs **in Kip's own process**, with your
+privileges, so the name allowlist is the trust gate. Installed connectors
+live in `<coop>/.henhouse/connectors/<name>/`, are listed in
+`<coop>/.henhouse/connectors.json`, and can be removed from the same screen.
+A connector you install can override one of the same name that ships with
+Kip, but never a built-in provider (`anthropic`, `openai`, `deepseek`,
+`local`, `other`, `kip`).
 
 ---
 

--- a/scripts/lib/connectors.js
+++ b/scripts/lib/connectors.js
@@ -46,6 +46,17 @@ const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6'
 const JSON_MODE_INSTRUCTION =
   'Respond with ONLY valid JSON and no other text — no markdown code fences, no explanation.'
 
+// Reasoning models (DeepSeek `deepseek-reasoner`, OpenAI `o1`/`o3`/`o4-mini`,
+// …) reject `response_format` and `temperature`. For a json:true call we'd
+// otherwise send `response_format`, eat a 400, and retry prompt-and-strip —
+// two round-trips every call. Detect them by name and go straight to
+// prompt-and-strip. `gpt-4o` and friends don't match (the `o` isn't on a
+// separator). See kip-app#68.
+const REASONING_MODEL_RE = /(?:^|[-/:_])(?:o[1-9](?:-mini|-preview|-pro)?|[a-z]*reasoner|[a-z]*reasoning|[a-z]*thinking)(?:$|[-/:_])/i
+function isReasoningModel (model) {
+  return typeof model === 'string' && REASONING_MODEL_RE.test(model)
+}
+
 // ---------------------------------------------------------------------------
 // Low-level provider calls — each built-in spec's complete() is a thin
 // wrapper over one of these. Moved verbatim from llm.js.
@@ -112,7 +123,10 @@ async function postChatCompletion (baseUrl, apiKey, body, doFetch) {
  *
  * For json:true, tries native response_format: {type: "json_object"} first;
  * if the provider/model errors on that parameter, retries once without it,
- * using the same prompt-and-strip approach as the Anthropic path.
+ * using the same prompt-and-strip approach as the Anthropic path. A known
+ * reasoning model (deepseek-reasoner, o1/o3, …) skips the native attempt
+ * entirely — it always rejects response_format — so json:true costs one
+ * round-trip, not two.
  */
 async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, json, maxTokens }, fetchImpl) {
   const doFetch = fetchImpl || fetch
@@ -124,8 +138,25 @@ async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, j
     return messages
   }
 
+  const promptStrip = () => {
+    const jsonSystem = system ? `${system}\n\n${JSON_MODE_INSTRUCTION}` : JSON_MODE_INSTRUCTION
+    return postChatCompletion(baseUrl, apiKey, {
+      model,
+      max_tokens: maxTokens,
+      messages: buildMessages(jsonSystem)
+    }, doFetch)
+  }
+
   let data
-  if (json) {
+  if (!json) {
+    data = await postChatCompletion(baseUrl, apiKey, {
+      model,
+      max_tokens: maxTokens,
+      messages: buildMessages(system)
+    }, doFetch)
+  } else if (isReasoningModel(model)) {
+    data = await promptStrip()
+  } else {
     try {
       data = await postChatCompletion(baseUrl, apiKey, {
         model,
@@ -134,19 +165,8 @@ async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, j
         response_format: { type: 'json_object' }
       }, doFetch)
     } catch {
-      const jsonSystem = system ? `${system}\n\n${JSON_MODE_INSTRUCTION}` : JSON_MODE_INSTRUCTION
-      data = await postChatCompletion(baseUrl, apiKey, {
-        model,
-        max_tokens: maxTokens,
-        messages: buildMessages(jsonSystem)
-      }, doFetch)
+      data = await promptStrip()
     }
-  } else {
-    data = await postChatCompletion(baseUrl, apiKey, {
-      model,
-      max_tokens: maxTokens,
-      messages: buildMessages(system)
-    }, doFetch)
   }
 
   const rawText = (data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content) || ''
@@ -560,6 +580,7 @@ module.exports = {
   validateSpec,
   resolveConfig,
   missingRequiredField,
+  isReasoningModel,
   isAllowlisted,
   readConnectorsConfig,
   installConnectorFromTarball,

--- a/scripts/test/connectors.test.js
+++ b/scripts/test/connectors.test.js
@@ -11,6 +11,7 @@ const {
   validateSpec,
   resolveConfig,
   missingRequiredField,
+  isReasoningModel,
   isAllowlisted,
   readConnectorsConfig,
   installConnectorFromTarball,
@@ -116,6 +117,15 @@ test('loadConnectors: built-in readiness matches its resolved config', () => {
   assert.equal(reg.get('other').isReady({ baseUrl: 'u', model: 'm' }), true)
   assert.equal(reg.get('kip').isReady({}), false, 'the managed connector needs a kip_ key')
   assert.equal(reg.get('kip').isReady({ apiKey: 'kip_x' }), true)
+})
+
+test('isReasoningModel: matches reasoning models, not lookalikes', () => {
+  for (const m of ['deepseek-reasoner', 'o1', 'o1-mini', 'o1-preview', 'o3', 'o3-mini', 'o4-mini', 'openai/o3-mini', 'some-reasoning-model']) {
+    assert.equal(isReasoningModel(m), true, `${m} is a reasoning model`)
+  }
+  for (const m of ['deepseek-chat', 'gpt-4o', 'gpt-4o-mini', 'claude-sonnet-4-6', 'llama3.1', '', undefined, null]) {
+    assert.equal(isReasoningModel(m), false, `${m} is not a reasoning model`)
+  }
 })
 
 // ---------------------------------------------------------------------------

--- a/scripts/test/llm.test.js
+++ b/scripts/test/llm.test.js
@@ -160,6 +160,22 @@ test('callLLM: openai-compatible falls back to prompt-and-strip when response_fo
   })
 })
 
+test('callLLM: json:true on a reasoning model skips response_format (one round-trip)', async () => {
+  await withEnv({ PROVIDER: 'deepseek', DEEPSEEK_API_KEY: 'k', DEEPSEEK_MODEL: 'deepseek-reasoner' }, async () => {
+    let callCount = 0
+    const impl = async (_url, init) => {
+      callCount++
+      const body = JSON.parse(init.body)
+      assert.equal(body.response_format, undefined, 'must not send response_format to a reasoning model')
+      assert.ok(body.messages[0].content.includes('ONLY valid JSON'), 'asks for JSON via the prompt instead')
+      return { ok: true, status: 200, json: async () => ({ choices: [{ message: { content: '{"ok":true}' } }] }) }
+    }
+    const result = await callLLM({ system: 'sys', prompt: 'hi', json: true }, { fetchImpl: impl, vaultRoot: EMPTY_VAULT })
+    assert.equal(callCount, 1, 'no 400-and-retry')
+    assert.equal(result.text, '{"ok":true}')
+  })
+})
+
 test('callLLM: missing a required env var throws a clear error', async () => {
   await withEnv({ PROVIDER: 'openai', OPENAI_API_KEY: undefined, OPENAI_MODEL: undefined }, async () => {
     await assert.rejects(() => callLLM({ system: 's', prompt: 'p' }, { vaultRoot: EMPTY_VAULT }), /OPENAI_API_KEY/)


### PR DESCRIPTION
Part of the connector epic (kip-app#62) follow-ups. Ships with **v0.3.5**.

## #68 — reasoning models (direct-provider half)

`deepseek-reasoner` and OpenAI `o1` / `o3` / `o4-mini` reject the
`response_format` parameter most Kip calls use for forced JSON. Before this,
a `json:true` call to one of them sent `response_format`, got a 400, and
retried prompt-and-strip — two round-trips every call.

`callOpenAICompatible` now recognises reasoning models by name
(`isReasoningModel`, exported + tested) and goes straight to prompt-and-strip.
`gpt-4o` / `gpt-4o-mini` / `claude-sonnet-4-6` etc. do **not** match.

Backend-side work (the managed `kip` connector sends `model:"auto"`, so the
backend adapter must do the equivalent when it picks a reasoner) stays on
#68.

## #60 — connector docs

- `GETTING-STARTED.md` §2: the **Kip (managed)** provider, the **Add a
  connector** flow (`@kip-ai/*` `.tgz`/URL, why the allowlist is the trust
  gate, where installed connectors live), a **Reasoning models** note.
- `FEATURES.md` / `DEVELOPMENT.md`: managed connector + installable
  connectors + `isReasoningModel`.
- `.env.example`: already had `KIP_API_KEY` / `KIP_BASE_URL`; added a
  reasoning-model note to the deepseek section.

## Tests

`scripts/test/connectors.test.js` — `isReasoningModel` matrix.
`scripts/test/llm.test.js` — a `json:true` call to `deepseek-reasoner` makes
one fetch, no `response_format`. Full suite: 210/210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)