### PR TITLE
Preference signals: callId plumbing + the enabled gate

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -76,6 +76,8 @@ scripts/
 │   │                # (fields + complete()); built-ins + bundled/graph-local
 │   │                # connectors (install from a .tgz, @kip-ai/* allowlist)
 │   ├── kip-connector.js # the managed-backend "kip" connector (AGPL, built-in)
+│   ├── preference-signals.js # the "is the kip connector active" gate — every
+│   │                # preference-signal surface (kip-app#73) checks it
 │   ├── untar.js    # zero-dep npm-tarball (.tgz) extractor for connector install
 │   ├── telemetry.js # per-run LLM-call timing/token recorder every callLLM()
 │   │                # feeds; content-free summary() + opt-in full-text trace
@@ -340,8 +342,21 @@ equivalent server-side for `model:"auto"` picks.
 `X-Kip-Workload` (the full call label) / `X-Kip-Phase` (its first
 `:`-segment) routing headers; body is `{ model: "auto", max_tokens,
 messages }`. `baseUrl` defaults to `https://api.kip-ai.be`, overridable to
-a self-hosted backend. Contract: `JWE24-code/kip-backend` → `KIP-BACKEND.md`.
+a self-hosted backend. It reads the `X-Kip-Call-Id` response header and
+returns it as `callId` on `{ text, raw, callId }` — `callLLM` passes that
+through and records it in telemetry; every other connector returns
+`callId: null`. Contract: `JWE24-code/kip-backend` → `KIP-BACKEND.md`.
 Tested against a mocked `fetch` in `scripts/test/kip-connector.test.js`.
+
+**Preference signals** (`lib/preference-signals.js`, epic kip-app#73) —
+content-free feedback (behaviour, micro-ratings, blind arena) that tunes
+the managed router. `preferenceSignalsEnabled(vaultRoot)` is the one gate:
+true only when the active provider is `kip`. `preferenceSignalsTarget()`
+hands back its resolved `{ baseUrl, apiKey }` (or null) for the
+`/v1/feedback` and `/v1/arena/*` POSTs. The renderer reaches this through
+an IPC shim. Everything downstream — block marking, the rating widget, the
+behaviour watcher, the arena UI, the batching poster — is gated on it, so
+a direct Anthropic/OpenAI/DeepSeek/local provider sees none of it.
 
 #### `groom.js` — coop health checks
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "peck": "node scripts/peck.js",
     "groom": "node scripts/groom.js",
     "hatch": "node scripts/hatch.js",
-    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js"
+    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/preference-signals.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.70.0",

--- a/scripts/lib/kip-connector.js
+++ b/scripts/lib/kip-connector.js
@@ -93,10 +93,13 @@ async function post (baseUrl, apiKey, body, headers, doFetch, signal) {
     err.status = res.status
     throw err
   }
-  return res.json()
+  // The backend tags every completion with a call id; every later preference
+  // signal (rating / behaviour / arena verdict) references it. See kip-app#73.
+  const callId = (res.headers && typeof res.headers.get === 'function' && res.headers.get('x-kip-call-id')) || null
+  return { data: await res.json(), callId }
 }
 
-/** Shared by complete() and testConnection(): one call, returns { text, raw }. */
+/** The connector's complete(): one backend call, returns { text, raw, callId }. */
 async function callBackend (resolved, call, ctx) {
   const doFetch = (ctx && ctx.fetch) || fetch
   const signal = ctx && ctx.signal
@@ -115,23 +118,23 @@ async function callBackend (resolved, call, ctx) {
     messages: buildMessages(call.system, call.prompt)
   }
 
-  let data
+  let data, callId
   if (call.json) {
     try {
-      data = await post(baseUrl, resolved.apiKey, { ...base, response_format: { type: 'json_object' } }, routingHeaders, doFetch, signal)
+      ({ data, callId } = await post(baseUrl, resolved.apiKey, { ...base, response_format: { type: 'json_object' } }, routingHeaders, doFetch, signal))
     } catch (err) {
       // a routing/plan/auth error is real — only retry a plain 400 (upstream
       // rejected response_format), matching the OpenAI-compatible path.
       if (err.status !== 400) throw err
       const sys = call.system ? `${call.system}\n\n${JSON_MODE_INSTRUCTION}` : JSON_MODE_INSTRUCTION
-      data = await post(baseUrl, resolved.apiKey, { ...base, messages: buildMessages(sys, call.prompt) }, routingHeaders, doFetch, signal)
+      ;({ data, callId } = await post(baseUrl, resolved.apiKey, { ...base, messages: buildMessages(sys, call.prompt) }, routingHeaders, doFetch, signal))
     }
   } else {
-    data = await post(baseUrl, resolved.apiKey, base, routingHeaders, doFetch, signal)
+    ({ data, callId } = await post(baseUrl, resolved.apiKey, base, routingHeaders, doFetch, signal))
   }
 
   const raw = (data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content) || ''
-  return { text: call.json ? stripCodeFences(raw) : String(raw).trim(), raw: data }
+  return { text: call.json ? stripCodeFences(raw) : String(raw).trim(), raw: data, callId: callId || null }
 }
 
 /** GET {baseUrl}/v1/usage — auth-only, not routed, not plan-checked. The

--- a/scripts/lib/llm.js
+++ b/scripts/lib/llm.js
@@ -126,7 +126,9 @@ function assertConfigured (spec, resolved) {
 /**
  * The one entry point every caller uses. Routes to the connector named by
  * coop/.henhouse/llm.json / the PROVIDER env var (default "anthropic");
- * always resolves to the same shape: { text, raw }.
+ * always resolves to the same shape: { text, raw, callId }. `callId` is the
+ * managed backend's per-call id — set only by the kip connector, null for
+ * every other provider — and is what preference signals reference (kip-app#73).
  *
  * `overrides` (optional, second arg) is for tests only — real callers never
  * pass it: { AnthropicClient } to replace the Anthropic SDK class,
@@ -159,6 +161,7 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label 
   }
   try {
     const result = await spec.complete(resolved, call, ctx)
+    const callId = (result && result.callId) || null
 
     const usage = extractUsage(result.raw)
     const reasoning = extractReasoning(result.raw)
@@ -168,6 +171,7 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label 
     telemetry.record({
       ...common,
       model: realModel,
+      callId,
       ms: Date.now() - started,
       ok: true,
       systemChars: (system || '').length,
@@ -181,7 +185,7 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label 
       responseText: result.text,
       reasoning
     })
-    return result
+    return { ...result, callId }
   } catch (err) {
     telemetry.record({
       ...common,

--- a/scripts/lib/preference-signals.js
+++ b/scripts/lib/preference-signals.js
@@ -1,0 +1,51 @@
+// The one gate every preference-signal surface checks (epic kip-app#73).
+//
+// Preference signals — implicit behaviour, micro-ratings, blind arena — feed
+// three content-free numbers back to the managed Kip backend so its router
+// can tune perceived-quality-per-price. They are ENTIRELY INERT unless the
+// active LLM provider is the managed `kip` connector: a direct
+// Anthropic/OpenAI/DeepSeek/local provider has no managed router to inform
+// and no X-Kip-Call-Id to reference, so nothing collects, marks, or posts.
+//
+// The renderer has its own thin cljs shim over an IPC call into this module;
+// the retrieval-layer scripts call these directly.
+
+const { getProviderConfig } = require('./llm')
+
+const KIP_PROVIDER_ID = 'kip'
+const DEFAULT_BASE_URL = 'https://api.kip-ai.be'
+
+/**
+ * True only when the active provider is the managed Kip connector, resolved
+ * exactly as describeProvider() / the settings UI resolve it (llm.json's
+ * `provider`, else $PROVIDER, else "anthropic"). Never throws — a broken or
+ * absent config is simply "not enabled".
+ */
+function preferenceSignalsEnabled (vaultRoot) {
+  try {
+    return getProviderConfig(vaultRoot).provider === KIP_PROVIDER_ID
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The managed backend's resolved base URL + bearer key, for the feedback and
+ * arena POSTs to reuse rather than re-resolving — or null when preference
+ * signals aren't enabled (wrong provider, or no key). Callers treat null as
+ * "do nothing".
+ */
+function preferenceSignalsTarget (vaultRoot) {
+  try {
+    const cfg = getProviderConfig(vaultRoot)
+    if (cfg.provider !== KIP_PROVIDER_ID || !cfg.apiKey) return null
+    return {
+      baseUrl: (cfg.baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, ''),
+      apiKey: cfg.apiKey
+    }
+  } catch {
+    return null
+  }
+}
+
+module.exports = { KIP_PROVIDER_ID, preferenceSignalsEnabled, preferenceSignalsTarget }

--- a/scripts/test/kip-connector.test.js
+++ b/scripts/test/kip-connector.test.js
@@ -6,14 +6,16 @@ const { validateSpec } = require('../lib/connectors')
 
 const RESOLVED = { apiKey: 'kip_testkey', baseUrl: 'http://lan.test:8080' }
 
-/** A fake fetch that records the last call and returns `body` (200 unless overridden). */
-function fakeFetch (body, { ok = true, status = 200 } = {}) {
+/** A fake fetch that records the last call and returns `body` (200 unless overridden).
+ *  `resHeaders` populates the response's Headers (e.g. { 'x-kip-call-id': '…' }). */
+function fakeFetch (body, { ok = true, status = 200, resHeaders = {} } = {}) {
   let last = null
   const impl = async (url, init) => {
     last = { url, init, headers: init.headers, body: JSON.parse(init.body) }
     return {
       ok,
       status,
+      headers: new Headers(resHeaders),
       json: async () => body,
       text: async () => (typeof body === 'string' ? body : JSON.stringify(body))
     }
@@ -54,6 +56,7 @@ test('complete: sends auth + routing headers + model:"auto"', async () => {
 
   assert.equal(res.text, 'hi from kip')
   assert.ok(res.raw)
+  assert.equal(res.callId, null, 'no X-Kip-Call-Id header -> null')
   assert.equal(last().url, 'http://lan.test:8080/v1/chat/completions')
   assert.equal(last().headers.Authorization, 'Bearer kip_testkey')
   assert.equal(last().headers['X-Kip-Workload'], 'hatch:generate:entity')
@@ -64,6 +67,25 @@ test('complete: sends auth + routing headers + model:"auto"', async () => {
     { role: 'system', content: 'sys' },
     { role: 'user', content: 'q' }
   ])
+})
+
+test('complete: returns the X-Kip-Call-Id header as callId', async () => {
+  const { impl } = fakeFetch(reply('hi'), { resHeaders: { 'x-kip-call-id': 'call_abc123' } })
+  const res = await kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10 }, { fetch: impl })
+  assert.equal(res.callId, 'call_abc123')
+})
+
+test('complete json:true: callId survives the prompt-and-strip 400 retry', async () => {
+  const impl = async (_url, init) => {
+    const body = JSON.parse(init.body)
+    if (body.response_format) {
+      return { ok: false, status: 400, headers: new Headers(), json: async () => ({ error: { message: 'no response_format' } }), text: async () => '' }
+    }
+    return { ok: true, status: 200, headers: new Headers({ 'x-kip-call-id': 'call_retry' }), json: async () => reply('{"ok":true}'), text: async () => '' }
+  }
+  const res = await kip.complete(RESOLVED, { system: 's', prompt: 'q', json: true, maxTokens: 50 }, { fetch: impl })
+  assert.equal(res.text, '{"ok":true}')
+  assert.equal(res.callId, 'call_retry')
 })
 
 test('complete: no label -> no routing headers', async () => {

--- a/scripts/test/llm.test.js
+++ b/scripts/test/llm.test.js
@@ -54,11 +54,11 @@ function fakeAnthropicClient (responseText) {
   return { FakeAnthropic, getLastCall: () => lastCall }
 }
 
-function fakeFetch (responseBody, { ok = true, status = 200 } = {}) {
+function fakeFetch (responseBody, { ok = true, status = 200, resHeaders = {} } = {}) {
   let lastCall = null
   const impl = async (url, init) => {
     lastCall = { url, init }
-    return { ok, status, json: async () => responseBody, text: async () => JSON.stringify(responseBody) }
+    return { ok, status, headers: new Headers(resHeaders), json: async () => responseBody, text: async () => JSON.stringify(responseBody) }
   }
   return { impl, getLastCall: () => lastCall }
 }
@@ -80,6 +80,7 @@ test('callLLM: openai provider normalizes to {text, raw}, uses its own base URL/
     const result = await callLLM({ system: 'sys', prompt: 'hi' }, { fetchImpl: impl, vaultRoot: EMPTY_VAULT })
     assert.equal(result.text, 'hello from openai')
     assert.ok(result.raw)
+    assert.equal(result.callId, null, 'callId is null for a non-managed provider')
     assert.ok(getLastCall().url.startsWith('https://api.openai.com/v1'))
     const body = JSON.parse(getLastCall().init.body)
     assert.equal(body.model, 'gpt-test')
@@ -246,6 +247,7 @@ test('callLLM: records one content-free telemetry entry per successful call', as
   assert.equal(entries[0].label, 'test:call')
   assert.equal(typeof entries[0].ms, 'number')
   assert.equal(entries[0].promptChars, 5)
+  assert.equal(entries[0].callId, null, 'callId recorded (null for anthropic)')
   // fake response has no `usage` — the extractor must tolerate that, not throw
   assert.equal(entries[0].inputTokens, 0)
   for (const k of ['prompt', 'responseText', 'system']) assert.ok(!(k in entries[0]))
@@ -358,9 +360,12 @@ test('callLLM: "other" provider works like any OpenAI-compatible endpoint once c
 
 test('callLLM: "kip" provider routes through the managed backend with routing headers', async () => {
   await withEnv({ PROVIDER: 'kip', KIP_API_KEY: 'kip_env', KIP_BASE_URL: 'http://lan.test:8080' }, async () => {
-    const { impl, getLastCall } = fakeFetch({ model: 'claude-sonnet-4-6', choices: [{ message: { content: 'from kip' } }] })
+    const { impl, getLastCall } = fakeFetch(
+      { model: 'claude-sonnet-4-6', choices: [{ message: { content: 'from kip' } }] },
+      { resHeaders: { 'x-kip-call-id': 'call_xyz' } })
     const result = await callLLM({ system: 's', prompt: 'p', label: 'peck:answer' }, { fetchImpl: impl, vaultRoot: EMPTY_VAULT })
     assert.equal(result.text, 'from kip')
+    assert.equal(result.callId, 'call_xyz', 'callId passed through from the kip connector')
     assert.equal(getLastCall().url, 'http://lan.test:8080/v1/chat/completions')
     assert.equal(getLastCall().init.headers.Authorization, 'Bearer kip_env')
     assert.equal(getLastCall().init.headers['X-Kip-Workload'], 'peck:answer')

--- a/scripts/test/preference-signals.test.js
+++ b/scripts/test/preference-signals.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { preferenceSignalsEnabled, preferenceSignalsTarget } = require('../lib/preference-signals')
+
+const EMPTY_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'pref-signals-test-'))
+test.after(() => fs.rmSync(EMPTY_VAULT, { recursive: true, force: true }))
+
+/** Set env vars for the duration of fn, restoring after. */
+async function withEnv (vars, fn) {
+  const original = {}
+  for (const k of Object.keys(vars)) {
+    original[k] = process.env[k]
+    if (vars[k] === undefined) delete process.env[k]
+    else process.env[k] = vars[k]
+  }
+  try { return await fn() } finally {
+    for (const [k, v] of Object.entries(original)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  }
+}
+
+test('preferenceSignalsEnabled: true only for the kip provider', async () => {
+  await withEnv({ PROVIDER: 'kip', KIP_API_KEY: 'kip_x' }, () => {
+    assert.equal(preferenceSignalsEnabled(EMPTY_VAULT), true)
+  })
+  await withEnv({ PROVIDER: 'anthropic' }, () => {
+    assert.equal(preferenceSignalsEnabled(EMPTY_VAULT), false)
+  })
+  await withEnv({ PROVIDER: 'deepseek', DEEPSEEK_API_KEY: 'sk-x' }, () => {
+    assert.equal(preferenceSignalsEnabled(EMPTY_VAULT), false)
+  })
+})
+
+test('preferenceSignalsEnabled: kip with no key still counts as the active provider', async () => {
+  // the gate is "is kip the provider", not "is kip fully configured" — a
+  // key-less kip is still the surface to show (it just can't post yet).
+  await withEnv({ PROVIDER: 'kip', KIP_API_KEY: undefined }, () => {
+    assert.equal(preferenceSignalsEnabled(EMPTY_VAULT), true)
+  })
+})
+
+test('preferenceSignalsEnabled: never throws on a broken PROVIDER', async () => {
+  await withEnv({ PROVIDER: 'not-a-provider' }, () => {
+    assert.equal(preferenceSignalsEnabled(EMPTY_VAULT), false)
+  })
+})
+
+test('preferenceSignalsTarget: resolved baseUrl + apiKey for kip, else null', async () => {
+  await withEnv({ PROVIDER: 'kip', KIP_API_KEY: 'kip_live', KIP_BASE_URL: 'http://lan.test:3000/' }, () => {
+    assert.deepEqual(preferenceSignalsTarget(EMPTY_VAULT), {
+      baseUrl: 'http://lan.test:3000', // trailing slash trimmed
+      apiKey: 'kip_live'
+    })
+  })
+  await withEnv({ PROVIDER: 'kip', KIP_API_KEY: undefined }, () => {
+    assert.equal(preferenceSignalsTarget(EMPTY_VAULT), null, 'no key -> null')
+  })
+  await withEnv({ PROVIDER: 'anthropic' }, () => {
+    assert.equal(preferenceSignalsTarget(EMPTY_VAULT), null, 'wrong provider -> null')
+  })
+})
+
+test('preferenceSignalsTarget: falls back to the hosted base URL', async () => {
+  await withEnv({ PROVIDER: 'kip', KIP_API_KEY: 'kip_x', KIP_BASE_URL: undefined }, () => {
+    assert.equal(preferenceSignalsTarget(EMPTY_VAULT).baseUrl, 'https://api.kip-ai.be')
+  })
+})


### PR DESCRIPTION
First slice of the **client half** of the preference-signals epic
(kip-app#73). **No runtime behaviour change, no UI, nothing posts yet** —
this is just the plumbing the later mechanisms build on.

## Prerequisites from the epic

1. **Return the call id.** `kip-connector.js` now reads the `X-Kip-Call-Id`
   response header and returns it as `callId` on `{ text, raw, callId }`
   (and it survives the `json:true` → 400 → prompt-and-strip retry).
   `callLLM` passes `callId` through on its return value and records it on
   the telemetry entry. Every non-kip connector → `callId: null`.
2. **Expose the resolved target.** `preferenceSignalsTarget(vaultRoot)` →
   `{ baseUrl, apiKey }` (trailing slash trimmed, hosted-URL fallback) for
   the later `/v1/feedback` + `/v1/arena/*` POSTs to reuse.

## The gate

`lib/preference-signals.js` · `preferenceSignalsEnabled(vaultRoot)` — true
only when the active provider is `kip`, resolved the same way
`describeProvider` resolves it. Never throws. Every downstream surface
(block marking, rating widget, behaviour watcher, arena UI, the poster)
will be gated on this, so a direct Anthropic/OpenAI/DeepSeek/local provider
sees none of it. The renderer gets a thin IPC shim over it later.

## Tests

- `kip-connector.test.js` — callId present / absent / across the 400 retry
- `llm.test.js` — pass-through, `null` for openai, recorded in telemetry
- `preference-signals.test.js` (new) — kip vs not, key-less kip still counts,
  broken PROVIDER doesn't throw, target resolution + fallback

Full suite **218/218**.

## Next in the epic

`telemetry.js` feedback sink + batching poster → mechanism 1 (behavioural)
→ mechanism 2 (rating widget) → arena 5a → 5b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)