### PR TITLE
peck: surface the answer call's callId in the turn result

### DIFF
--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -22,6 +22,7 @@ const { extractKeyTerms, answerQuestion, answerQuestionWithSkills, captureFacts 
 const { discoverSkills } = require('./skills')
 const { looksLikeReminder } = require('./reminders')
 const { DEFAULT_VAULT_ROOT } = require('./paths')
+const telemetry = require('./telemetry')
 
 const BROAD_SEARCH_LIMIT = 15
 const CAPTURE_TYPES = new Set(['entity', 'concept'])
@@ -135,6 +136,7 @@ async function fileAnswerToNest (question, answer, candidateSlugs, vaultRoot = D
  */
 async function answerFromPages (question, pages, { fileToNest, vaultRoot }) {
   const candidateSlugs = pages.map((p) => p.slug)
+  const telemetryStart = telemetry.entries().length
 
   let skills = []
   try {
@@ -161,7 +163,21 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot }) {
   if (fileToNest) {
     await fileAnswerToNest(question, answer, candidateSlugs, vaultRoot)
   }
-  return { answer, citedSlugs, candidateSlugs, steps }
+  // The managed backend's id for the answer call, so the app can attach a
+  // preference signal (👍/👎, "was the regen better?") to it. null for every
+  // other provider. Read from telemetry (which already records callId per
+  // PR kip-app#73) rather than threaded through answerQuestion's string
+  // return — bounded to the calls THIS invocation just made.
+  return { answer, citedSlugs, candidateSlugs, steps, callId: answerCallIdSince(telemetryStart) }
+}
+
+/** callId of the newest peck:answer* call at or after `startIdx` in telemetry, else null. */
+function answerCallIdSince (startIdx) {
+  const es = telemetry.entries()
+  for (let i = es.length - 1; i >= startIdx; i--) {
+    if (es[i].callId && /^peck:answer/.test(es[i].label || '')) return es[i].callId
+  }
+  return null
 }
 
 /**
@@ -204,7 +220,7 @@ function fileCapturedFacts (proposedPages, vaultRoot = DEFAULT_VAULT_ROOT) {
  * afterward (e.g. after an interactive y/n prompt). fileToNest:true does the
  * whole transaction — search, answer, file, log — in one call.
  *
- * @returns {{answer: string|null, citedSlugs: string[], candidateSlugs: string[], steps: Array}}
+ * @returns {{answer: string|null, citedSlugs: string[], candidateSlugs: string[], steps: Array, callId: string|null}}
  */
 async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_VAULT_ROOT } = {}) {
   const candidates = await retrieveCandidates(question, vaultRoot)

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -365,6 +365,36 @@ test('peckTurn — with no skills, only peck:answer is called (no skill-turn)', 
   } finally { s.restore() }
 })
 
+test('peckTurn — a question carries the managed backend callId (null for other providers)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  writePage(root, 'concepts', 'sleep', { type: 'concept', body: 'notes on sleep' })
+  rebuildRoost(root)
+
+  const original = global.fetch
+  t.after(() => { global.fetch = original })
+
+  // kip connector, backend tags the answer call
+  saveLLMConfig({ provider: 'kip', providers: { kip: { apiKey: 'kip_x', baseUrl: 'http://lan.test:3000' } } }, root)
+  global.fetch = async (url, init) => {
+    const sys = JSON.parse(init.body).messages.map((m) => m.content).join('\n')
+    const content = /key search terms/.test(sys) ? '{"terms":["sleep"]}' : 'Per [[sleep]], rest.'
+    const callId = /key search terms/.test(sys) ? 'call_terms' : 'call_answer'
+    return { ok: true, status: 200, headers: new Headers({ 'x-kip-call-id': callId }), json: async () => ({ choices: [{ message: { content }, finish_reason: 'stop' }] }) }
+  }
+  const r = await peckTurn('what about sleep?', { vaultRoot: root })
+  assert.equal(r.intent, 'question')
+  assert.equal(r.callId, 'call_answer', 'the peck:answer call id, not the key-terms one')
+
+  // a plain provider: same shape, callId null
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  const s = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep]], rest.' })
+  try {
+    const r2 = await peckTurn('what about sleep?', { vaultRoot: root })
+    assert.equal(r2.callId, null)
+  } finally { s.restore() }
+})
+
 test('peckTurn — an upcoming-event statement routes to the reminders skill, not fact capture', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))


### PR DESCRIPTION
Preference-signals epic (kip-app#73). `answerFromPages` (the single
chokepoint for `askQuestion` and `peckTurn`'s question/reminder intents)
now returns **`callId`** — the managed backend's id for the
`peck:answer` / `peck:answer:final` call.

- Read from `telemetry.entries()` (which records `callId` since #19),
  scanning only the calls made during this `answerFromPages` invocation —
  no change to `answerQuestion`'s string return or its 4 call sites.
- `null` for every non-`kip` provider.
- Flows out `chat.js`'s `JSON.stringify(result)` unchanged, so the app
  gets it for free.

Test: a `kip`-provider question's result carries the `peck:answer` call id
(not the key-terms call's); a `local`-provider question carries `null`.
Suite 229/229.

Next: the app stores it on the assistant message and the 👍/👎 widget
attaches a rating to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)