### PR TITLE
Learn at runtime which models reject response_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,19 @@ All notable changes to Kip. Format loosely follows
 The retrieval layer (this repo) and the desktop app
 ([kip-app](https://github.com/JWE24-code/kip-app)) are released together.
 
-## [0.3.5] — 2026-08-29
+## [0.3.5] — 2026-08-30
 
 ### The retrieval layer (`scripts/`)
 
-- **Reasoning models without the JSON-mode retry tax** — `deepseek-reasoner`
-  and OpenAI `o1` / `o3` / `o4-mini` reject the `response_format` parameter
-  most Kip calls use. The OpenAI-compatible client now recognises them by
-  name and asks for JSON in the prompt from the start, instead of sending
-  `response_format`, taking a 400, and retrying — one upstream call per
-  step, not two. `gpt-4o` and similar names are not affected.
+- **Reasoning models without the JSON-mode retry tax** — `deepseek-reasoner`,
+  `deepseek-r1`, OpenAI `o1` / `o3` / `o4-mini`, `qwq`, `magistral` and the
+  like reject the `response_format` parameter most Kip calls use, so a
+  `json:true` call used to send it, take a 400, and retry — two upstream
+  round-trips every time. The OpenAI-compatible client now recognises the
+  common ones by name and asks for JSON in the prompt from the start; **and
+  any other model that 400s on `response_format` is remembered for the rest
+  of the run**, so a model the name list misses pays the retry once, never
+  again. `gpt-4o` and similar names are unaffected.
 
 ### Docs
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -324,12 +324,16 @@ into the process with `fetch`, so the allowlist is the gate. Tested in
 `scripts/test/connectors.test.js` + `untar.test.js`.
 
 `callOpenAICompatible` for `json:true` tries native `response_format:
-{type:"json_object"}` and falls back to prompt-and-strip on any error —
-except for a **reasoning model** (`isReasoningModel(model)` — name match on
-`deepseek-reasoner`, `o1`/`o3`/`o4-mini`, …), which skips straight to
-prompt-and-strip since it always rejects that parameter. One round-trip, not
-two (kip-app#68). The managed backend does the equivalent server-side for
-`model:"auto"` picks.
+{type:"json_object"}` and falls back to prompt-and-strip on any error.
+Reasoning models reject `response_format`, so two things spare them the
+wasted round-trip: `isReasoningModel(model)` (name match — `deepseek-reasoner`,
+`r1`, `o1`/`o3`/`o4-mini`, `qwq`, `magistral`, `*reasoning`/`*thinking`;
+`gpt-4o` doesn't match) skips the native attempt from the first call, and a
+process-lived `Set` (`learnedNoResponseFormat`, keyed `baseUrl::model`)
+records any model that returns a **400** on `response_format` so every later
+call in the run skips it too. Net: a name-list miss costs one extra
+round-trip once, never more (kip-app#68). The managed backend does the
+equivalent server-side for `model:"auto"` picks.
 
 **The `kip` connector** (`lib/kip-connector.js`) POSTs to
 `{baseUrl}/v1/chat/completions` with `Authorization: Bearer kip_…` and

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -60,13 +60,15 @@ The settings are written to `<coop>/.henhouse/llm.json`. That file is **plain te
 
 ### Reasoning models
 
-`deepseek-reasoner` and OpenAI's `o1` / `o3` / `o4-mini` are supported. Kip
-detects them by name and asks for JSON in the prompt instead of the
-`response_format` parameter they reject — so there's no wasted round-trip.
-They think before answering, so they're slower; if you set one as your only
-model, *every* Hatch and Peck step pays that cost. A managed Kip backend
-avoids this by routing only the workloads that benefit (the deep-groom
-coherence and contradiction passes) to a reasoning model.
+`deepseek-reasoner`, `deepseek-r1`, OpenAI's `o1` / `o3` / `o4-mini` and
+similar reasoning models are supported. They reject the forced-JSON
+parameter Kip normally uses; Kip recognises the common ones by name and asks
+for JSON in the prompt instead, and it also learns any other model that
+rejects the parameter after trying it once — so there's no repeated wasted
+round-trip. They think before answering, so they're slower; if you set one
+as your only model, *every* Hatch and Peck step pays that cost. A managed
+Kip backend avoids this by routing only the workloads that benefit (the
+deep-groom coherence and contradiction passes) to a reasoning model.
 
 ### Add a connector
 

--- a/scripts/lib/connectors.js
+++ b/scripts/lib/connectors.js
@@ -46,16 +46,28 @@ const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6'
 const JSON_MODE_INSTRUCTION =
   'Respond with ONLY valid JSON and no other text — no markdown code fences, no explanation.'
 
-// Reasoning models (DeepSeek `deepseek-reasoner`, OpenAI `o1`/`o3`/`o4-mini`,
-// …) reject `response_format` and `temperature`. For a json:true call we'd
-// otherwise send `response_format`, eat a 400, and retry prompt-and-strip —
-// two round-trips every call. Detect them by name and go straight to
+// Reasoning models (DeepSeek `deepseek-reasoner` / `r1`, OpenAI `o1`/`o3`/
+// `o4-mini`, Qwen `qwq`, Mistral `magistral`, …) reject `response_format`
+// and `temperature`. For a json:true call we'd otherwise send
+// `response_format`, eat a 400, and retry prompt-and-strip — two round-trips
+// every call. Recognise the common ones by name and go straight to
 // prompt-and-strip. `gpt-4o` and friends don't match (the `o` isn't on a
 // separator). See kip-app#68.
-const REASONING_MODEL_RE = /(?:^|[-/:_])(?:o[1-9](?:-mini|-preview|-pro)?|[a-z]*reasoner|[a-z]*reasoning|[a-z]*thinking)(?:$|[-/:_])/i
+//
+// The name list can't be exhaustive, so it's only a fast path: any model
+// that actually 400s on `response_format` is remembered for the rest of the
+// process (`learnedNoResponseFormat`) and skips the doomed attempt on every
+// later call — so a miss here costs one wasted round-trip once, never more.
+const REASONING_MODEL_RE = /(?:^|[-/:_])(?:o[1-9](?:-mini|-preview|-pro)?|r1|qwq|magistral|[a-z]*reasoner|[a-z]*reasoning|[a-z]*thinking)(?:$|[-/:_])/i
 function isReasoningModel (model) {
   return typeof model === 'string' && REASONING_MODEL_RE.test(model)
 }
+
+// `${baseUrl}::${model}` seen to reject response_format with a 400 in this
+// process. Module-level so it's shared across every call in a run (Hatch and
+// deep-Groom make many). Cleared only by process exit.
+const learnedNoResponseFormat = new Set()
+const jsonModeKey = (baseUrl, model) => `${baseUrl || ''}::${model || ''}`
 
 // ---------------------------------------------------------------------------
 // Low-level provider calls — each built-in spec's complete() is a thin
@@ -122,11 +134,12 @@ async function postChatCompletion (baseUrl, apiKey, body, doFetch) {
  * baseUrl/apiKey/model differ between them.
  *
  * For json:true, tries native response_format: {type: "json_object"} first;
- * if the provider/model errors on that parameter, retries once without it,
- * using the same prompt-and-strip approach as the Anthropic path. A known
- * reasoning model (deepseek-reasoner, o1/o3, …) skips the native attempt
- * entirely — it always rejects response_format — so json:true costs one
- * round-trip, not two.
+ * if the provider/model 400s on that parameter, retries once without it
+ * (prompt-and-strip, same as the Anthropic path) AND remembers the model so
+ * later calls skip straight there. A model recognised as a reasoning model
+ * by name (deepseek-reasoner, o1/o3, …) skips the native attempt from the
+ * first call. Either way json:true costs one round-trip, not two, on every
+ * call after (at most) one.
  */
 async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, json, maxTokens }, fetchImpl) {
   const doFetch = fetchImpl || fetch
@@ -147,6 +160,9 @@ async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, j
     }, doFetch)
   }
 
+  const skipNativeJson =
+    isReasoningModel(model) || learnedNoResponseFormat.has(jsonModeKey(baseUrl, model))
+
   let data
   if (!json) {
     data = await postChatCompletion(baseUrl, apiKey, {
@@ -154,7 +170,7 @@ async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, j
       max_tokens: maxTokens,
       messages: buildMessages(system)
     }, doFetch)
-  } else if (isReasoningModel(model)) {
+  } else if (skipNativeJson) {
     data = await promptStrip()
   } else {
     try {
@@ -164,7 +180,11 @@ async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, j
         messages: buildMessages(system),
         response_format: { type: 'json_object' }
       }, doFetch)
-    } catch {
+    } catch (err) {
+      // Only a 400 means "this model won't take response_format" — a 401 /
+      // 429 / 5xx / network blip shouldn't teach us anything (but still gets
+      // one prompt-and-strip retry, as before).
+      if (err && err.status === 400) learnedNoResponseFormat.add(jsonModeKey(baseUrl, model))
       data = await promptStrip()
     }
   }
@@ -581,6 +601,7 @@ module.exports = {
   resolveConfig,
   missingRequiredField,
   isReasoningModel,
+  _clearLearnedJsonMode: () => learnedNoResponseFormat.clear(),
   isAllowlisted,
   readConnectorsConfig,
   installConnectorFromTarball,

--- a/scripts/test/connectors.test.js
+++ b/scripts/test/connectors.test.js
@@ -120,10 +120,14 @@ test('loadConnectors: built-in readiness matches its resolved config', () => {
 })
 
 test('isReasoningModel: matches reasoning models, not lookalikes', () => {
-  for (const m of ['deepseek-reasoner', 'o1', 'o1-mini', 'o1-preview', 'o3', 'o3-mini', 'o4-mini', 'openai/o3-mini', 'some-reasoning-model']) {
+  for (const m of [
+    'deepseek-reasoner', 'deepseek-r1', 'deepseek-r1-distill-qwen-7b',
+    'o1', 'o1-mini', 'o1-preview', 'o3', 'o3-mini', 'o4-mini', 'openai/o3-mini',
+    'qwq-32b', 'magistral-small-2506', 'some-reasoning-model', 'gemini-2.5-flash-thinking'
+  ]) {
     assert.equal(isReasoningModel(m), true, `${m} is a reasoning model`)
   }
-  for (const m of ['deepseek-chat', 'gpt-4o', 'gpt-4o-mini', 'claude-sonnet-4-6', 'llama3.1', '', undefined, null]) {
+  for (const m of ['deepseek-chat', 'gpt-4o', 'gpt-4o-mini', 'claude-sonnet-4-6', 'llama3.1', 'mistral-7b', '', undefined, null]) {
     assert.equal(isReasoningModel(m), false, `${m} is not a reasoning model`)
   }
 })

--- a/scripts/test/llm.test.js
+++ b/scripts/test/llm.test.js
@@ -5,6 +5,7 @@ const os = require('node:os')
 const path = require('node:path')
 
 const { callLLM, loadLLMConfig, saveLLMConfig, testConnection } = require('../lib/llm')
+const { _clearLearnedJsonMode } = require('../lib/connectors')
 const telemetry = require('../lib/telemetry')
 
 function makeTempVault () {
@@ -158,6 +159,51 @@ test('callLLM: openai-compatible falls back to prompt-and-strip when response_fo
     assert.equal(callCount, 2)
     assert.equal(result.text, '{"ok":true}')
   })
+})
+
+test('callLLM: after one 400 on response_format, later calls to that model skip it', async () => {
+  _clearLearnedJsonMode()
+  await withEnv({ PROVIDER: 'other', OTHER_BASE_URL: 'https://example.test/v1', OTHER_API_KEY: 'k', OTHER_MODEL: 'mystery-thinker-9000' }, async () => {
+    let withRF = 0
+    let withoutRF = 0
+    const impl = async (_url, init) => {
+      const body = JSON.parse(init.body)
+      if (body.response_format) {
+        withRF++
+        return { ok: false, status: 400, text: async () => 'response_format not supported', json: async () => ({}) }
+      }
+      withoutRF++
+      return { ok: true, status: 200, json: async () => ({ choices: [{ message: { content: '{"ok":true}' } }] }) }
+    }
+    const opts = { fetchImpl: impl, vaultRoot: EMPTY_VAULT }
+    await callLLM({ system: 's', prompt: 'p', json: true }, opts) // learns: 400 then retry
+    await callLLM({ system: 's', prompt: 'p', json: true }, opts) // straight to prompt-strip
+    await callLLM({ system: 's', prompt: 'p', json: true }, opts)
+    assert.equal(withRF, 1, 'response_format attempted exactly once, ever')
+    assert.equal(withoutRF, 3, 'every call still returns via prompt-and-strip')
+  })
+  _clearLearnedJsonMode()
+})
+
+test('callLLM: a non-400 error does not poison the skip cache', async () => {
+  _clearLearnedJsonMode()
+  await withEnv({ PROVIDER: 'other', OTHER_BASE_URL: 'https://example.test/v1', OTHER_API_KEY: 'k', OTHER_MODEL: 'gpt-4o-ish' }, async () => {
+    let withRF = 0
+    const impl = async (_url, init) => {
+      const body = JSON.parse(init.body)
+      if (body.response_format) {
+        withRF++
+        if (withRF === 1) return { ok: false, status: 503, text: async () => 'upstream busy', json: async () => ({}) }
+        return { ok: true, status: 200, json: async () => ({ choices: [{ message: { content: '{"ok":true}' } }] }) }
+      }
+      return { ok: true, status: 200, json: async () => ({ choices: [{ message: { content: '{"fallback":true}' } }] }) }
+    }
+    const opts = { fetchImpl: impl, vaultRoot: EMPTY_VAULT }
+    await callLLM({ system: 's', prompt: 'p', json: true }, opts) // 503 -> one prompt-strip retry, learns nothing
+    await callLLM({ system: 's', prompt: 'p', json: true }, opts) // tries response_format again
+    assert.equal(withRF, 2, 'still tries the native path on the next call after a 503')
+  })
+  _clearLearnedJsonMode()
 })
 
 test('callLLM: json:true on a reasoning model skips response_format (one round-trip)', async () => {


### PR DESCRIPTION
Follow-up to #17. Makes the reasoning-model handling generic instead of
depending on a name list being complete.

## Change

`callOpenAICompatible` keeps a process-lived `Set`
(`learnedNoResponseFormat`, keyed `baseUrl::model`). When a `json:true` call
gets a **400** on `response_format`, the model is recorded, and every later
call in the run skips straight to prompt-and-strip for it.

- `isReasoningModel` (name match) is now just a fast path for the first call
  to a known model. Also broadened: `deepseek-r1`, `qwq`, `magistral`.
- Non-400 errors (401 / 429 / 5xx / network) still get the one prompt-strip
  retry but **don't** poison the cache.
- Net: a model the name list misses pays the double round-trip once, never
  again. Correctness never depends on the list.

`_clearLearnedJsonMode()` exported for test isolation.

## Tests

`scripts/test/llm.test.js`:
- after one 400, the next calls to that model make one fetch, no `response_format`
- a 503 on `response_format` does **not** stop the next call trying it again

`scripts/test/connectors.test.js` — `isReasoningModel` matrix + `r1`/`qwq`/`magistral`.
Full suite 211/211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)