### PR TITLE
Preference signals: telemetry feedback sink + batching poster

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -78,9 +78,12 @@ scripts/
 │   ├── kip-connector.js # the managed-backend "kip" connector (AGPL, built-in)
 │   ├── preference-signals.js # the "is the kip connector active" gate — every
 │   │                # preference-signal surface (kip-app#73) checks it
+│   ├── feedback-poster.js # batches content-free preference signals and POSTs
+│   │                # them to the managed backend; kip-only, best-effort
 │   ├── untar.js    # zero-dep npm-tarball (.tgz) extractor for connector install
 │   ├── telemetry.js # per-run LLM-call timing/token recorder every callLLM()
 │   │                # feeds; content-free summary() + opt-in full-text trace
+│   │                # + onFeedback sink for preference signals (kip-app#73)
 │   ├── prompts.js  # prompt content built on callLLM(): extractKeyTerms,
 │   │                # answerQuestion, answerQuestionWithSkills (the Peck tool
 │   │                # loop), flagContradictions, proposeAndDraftPages, ...
@@ -348,15 +351,29 @@ through and records it in telemetry; every other connector returns
 `callId: null`. Contract: `JWE24-code/kip-backend` → `KIP-BACKEND.md`.
 Tested against a mocked `fetch` in `scripts/test/kip-connector.test.js`.
 
-**Preference signals** (`lib/preference-signals.js`, epic kip-app#73) —
-content-free feedback (behaviour, micro-ratings, blind arena) that tunes
-the managed router. `preferenceSignalsEnabled(vaultRoot)` is the one gate:
-true only when the active provider is `kip`. `preferenceSignalsTarget()`
-hands back its resolved `{ baseUrl, apiKey }` (or null) for the
-`/v1/feedback` and `/v1/arena/*` POSTs. The renderer reaches this through
-an IPC shim. Everything downstream — block marking, the rating widget, the
-behaviour watcher, the arena UI, the batching poster — is gated on it, so
-a direct Anthropic/OpenAI/DeepSeek/local provider sees none of it.
+**Preference signals** (epic kip-app#73) — content-free feedback (behaviour,
+micro-ratings, blind arena) that tunes the managed router.
+
+- `lib/preference-signals.js` — `preferenceSignalsEnabled(vaultRoot)` is the
+  one gate: true only when the active provider is `kip`.
+  `preferenceSignalsTarget()` hands back its resolved `{ baseUrl, apiKey }`
+  (or null) for the `/v1/feedback` and `/v1/arena/*` POSTs. The renderer
+  reaches this through an IPC shim. Everything downstream — block marking,
+  the rating widget, the behaviour watcher, the arena UI — is gated on it,
+  so a direct Anthropic/OpenAI/DeepSeek/local provider sees none of it.
+- `telemetry.onFeedback(fn)` / `telemetry.sendFeedback(signal)` — a sink
+  parallel to `onTrace`, but for closed enum/int signals only (`reset()`
+  clears it too).
+- `lib/feedback-poster.js` — `createFeedbackPoster({ vaultRoot })` →
+  `{ enqueue, flush, stop }`: batches, auto-flushes every 5 s on an
+  `unref()`'d timer, `flush()` is capped at 1 s, and it re-checks
+  `preferenceSignalsTarget` on every enqueue/flush so switching provider
+  mid-run stops it. `sanitizeSignal` reduces a signal to the wire field set
+  (`rating`: `call_id/kind/score/scale`; `behavior`:
+  `call_id/kind/behavior/edit_bucket`) — a stray `text`/`prompt`/`note`
+  can't ride along. `installFeedbackPoster()` wires one to `telemetry` +
+  a `beforeExit` flush; every CLI entrypoint calls it right after
+  `telemetry.reset()`.
 
 #### `groom.js` — coop health checks
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "peck": "node scripts/peck.js",
     "groom": "node scripts/groom.js",
     "hatch": "node scripts/hatch.js",
-    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/preference-signals.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js"
+    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/preference-signals.test.js scripts/test/feedback-poster.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.70.0",

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -29,6 +29,7 @@ const { peckTurn } = require('./lib/peck')
 const { DEFAULT_VAULT_ROOT } = require('./lib/paths')
 const telemetry = require('./lib/telemetry')
 const { createRunReporter } = require('./lib/run-progress')
+const { installFeedbackPoster } = require('./lib/feedback-poster')
 
 const ROOST_DIR = path.join(DEFAULT_VAULT_ROOT, '.roost')
 const traceOn = process.argv.includes('--trace') || process.env.KIP_PECK_TRACE === '1'
@@ -47,6 +48,7 @@ async function main () {
   // for a filed answer, does one resolvePage() — turns don't race on page
   // creation or the DB the way a bulk hatch does.
   telemetry.reset()
+  installFeedbackPoster({ vaultRoot: DEFAULT_VAULT_ROOT })
   const reporter = createRunReporter({
     dir: ROOST_DIR,
     progressFile: path.join(ROOST_DIR, 'peck-progress.json'),

--- a/scripts/groom.js
+++ b/scripts/groom.js
@@ -27,6 +27,7 @@ const {
 const { describeProvider } = require('./lib/llm')
 const telemetry = require('./lib/telemetry')
 const { createRunReporter } = require('./lib/run-progress')
+const { installFeedbackPoster } = require('./lib/feedback-poster')
 
 const MAX_CONTRADICTION_GROUP_SIZE = 6
 const DEEP_CONTRADICTION_GROUP_SIZE = 12
@@ -468,6 +469,7 @@ async function main () {
     console.error('  deep groom — many LLM calls, can take several minutes')
     const roostDir = path.join(vaultRoot, '.roost')
     telemetry.reset()
+    installFeedbackPoster({ vaultRoot })
     reporter = createRunReporter({
       dir: roostDir,
       progressFile: path.join(roostDir, 'groom-progress.json'),

--- a/scripts/hatch-all.js
+++ b/scripts/hatch-all.js
@@ -30,6 +30,7 @@ const { pendingSourcesSummary, hatchAllSources, proposeNextPending, commitReview
 const { DEFAULT_VAULT_ROOT } = require('./lib/paths')
 const telemetry = require('./lib/telemetry')
 const { createRunReporter } = require('./lib/run-progress')
+const { installFeedbackPoster } = require('./lib/feedback-poster')
 
 const ROOST_DIR = path.join(DEFAULT_VAULT_ROOT, '.roost')
 const PROGRESS_FILE = path.join(ROOST_DIR, 'hatch-progress.json')
@@ -116,6 +117,7 @@ async function main () {
   }
 
   telemetry.reset()
+  installFeedbackPoster({ vaultRoot: DEFAULT_VAULT_ROOT })
   reporter = createRunReporter({
     dir: ROOST_DIR, progressFile: PROGRESS_FILE, metricsFile: METRICS_FILE, traceFile: TRACE_FILE, traceOn
   })

--- a/scripts/lib/feedback-poster.js
+++ b/scripts/lib/feedback-poster.js
@@ -1,0 +1,136 @@
+// Batches preference signals (kip-app#73) and POSTs them to the managed
+// backend's /v1/feedback. An entrypoint wires it via
+//   const feedback = createFeedbackPoster({ vaultRoot })
+//   telemetry.onFeedback(feedback.enqueue)
+//   // ... and `await feedback.flush()` once before it exits
+// or the electron main process drives `enqueue` straight from its
+// kipFeedback IPC.
+//
+// Rules (from the epic):
+//   - kip provider only — enqueue() and flush() no-op otherwise (checked
+//     live each time, so switching provider mid-run stops it)
+//   - best-effort — never throws into a run; every network error is swallowed
+//   - never blocks exit more than ~1s — flush() caps its own wait, the
+//     internal timer is unref()'d
+//   - closed field set only — no free text can ride along, even if a caller
+//     attaches extra keys
+
+const telemetry = require('./telemetry')
+const { preferenceSignalsTarget } = require('./preference-signals')
+
+const DEFAULT_FLUSH_MS = 5000
+const DEFAULT_FLUSH_BUDGET_MS = 1000
+
+// the ONLY keys that may cross the wire, per signal kind.
+const FIELDS_BY_KIND = {
+  rating: ['call_id', 'kind', 'score', 'scale'],
+  behavior: ['call_id', 'kind', 'behavior', 'edit_bucket']
+}
+
+/**
+ * Reduce a signal to its closed field set, or null if it isn't a well-formed
+ * rating / behavior signal. Anything not in the whitelist (a stray `text`,
+ * `prompt`, `note`, …) is dropped here.
+ */
+function sanitizeSignal (signal) {
+  if (!signal || typeof signal !== 'object') return null
+  if (typeof signal.call_id !== 'string' || !signal.call_id) return null
+  const fields = FIELDS_BY_KIND[signal.kind]
+  if (!fields) return null
+  const out = {}
+  for (const k of fields) if (signal[k] !== undefined) out[k] = signal[k]
+  return out
+}
+
+function createFeedbackPoster ({
+  vaultRoot,
+  fetchImpl,
+  flushMs = DEFAULT_FLUSH_MS,
+  flushBudgetMs = DEFAULT_FLUSH_BUDGET_MS,
+  logger = console
+} = {}) {
+  const doFetch = fetchImpl || ((...a) => fetch(...a))
+  let queue = []
+  let timer = null
+
+  const debug = (msg) => { if (logger && typeof logger.debug === 'function') logger.debug(`[feedback] ${msg}`) }
+
+  async function postOne (target, body) {
+    try {
+      const res = await doFetch(`${target.baseUrl}/v1/feedback`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${target.apiKey}`
+        },
+        body: JSON.stringify(body)
+      })
+      if (res && !res.ok) debug(`${res.status} for ${body.kind}`)
+    } catch (err) {
+      debug((err && err.message) || String(err))
+    }
+  }
+
+  async function drain () {
+    if (timer) { clearTimeout(timer); timer = null }
+    if (!queue.length) return
+    const batch = queue
+    queue = []
+    const target = preferenceSignalsTarget(vaultRoot)
+    if (!target) return // provider changed away from kip / no key — drop
+    await Promise.all(batch.map((body) => postOne(target, body)))
+  }
+
+  return {
+    /** Queue one signal. Silent no-op if malformed or the kip provider isn't active. */
+    enqueue (signal) {
+      const clean = sanitizeSignal(signal)
+      if (!clean) return
+      if (!preferenceSignalsTarget(vaultRoot)) return
+      queue.push(clean)
+      if (!timer) {
+        timer = setTimeout(() => { drain().catch(() => {}) }, flushMs)
+        if (timer.unref) timer.unref() // must never keep a CLI process alive
+      }
+    },
+
+    /** Flush now, capped at flushBudgetMs so a slow backend can't delay exit. */
+    async flush () {
+      await Promise.race([
+        drain().catch(() => {}),
+        new Promise((resolve) => setTimeout(resolve, flushBudgetMs))
+      ])
+    },
+
+    /** Drop everything pending and cancel the timer. */
+    stop () {
+      if (timer) { clearTimeout(timer); timer = null }
+      queue = []
+    },
+
+    get pending () { return queue.length }
+  }
+}
+
+/**
+ * The one line a CLI entrypoint needs: create a poster, register it as
+ * telemetry's feedback sink, and flush it (capped) on `beforeExit`. Call it
+ * right after telemetry.reset() — reset() clears the sink. Returns the poster
+ * (mostly for tests; entrypoints can ignore it).
+ *
+ * `beforeExit` doesn't fire on process.exit() or an uncaught throw — that's
+ * acceptable for a best-effort signal.
+ */
+function installFeedbackPoster (opts = {}) {
+  const poster = createFeedbackPoster(opts)
+  telemetry.onFeedback(poster.enqueue)
+  let flushed = false
+  process.once('beforeExit', () => {
+    if (flushed) return
+    flushed = true
+    poster.flush().catch(() => {})
+  })
+  return poster
+}
+
+module.exports = { createFeedbackPoster, installFeedbackPoster, sanitizeSignal }

--- a/scripts/lib/telemetry.js
+++ b/scripts/lib/telemetry.js
@@ -10,13 +10,15 @@
 
 let records = []
 let traceSink = null
+let feedbackSink = null
 let phaseStack = []
 
-/** Clears everything, including any registered trace sink. Call at run start. */
+/** Clears everything, including the trace and feedback sinks. Call at run start. */
 function reset () {
   records = []
   phaseStack = []
   traceSink = null
+  feedbackSink = null
 }
 
 function currentPhase () {
@@ -66,6 +68,28 @@ function record (rec) {
 /** Register (or clear, with null) the full-text trace sink. */
 function onTrace (fn) {
   traceSink = fn || null
+}
+
+/**
+ * Register (or clear, with null) the preference-signal sink (kip-app#73).
+ * Separate from onTrace: this one carries ONLY closed enum/int signals —
+ * `{ call_id, kind, score?/scale?/behavior?/edit_bucket? }` — never prompt,
+ * response, or edit text. Wired by the entrypoints to lib/feedback-poster.
+ */
+function onFeedback (fn) {
+  feedbackSink = fn || null
+}
+
+/**
+ * Emit one content-free preference signal. Best-effort and fire-and-forget:
+ * a missing or throwing sink never disturbs the run. No-op unless a sink is
+ * registered (which lib/feedback-poster only does for the kip provider).
+ */
+function sendFeedback (signal) {
+  if (!feedbackSink || !signal) return
+  try {
+    feedbackSink(signal)
+  } catch { /* best-effort — never let a signal break a run */ }
 }
 
 function num (x) {
@@ -127,4 +151,4 @@ function entries () {
   return records.map((e) => ({ ...e }))
 }
 
-module.exports = { reset, withPhase, record, onTrace, currentPhase, summary, entries }
+module.exports = { reset, withPhase, record, onTrace, onFeedback, sendFeedback, currentPhase, summary, entries }

--- a/scripts/peck.js
+++ b/scripts/peck.js
@@ -19,6 +19,7 @@ const { describeProvider } = require('./lib/llm')
 const { DEFAULT_VAULT_ROOT } = require('./lib/paths')
 const telemetry = require('./lib/telemetry')
 const { createRunReporter } = require('./lib/run-progress')
+const { installFeedbackPoster } = require('./lib/feedback-poster')
 
 const ROOST_DIR = path.join(DEFAULT_VAULT_ROOT, '.roost')
 const traceOn = process.argv.includes('--trace') || process.env.KIP_PECK_TRACE === '1'
@@ -35,6 +36,7 @@ async function main () {
   console.error(describeProvider())
 
   telemetry.reset()
+  installFeedbackPoster({ vaultRoot })
   const reporter = createRunReporter({
     dir: ROOST_DIR,
     progressFile: path.join(ROOST_DIR, 'peck-progress.json'),

--- a/scripts/reminders.js
+++ b/scripts/reminders.js
@@ -24,6 +24,7 @@ const { generateMeetingPrep } = require('./lib/prompts')
 const { DEFAULT_VAULT_ROOT } = require('./lib/paths')
 const telemetry = require('./lib/telemetry')
 const { createRunReporter } = require('./lib/run-progress')
+const { installFeedbackPoster } = require('./lib/feedback-poster')
 const {
   addReminder, listReminders, cancelReminder, setReminderSound, dueReminders, markNotified,
   loadReminders, describeReminder, fmtWhen, fmtLead
@@ -61,6 +62,7 @@ async function runDue () {
   if (!due.length) { out({ fired: [] }, 'Nothing due.'); return }
 
   telemetry.reset()
+  installFeedbackPoster({ vaultRoot: DEFAULT_VAULT_ROOT })
   const reporter = createRunReporter({
     dir: ROOST_DIR,
     progressFile: path.join(ROOST_DIR, 'reminders-progress.json'),

--- a/scripts/test/feedback-poster.test.js
+++ b/scripts/test/feedback-poster.test.js
@@ -1,0 +1,129 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { createFeedbackPoster, sanitizeSignal } = require('../lib/feedback-poster')
+
+const EMPTY_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'feedback-poster-test-'))
+test.after(() => fs.rmSync(EMPTY_VAULT, { recursive: true, force: true }))
+
+async function withEnv (vars, fn) {
+  const original = {}
+  for (const k of Object.keys(vars)) {
+    original[k] = process.env[k]
+    if (vars[k] === undefined) delete process.env[k]
+    else process.env[k] = vars[k]
+  }
+  try { return await fn() } finally {
+    for (const [k, v] of Object.entries(original)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  }
+}
+
+const KIP_ENV = { PROVIDER: 'kip', KIP_API_KEY: 'kip_test', KIP_BASE_URL: 'http://lan.test:3000' }
+
+/** Records every POST; returns { impl, calls }. */
+function recordingFetch ({ reject = false, ok = true } = {}) {
+  const calls = []
+  const impl = async (url, init) => {
+    calls.push({ url, init, body: JSON.parse(init.body) })
+    if (reject) throw new Error('network down')
+    return { ok, status: ok ? 200 : 500 }
+  }
+  return { impl, calls }
+}
+
+test('sanitizeSignal: keeps the closed field set, drops everything else', () => {
+  assert.deepEqual(
+    sanitizeSignal({ call_id: 'c1', kind: 'rating', score: 1, scale: 2, note: 'loved it', prompt: 'secret' }),
+    { call_id: 'c1', kind: 'rating', score: 1, scale: 2 })
+  assert.deepEqual(
+    sanitizeSignal({ call_id: 'c2', kind: 'behavior', behavior: 'edited', edit_bucket: 3, editText: 'the diff' }),
+    { call_id: 'c2', kind: 'behavior', behavior: 'edited', edit_bucket: 3 })
+})
+
+test('sanitizeSignal: rejects malformed signals', () => {
+  assert.equal(sanitizeSignal(null), null)
+  assert.equal(sanitizeSignal({ kind: 'rating', score: 1 }), null, 'no call_id')
+  assert.equal(sanitizeSignal({ call_id: '', kind: 'rating' }), null, 'empty call_id')
+  assert.equal(sanitizeSignal({ call_id: 'c', kind: 'freeform' }), null, 'unknown kind')
+  assert.equal(sanitizeSignal({ call_id: 'c' }), null, 'no kind')
+})
+
+test('poster: enqueue is a no-op when the provider is not kip', async () => {
+  await withEnv({ PROVIDER: 'anthropic' }, async () => {
+    const { impl, calls } = recordingFetch()
+    const poster = createFeedbackPoster({ vaultRoot: EMPTY_VAULT, fetchImpl: impl })
+    poster.enqueue({ call_id: 'c1', kind: 'rating', score: 1, scale: 2 })
+    assert.equal(poster.pending, 0)
+    await poster.flush()
+    assert.equal(calls.length, 0)
+  })
+})
+
+test('poster: batches, then flush POSTs each signal to /v1/feedback with the bearer key', async () => {
+  await withEnv(KIP_ENV, async () => {
+    const { impl, calls } = recordingFetch()
+    const poster = createFeedbackPoster({ vaultRoot: EMPTY_VAULT, fetchImpl: impl })
+    poster.enqueue({ call_id: 'c1', kind: 'rating', score: 1, scale: 2 })
+    poster.enqueue({ call_id: 'c2', kind: 'behavior', behavior: 'regenerated' })
+    assert.equal(poster.pending, 2, 'nothing sent until flush / the timer')
+
+    await poster.flush()
+    assert.equal(calls.length, 2)
+    assert.equal(calls[0].url, 'http://lan.test:3000/v1/feedback')
+    assert.equal(calls[0].init.headers.Authorization, 'Bearer kip_test')
+    assert.deepEqual(calls[0].body, { call_id: 'c1', kind: 'rating', score: 1, scale: 2 })
+    assert.deepEqual(calls[1].body, { call_id: 'c2', kind: 'behavior', behavior: 'regenerated' })
+    assert.equal(poster.pending, 0)
+  })
+})
+
+test('poster: a malformed signal never reaches the queue', async () => {
+  await withEnv(KIP_ENV, async () => {
+    const { impl, calls } = recordingFetch()
+    const poster = createFeedbackPoster({ vaultRoot: EMPTY_VAULT, fetchImpl: impl })
+    poster.enqueue({ kind: 'rating' }) // no call_id
+    poster.enqueue('nonsense')
+    assert.equal(poster.pending, 0)
+    await poster.flush()
+    assert.equal(calls.length, 0)
+  })
+})
+
+test('poster: a network failure is swallowed, queue still clears', async () => {
+  await withEnv(KIP_ENV, async () => {
+    const { impl } = recordingFetch({ reject: true })
+    const poster = createFeedbackPoster({ vaultRoot: EMPTY_VAULT, fetchImpl: impl, logger: { debug () {} } })
+    poster.enqueue({ call_id: 'c1', kind: 'rating', score: 0, scale: 2 })
+    await poster.flush() // must not throw
+    assert.equal(poster.pending, 0)
+  })
+})
+
+test('poster: the auto-flush timer fires and is unref-safe', async () => {
+  await withEnv(KIP_ENV, async () => {
+    const { impl, calls } = recordingFetch()
+    const poster = createFeedbackPoster({ vaultRoot: EMPTY_VAULT, fetchImpl: impl, flushMs: 20 })
+    poster.enqueue({ call_id: 'c1', kind: 'rating', score: 1, scale: 2 })
+    await new Promise((r) => setTimeout(r, 60))
+    assert.equal(calls.length, 1, 'timer flushed without an explicit flush()')
+  })
+})
+
+test('poster: flush drops the batch if the provider changed away from kip mid-run', async () => {
+  const { impl, calls } = recordingFetch()
+  const poster = createFeedbackPoster({ vaultRoot: EMPTY_VAULT, fetchImpl: impl })
+  await withEnv(KIP_ENV, async () => {
+    poster.enqueue({ call_id: 'c1', kind: 'rating', score: 1, scale: 2 })
+    assert.equal(poster.pending, 1)
+  })
+  await withEnv({ PROVIDER: 'anthropic' }, async () => {
+    await poster.flush()
+  })
+  assert.equal(calls.length, 0, 'no POST once kip is no longer active')
+})


### PR DESCRIPTION
Second slice of the client half of the preference-signals epic
(kip-app#73). Builds on #19 (merged). **No signals are emitted yet, so no
runtime change** — this is the poster the mechanisms plug into.

## `telemetry.js`

`onFeedback(fn)` / `sendFeedback(signal)` — a sink parallel to `onTrace`,
but carrying only closed enum/int signals, never text. `reset()` clears it
alongside the trace sink.

## `lib/feedback-poster.js`

`createFeedbackPoster({ vaultRoot, fetchImpl?, flushMs?, flushBudgetMs? })`
→ `{ enqueue, flush, stop, pending }`:

- **batches** — `enqueue` queues, a 5 s `unref()`'d timer or `flush()` sends
- **kip-only** — re-checks `preferenceSignalsTarget(vaultRoot)` on every
  enqueue *and* flush, so switching provider mid-run drops the batch
- **best-effort** — every network error swallowed; `flush()` races a 1 s
  budget so a slow backend can't delay process exit
- **closed field set** — `sanitizeSignal` keeps only
  `call_id/kind/score/scale` (rating) or
  `call_id/kind/behavior/edit_bucket` (behavior); a stray `text` / `prompt`
  / `note` is dropped before it can be sent

`installFeedbackPoster({ vaultRoot })` — the one line each CLI entrypoint
adds right after `telemetry.reset()`: creates a poster, registers it, and
flushes it on `beforeExit`. Wired into `chat` / `peck` / `hatch-all` /
`groom` (deep) / `reminders`.

## Tests

`feedback-poster.test.js` — sanitize (drops free text, rejects malformed),
batch + POST shape, no-op when provider ≠ kip, network failure swallowed,
timer auto-flush, mid-run provider switch drops the batch. Full suite
**226/226**. All 5 entrypoints smoke-loaded.

## Next

cljs/electron: IPC shim over `preferenceSignalsEnabled` + `kipFeedback`,
`kip-call-id::` block marking, the behaviour watcher (mechanism 1), the
👍/👎 widget (mechanism 2), then arena.

🤖 Generated with [Claude Code](https://claude.com/claude-code)