### PR TITLE
Preference signals: arena regenerate free-rider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ All notable changes to Kip. Format loosely follows
 The retrieval layer (this repo) and the desktop app
 ([kip-app](https://github.com/JWE24-code/kip-app)) are released together.
 
+## [0.3.7] — 2026-08-30
+
+### The retrieval layer (`scripts/`)
+
+- **Preference signals** (epic kip-app#73) — content-free plumbing so the
+  managed backend can learn which model / workload pairings land. All of it
+  is inert unless the active provider is the `kip` connector.
+  - `callLLM` now resolves to `{ text, raw, callId, arenaId }`. The `kip`
+    connector reads `X-Kip-Call-Id` off every completion; every other
+    connector reports `null`.
+  - `telemetry.onFeedback` / `sendFeedback` — a closed enum/int sink
+    parallel to the full-text trace sink. `lib/feedback-poster.js` batches
+    those to `/v1/feedback` (best-effort, `unref`'d timer, capped flush,
+    re-checks the provider every enqueue) and is wired into every CLI
+    entrypoint.
+  - **Regenerate free-rider** — `chat.js --arena-compare-to <callId>` (and
+    `peckTurn({ arenaCompareToCallId })`) re-answers a question as arena
+    candidate B against the first answer, via `/v1/arena/completions`. The
+    turn result carries `arenaId`; `feedback-poster.postArenaVerdict()`
+    posts the A/B verdict. Skills are skipped on this path — a regenerate
+    is a clean model-vs-model comparison.
+
 ## [0.3.5] — 2026-08-30
 
 ### The retrieval layer (`scripts/`)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -346,10 +346,18 @@ equivalent server-side for `model:"auto"` picks.
 `:`-segment) routing headers; body is `{ model: "auto", max_tokens,
 messages }`. `baseUrl` defaults to `https://api.kip-ai.be`, overridable to
 a self-hosted backend. It reads the `X-Kip-Call-Id` response header and
-returns it as `callId` on `{ text, raw, callId }` — `callLLM` passes that
-through and records it in telemetry; every other connector returns
-`callId: null`. Contract: `JWE24-code/kip-backend` → `KIP-BACKEND.md`.
-Tested against a mocked `fetch` in `scripts/test/kip-connector.test.js`.
+returns it as `callId` on `{ text, raw, callId, arenaId }` — `callLLM`
+passes that through and records it in telemetry; every other connector
+returns `callId: null`. Contract: `JWE24-code/kip-backend` →
+`KIP-BACKEND.md`. Tested against a mocked `fetch` in
+`scripts/test/kip-connector.test.js`.
+
+A call carrying `arena: { compareToCallId }` (only `answerQuestion`, for a
+Peck regenerate — see below) goes to `{baseUrl}/v1/arena/completions`
+instead, with `compare_to_call_id` set so only candidate B runs. The
+response is `{ arena_id, origin, b: { …completion, kip_call_id }, a? }`;
+the connector returns B's text, `callId: b.kip_call_id`, and
+`arenaId: arena_id` (mirrored by the `X-Kip-Arena-Id` header).
 
 **Preference signals** (epic kip-app#73) — content-free feedback (behaviour,
 micro-ratings, blind arena) that tunes the managed router.
@@ -373,7 +381,16 @@ micro-ratings, blind arena) that tunes the managed router.
   `call_id/kind/behavior/edit_bucket`) — a stray `text`/`prompt`/`note`
   can't ride along. `installFeedbackPoster()` wires one to `telemetry` +
   a `beforeExit` flush; every CLI entrypoint calls it right after
-  `telemetry.reset()`.
+  `telemetry.reset()`. `postArenaVerdict(arenaId, winner, { vaultRoot })` is
+  the sibling one-shot for an arena A/B verdict (`winner` ∈
+  `a`/`b`/`tie`/`skip`) — POSTs to `{baseUrl}/v1/arena/<id>/verdict`; the
+  app drives it from its `:kipArena` IPC.
+- **The regenerate free-rider** — `peckTurn(input, { arenaCompareToCallId })`
+  / `chat.js --arena-compare-to <callId>` re-answers a question as arena
+  candidate B against the first answer. `answerFromPages` takes the plain
+  `answerQuestion` path for it (no skills — they add per-run variance that
+  muddies a model-vs-model comparison). The turn result carries `arenaId`;
+  the app shows a "was this better?" strip and posts the verdict.
 
 #### `groom.js` — coop health checks
 

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -7,8 +7,12 @@
 //
 // Prints the peckTurn() result as JSON to stdout; the provider banner goes to
 // stderr so stdout stays pure JSON for the caller.
-//   { intent: "question",  answer, citedSlugs, candidateSlugs, steps }
+//   { intent: "question",  answer, citedSlugs, candidateSlugs, steps, callId, arenaId }
 //   { intent: "statement", learned, note, pages?, candidateSlugs }
+//
+// callId / arenaId are the managed backend's ids for the answer call (both
+// null on any other provider). arenaId is set only for a --arena-compare-to
+// regenerate; a verdict on it goes back via the app's :kipArena IPC.
 //
 // `steps` (question only) is what the skills tool loop ran, if anything:
 //   [{ skill, input, ok, ms, outputPreview }, ...].
@@ -35,12 +39,17 @@ const ROOST_DIR = path.join(DEFAULT_VAULT_ROOT, '.roost')
 const traceOn = process.argv.includes('--trace') || process.env.KIP_PECK_TRACE === '1'
 
 async function main () {
-  const input = process.argv.slice(2).find((a) => !a.startsWith('--'))
+  const args = process.argv.slice(2)
+  const input = args.find((a) => !a.startsWith('--'))
   if (!input || !input.trim()) {
-    console.error('Usage: node scripts/chat.js "your question — or a fact to remember" [--trace]')
+    console.error('Usage: node scripts/chat.js "your question — or a fact to remember" [--trace] [--arena-compare-to <callId>]')
     process.exitCode = 1
     return
   }
+  // A regenerate on the managed backend (kip-app#73): re-answer this question
+  // as arena candidate B against the first answer's callId.
+  const acIdx = args.indexOf('--arena-compare-to')
+  const arenaCompareToCallId = acIdx >= 0 ? args[acIdx + 1] : null
 
   console.error(describeProvider())
 
@@ -60,7 +69,7 @@ async function main () {
   reporter.flush(true)
 
   try {
-    const result = await peckTurn(input, { fileToNest: false, vaultRoot: DEFAULT_VAULT_ROOT })
+    const result = await peckTurn(input, { fileToNest: false, vaultRoot: DEFAULT_VAULT_ROOT, arenaCompareToCallId })
     reporter.flush(false)
     reporter.writeMetrics()
     reporter.close()

--- a/scripts/lib/feedback-poster.js
+++ b/scripts/lib/feedback-poster.js
@@ -4,7 +4,8 @@
 //   telemetry.onFeedback(feedback.enqueue)
 //   // ... and `await feedback.flush()` once before it exits
 // or the electron main process drives `enqueue` straight from its
-// kipFeedback IPC.
+// kipFeedback IPC. postArenaVerdict() is the sibling one-shot for an arena
+// A/B verdict (the electron kipArena IPC).
 //
 // Rules (from the epic):
 //   - kip provider only — enqueue() and flush() no-op otherwise (checked
@@ -81,6 +82,35 @@ async function postFeedback (signal, { vaultRoot, fetchImpl, logger = console } 
   return { ok: await postBody(target, clean, doFetch, debugWith(logger)) }
 }
 
+const ARENA_WINNERS = new Set(['a', 'b', 'tie', 'skip'])
+
+/**
+ * One-shot: POST a verdict on an arena comparison (kip-app#73). For the
+ * electron main process's kipArena IPC. `winner` must be "a" | "b" | "tie" |
+ * "skip"; anything else, a blank arenaId, or a non-kip provider resolves
+ * { ok: false } without a request. Never throws.
+ */
+async function postArenaVerdict (arenaId, winner, { vaultRoot, fetchImpl, logger = console } = {}) {
+  if (typeof arenaId !== 'string' || !arenaId) return { ok: false }
+  if (!ARENA_WINNERS.has(winner)) return { ok: false }
+  const target = preferenceSignalsTarget(vaultRoot)
+  if (!target) return { ok: false }
+  const doFetch = fetchImpl || ((...a) => fetch(...a))
+  const debug = debugWith(logger)
+  try {
+    const res = await doFetch(`${target.baseUrl}/v1/arena/${encodeURIComponent(arenaId)}/verdict`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${target.apiKey}` },
+      body: JSON.stringify({ winner })
+    })
+    if (res && !res.ok) debug(`${res.status} for arena verdict`)
+    return { ok: !!(res && res.ok) }
+  } catch (err) {
+    debug((err && err.message) || String(err))
+    return { ok: false }
+  }
+}
+
 function createFeedbackPoster ({
   vaultRoot,
   fetchImpl,
@@ -155,4 +185,4 @@ function installFeedbackPoster (opts = {}) {
   return poster
 }
 
-module.exports = { createFeedbackPoster, installFeedbackPoster, postFeedback, sanitizeSignal }
+module.exports = { createFeedbackPoster, installFeedbackPoster, postFeedback, postArenaVerdict, sanitizeSignal }

--- a/scripts/lib/kip-connector.js
+++ b/scripts/lib/kip-connector.js
@@ -20,6 +20,12 @@
 //   errors: 401 bad key · 402 plan/budget · 429 rate limit · 5xx upstream,
 //           OpenAI-shaped { error: { message, type, code } }.
 //   testConnection() uses GET {baseUrl}/v1/usage — auth-only, not routed.
+//
+//   Arena (kip-app#73): a call carrying call.arena goes to
+//   POST {baseUrl}/v1/arena/completions instead, with an optional
+//   compare_to_call_id (regen free-rider — only B is run). Response:
+//   { arena_id, origin, b{…completion, kip_call_id}, a? }; a later verdict
+//   goes to POST {baseUrl}/v1/arena/<arena_id>/verdict (see feedback-poster.js).
 
 const CONNECTOR_API = 1
 const DEFAULT_BASE_URL = 'https://api.kip-ai.be'
@@ -65,8 +71,7 @@ function networkError (url, err) {
   return e
 }
 
-async function post (baseUrl, apiKey, body, headers, doFetch, signal) {
-  const url = `${baseUrl.replace(/\/+$/, '')}/v1/chat/completions`
+async function postJson (url, apiKey, body, headers, doFetch, signal) {
   let res
   try {
     res = await doFetch(url, {
@@ -93,13 +98,37 @@ async function post (baseUrl, apiKey, body, headers, doFetch, signal) {
     err.status = res.status
     throw err
   }
-  // The backend tags every completion with a call id; every later preference
-  // signal (rating / behaviour / arena verdict) references it. See kip-app#73.
-  const callId = (res.headers && typeof res.headers.get === 'function' && res.headers.get('x-kip-call-id')) || null
-  return { data: await res.json(), callId }
+  return res
 }
 
-/** The connector's complete(): one backend call, returns { text, raw, callId }. */
+const header = (res, name) =>
+  (res && res.headers && typeof res.headers.get === 'function' && res.headers.get(name)) || null
+
+async function post (baseUrl, apiKey, body, headers, doFetch, signal) {
+  const url = `${baseUrl.replace(/\/+$/, '')}/v1/chat/completions`
+  const res = await postJson(url, apiKey, body, headers, doFetch, signal)
+  // The backend tags every completion with a call id; every later preference
+  // signal (rating / behaviour / arena verdict) references it. See kip-app#73.
+  return { data: await res.json(), callId: header(res, 'x-kip-call-id') }
+}
+
+/** POST {baseUrl}/v1/arena/completions — runs B (and A, unless compare_to_call_id
+ *  names an existing call) and returns the pair for a later verdict. See
+ *  kip-app#73 and KIP-BACKEND.md §3.5. Body: { arena_id, origin, b{…,kip_call_id},
+ *  a? }. The header X-Kip-Arena-Id mirrors body.arena_id. */
+async function postArena (baseUrl, apiKey, body, headers, doFetch, signal) {
+  const url = `${baseUrl.replace(/\/+$/, '')}/v1/arena/completions`
+  const res = await postJson(url, apiKey, body, headers, doFetch, signal)
+  const data = await res.json()
+  return { data, arenaId: data.arena_id || header(res, 'x-kip-arena-id') }
+}
+
+const completionText = (c) =>
+  (c && c.choices && c.choices[0] && c.choices[0].message && c.choices[0].message.content) || ''
+
+/** The connector's complete(): one backend call, returns
+ *  { text, raw, callId, arenaId }. `arenaId` is null unless call.arena asked
+ *  for an arena comparison (see kip-app#73). */
 async function callBackend (resolved, call, ctx) {
   const doFetch = (ctx && ctx.fetch) || fetch
   const signal = ctx && ctx.signal
@@ -118,6 +147,22 @@ async function callBackend (resolved, call, ctx) {
     messages: buildMessages(call.system, call.prompt)
   }
 
+  // Arena: run this call as candidate B against an existing answer (regen
+  // free-rider — kip-app#73). Text-only; the Peck answer call is the only
+  // caller and it isn't a JSON call.
+  if (call.arena) {
+    const arenaBody = { ...base }
+    if (call.arena.compareToCallId) arenaBody.compare_to_call_id = call.arena.compareToCallId
+    const { data, arenaId } = await postArena(baseUrl, resolved.apiKey, arenaBody, routingHeaders, doFetch, signal)
+    const b = data.b || {}
+    return {
+      text: String(completionText(b)).trim(),
+      raw: b,
+      callId: b.kip_call_id || null,
+      arenaId: arenaId || null
+    }
+  }
+
   let data, callId
   if (call.json) {
     try {
@@ -133,8 +178,8 @@ async function callBackend (resolved, call, ctx) {
     ({ data, callId } = await post(baseUrl, resolved.apiKey, base, routingHeaders, doFetch, signal))
   }
 
-  const raw = (data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content) || ''
-  return { text: call.json ? stripCodeFences(raw) : String(raw).trim(), raw: data, callId: callId || null }
+  const raw = completionText(data)
+  return { text: call.json ? stripCodeFences(raw) : String(raw).trim(), raw: data, callId: callId || null, arenaId: null }
 }
 
 /** GET {baseUrl}/v1/usage — auth-only, not routed, not plan-checked. The
@@ -216,5 +261,5 @@ module.exports = {
   },
 
   // exported for tests
-  _internals: { phaseOf, networkError, DEFAULT_BASE_URL }
+  _internals: { phaseOf, networkError, postArena, DEFAULT_BASE_URL }
 }

--- a/scripts/lib/llm.js
+++ b/scripts/lib/llm.js
@@ -126,9 +126,15 @@ function assertConfigured (spec, resolved) {
 /**
  * The one entry point every caller uses. Routes to the connector named by
  * coop/.henhouse/llm.json / the PROVIDER env var (default "anthropic");
- * always resolves to the same shape: { text, raw, callId }. `callId` is the
- * managed backend's per-call id — set only by the kip connector, null for
- * every other provider — and is what preference signals reference (kip-app#73).
+ * always resolves to the same shape: { text, raw, callId, arenaId }. `callId`
+ * is the managed backend's per-call id — set only by the kip connector, null
+ * for every other provider — and is what preference signals reference
+ * (kip-app#73). `arenaId` is set only when `arena` was passed and the kip
+ * connector ran an A/B comparison — null otherwise.
+ *
+ * `arena` (optional): { compareToCallId } routes the call through the managed
+ * backend's arena endpoint as candidate B against an existing answer (the
+ * regenerate free-rider). Ignored by every non-kip connector.
  *
  * `overrides` (optional, second arg) is for tests only — real callers never
  * pass it: { AnthropicClient } to replace the Anthropic SDK class,
@@ -138,7 +144,7 @@ function assertConfigured (spec, resolved) {
  * `label` (optional) tags the call in scripts/lib/telemetry.js — e.g.
  * "hatch:propose", "hatch:generate:entity", "peck:answer".
  */
-async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label }, overrides = {}) {
+async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label, arena = null }, overrides = {}) {
   const vaultRoot = overrides.vaultRoot || DEFAULT_VAULT_ROOT
   const { spec, resolved } = resolveActive(vaultRoot, {
     anthropicClient: overrides.AnthropicClient,
@@ -146,7 +152,7 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label 
   })
   assertConfigured(spec, resolved)
 
-  const call = { system, prompt, json, maxTokens, label: label || null }
+  const call = { system, prompt, json, maxTokens, label: label || null, arena: arena || null }
   const ctx = {
     fetch: overrides.fetchImpl || fetch,
     signal: overrides.signal,
@@ -162,6 +168,7 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label 
   try {
     const result = await spec.complete(resolved, call, ctx)
     const callId = (result && result.callId) || null
+    const arenaId = (result && result.arenaId) || null
 
     const usage = extractUsage(result.raw)
     const reasoning = extractReasoning(result.raw)
@@ -172,6 +179,7 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label 
       ...common,
       model: realModel,
       callId,
+      arenaId,
       ms: Date.now() - started,
       ok: true,
       systemChars: (system || '').length,
@@ -185,7 +193,7 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label 
       responseText: result.text,
       reasoning
     })
-    return { ...result, callId }
+    return { ...result, callId, arenaId }
   } catch (err) {
     telemetry.record({
       ...common,

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -134,7 +134,7 @@ async function fileAnswerToNest (question, answer, candidateSlugs, vaultRoot = D
  * can call them mid-answer — `steps` records what it ran. Skill discovery and
  * the whole tool loop are best-effort: a failure downgrades to a plain answer.
  */
-async function answerFromPages (question, pages, { fileToNest, vaultRoot }) {
+async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena = null }) {
   const candidateSlugs = pages.map((p) => p.slug)
   const telemetryStart = telemetry.entries().length
 
@@ -147,7 +147,12 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot }) {
 
   let answer
   let steps = []
-  if (skills.length) {
+  if (arena) {
+    // A regenerate free-rider (kip-app#73): plain answer only. Skills add
+    // per-run variance that would muddy a model-vs-model comparison, and a
+    // regen is "answer this again, differently" — not "re-run the tool loop".
+    answer = await answerQuestion(question, pages, vaultRoot, { arena })
+  } else if (skills.length) {
     try {
       ({ answer, steps } = await answerQuestionWithSkills(question, pages, skills, vaultRoot))
     } catch (err) {
@@ -163,21 +168,24 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot }) {
   if (fileToNest) {
     await fileAnswerToNest(question, answer, candidateSlugs, vaultRoot)
   }
-  // The managed backend's id for the answer call, so the app can attach a
-  // preference signal (👍/👎, "was the regen better?") to it. null for every
-  // other provider. Read from telemetry (which already records callId per
-  // PR kip-app#73) rather than threaded through answerQuestion's string
-  // return — bounded to the calls THIS invocation just made.
-  return { answer, citedSlugs, candidateSlugs, steps, callId: answerCallIdSince(telemetryStart) }
+  // The managed backend's ids for the answer call, so the app can attach a
+  // preference signal (👍/👎, "was the regen better?") to it. Both null for
+  // every other provider. Read from telemetry (which already records callId /
+  // arenaId per PR kip-app#73) rather than threaded through answerQuestion's
+  // string return — bounded to the calls THIS invocation just made.
+  const { callId, arenaId } = answerCallSince(telemetryStart)
+  return { answer, citedSlugs, candidateSlugs, steps, callId, arenaId }
 }
 
-/** callId of the newest peck:answer* call at or after `startIdx` in telemetry, else null. */
-function answerCallIdSince (startIdx) {
+/** callId + arenaId of the newest peck:answer* call at or after `startIdx`. */
+function answerCallSince (startIdx) {
   const es = telemetry.entries()
   for (let i = es.length - 1; i >= startIdx; i--) {
-    if (es[i].callId && /^peck:answer/.test(es[i].label || '')) return es[i].callId
+    if (/^peck:answer/.test(es[i].label || '') && (es[i].callId || es[i].arenaId)) {
+      return { callId: es[i].callId || null, arenaId: es[i].arenaId || null }
+    }
   }
-  return null
+  return { callId: null, arenaId: null }
 }
 
 /**
@@ -220,15 +228,20 @@ function fileCapturedFacts (proposedPages, vaultRoot = DEFAULT_VAULT_ROOT) {
  * afterward (e.g. after an interactive y/n prompt). fileToNest:true does the
  * whole transaction — search, answer, file, log — in one call.
  *
- * @returns {{answer: string|null, citedSlugs: string[], candidateSlugs: string[], steps: Array, callId: string|null}}
+ * `arenaCompareToCallId` (optional): the callId of an earlier answer to this
+ * same question — routes the answer call through the managed backend's arena
+ * as candidate B (the regenerate free-rider, kip-app#73).
+ *
+ * @returns {{answer: string|null, citedSlugs: string[], candidateSlugs: string[], steps: Array, callId: string|null, arenaId: string|null}}
  */
-async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_VAULT_ROOT } = {}) {
+async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_VAULT_ROOT, arenaCompareToCallId = null } = {}) {
   const candidates = await retrieveCandidates(question, vaultRoot)
   if (candidates.length === 0 && !anySkills(vaultRoot)) {
     return { answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
   }
   const pages = readPageBodies(vaultRoot, candidates)
-  return answerFromPages(question, pages, { fileToNest, vaultRoot })
+  const arena = arenaCompareToCallId ? { compareToCallId: arenaCompareToCallId } : null
+  return answerFromPages(question, pages, { fileToNest, vaultRoot, arena })
 }
 
 /**
@@ -243,7 +256,7 @@ async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_V
  *              shape as question; the `reminders` skill did the work and its
  *              confirmation is in `answer`.
  */
-async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = false } = {}) {
+async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = false, arenaCompareToCallId = null } = {}) {
   // An upcoming event the user wants reminding about ("I have a meeting Friday
   // at 15h", "remind me to …") — route to the skills path (the `reminders`
   // skill creates it), NOT fact-capture, which would file it as a nest page.
@@ -268,7 +281,8 @@ async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = f
   if (pages.length === 0 && !anySkills(vaultRoot)) {
     return { intent: 'question', answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
   }
-  return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot })) }
+  const arena = arenaCompareToCallId ? { compareToCallId: arenaCompareToCallId } : null
+  return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena })) }
 }
 
 module.exports = { askQuestion, peckTurn, classifyPeckInput, fileAnswerToNest, fileCapturedFacts, extractCitedSlugs }

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -34,10 +34,13 @@ Answer using ONLY the information in these pages — do not use outside knowledg
 
 Cite every claim back to the specific page it came from using Logseq's wikilink syntax: [[exact-page-slug]], using the exact slug shown in each "### Page: <slug>" heading. Prefer citing inline, next to the claim it supports, over a single list of links at the end.`
 
-/** Answers a question against a set of candidate wiki pages, with [[slug]] citations. */
-async function answerQuestion (question, pages, vaultRoot) {
+/** Answers a question against a set of candidate wiki pages, with [[slug]]
+ *  citations. `arena` (optional): { compareToCallId } runs this as arena
+ *  candidate B against an earlier answer — the regenerate free-rider
+ *  (kip-app#73). Only meaningful on the managed kip connector. */
+async function answerQuestion (question, pages, vaultRoot, { arena = null } = {}) {
   const prompt = `${formatPagesForPrompt(pages)}\n\n---\n\nQuestion: ${question}`
-  const { text } = await callLLM({ system: ANSWER_SYSTEM_PROMPT, prompt, maxTokens: 4096, label: 'peck:answer' }, { vaultRoot })
+  const { text } = await callLLM({ system: ANSWER_SYSTEM_PROMPT, prompt, maxTokens: 4096, label: 'peck:answer', arena }, { vaultRoot })
   return text
 }
 

--- a/scripts/test/feedback-poster.test.js
+++ b/scripts/test/feedback-poster.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
 
-const { createFeedbackPoster, postFeedback, sanitizeSignal } = require('../lib/feedback-poster')
+const { createFeedbackPoster, postFeedback, postArenaVerdict, sanitizeSignal } = require('../lib/feedback-poster')
 
 const EMPTY_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'feedback-poster-test-'))
 test.after(() => fs.rmSync(EMPTY_VAULT, { recursive: true, force: true }))
@@ -140,6 +140,39 @@ test('postFeedback: { ok: false } and no request when not kip / malformed / netw
   await withEnv(KIP_ENV, async () => {
     const bad = recordingFetch({ reject: true })
     assert.deepEqual(await postFeedback({ call_id: 'c', kind: 'behavior', behavior: 'accepted' }, { vaultRoot: EMPTY_VAULT, fetchImpl: bad.impl, logger: { debug () {} } }), { ok: false })
+  })
+})
+
+test('postArenaVerdict: POSTs { winner } to /v1/arena/<id>/verdict for the kip provider', async () => {
+  await withEnv(KIP_ENV, async () => {
+    const { impl, calls } = recordingFetch()
+    const r = await postArenaVerdict('arena_7', 'b', { vaultRoot: EMPTY_VAULT, fetchImpl: impl })
+    assert.deepEqual(r, { ok: true })
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].url, 'http://lan.test:3000/v1/arena/arena_7/verdict')
+    assert.equal(calls[0].init.headers.Authorization, 'Bearer kip_test')
+    assert.deepEqual(calls[0].body, { winner: 'b' })
+  })
+})
+
+test('postArenaVerdict: { ok: false } and no request for a bad winner / blank id / non-kip', async () => {
+  const { impl, calls } = recordingFetch()
+  await withEnv(KIP_ENV, async () => {
+    assert.deepEqual(await postArenaVerdict('arena_7', 'best', { vaultRoot: EMPTY_VAULT, fetchImpl: impl }), { ok: false })
+    assert.deepEqual(await postArenaVerdict('', 'a', { vaultRoot: EMPTY_VAULT, fetchImpl: impl }), { ok: false })
+  })
+  await withEnv({ PROVIDER: 'anthropic' }, async () => {
+    assert.deepEqual(await postArenaVerdict('arena_7', 'a', { vaultRoot: EMPTY_VAULT, fetchImpl: impl }), { ok: false })
+  })
+  assert.equal(calls.length, 0)
+})
+
+test('postArenaVerdict: a network failure is swallowed', async () => {
+  await withEnv(KIP_ENV, async () => {
+    const bad = recordingFetch({ reject: true })
+    assert.deepEqual(
+      await postArenaVerdict('arena_7', 'tie', { vaultRoot: EMPTY_VAULT, fetchImpl: bad.impl, logger: { debug () {} } }),
+      { ok: false })
   })
 })
 

--- a/scripts/test/kip-connector.test.js
+++ b/scripts/test/kip-connector.test.js
@@ -88,6 +88,47 @@ test('complete json:true: callId survives the prompt-and-strip 400 retry', async
   assert.equal(res.callId, 'call_retry')
 })
 
+test('complete: non-arena calls report arenaId: null', async () => {
+  const { impl } = fakeFetch(reply('hi'))
+  const res = await kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10 }, { fetch: impl })
+  assert.equal(res.arenaId, null)
+})
+
+test('complete arena: routes to /v1/arena/completions with compare_to_call_id', async () => {
+  const arenaBody = {
+    arena_id: 'arena_9',
+    origin: 'regen',
+    b: { ...reply('the regenerated answer'), kip_call_id: 'call_B' }
+  }
+  const { impl, last } = fakeFetch(arenaBody, { resHeaders: { 'x-kip-arena-id': 'arena_9' } })
+  const res = await kip.complete(RESOLVED,
+    { system: 'sys', prompt: 'q', maxTokens: 4096, label: 'peck:answer', arena: { compareToCallId: 'call_A' } },
+    { fetch: impl })
+
+  assert.equal(last().url, 'http://lan.test:8080/v1/arena/completions')
+  assert.equal(last().body.compare_to_call_id, 'call_A')
+  assert.equal(last().body.model, 'auto')
+  assert.equal(last().headers['X-Kip-Workload'], 'peck:answer')
+  assert.equal(res.text, 'the regenerated answer')
+  assert.equal(res.callId, 'call_B', 'callId is candidate B\'s own kip_call_id')
+  assert.equal(res.arenaId, 'arena_9')
+})
+
+test('complete arena: arenaId falls back to the X-Kip-Arena-Id header', async () => {
+  const arenaBody = { origin: 'regen', b: { ...reply('x'), kip_call_id: 'call_B' } } // no arena_id in body
+  const { impl } = fakeFetch(arenaBody, { resHeaders: { 'x-kip-arena-id': 'arena_hdr' } })
+  const res = await kip.complete(RESOLVED,
+    { prompt: 'q', maxTokens: 10, arena: { compareToCallId: 'call_A' } }, { fetch: impl })
+  assert.equal(res.arenaId, 'arena_hdr')
+})
+
+test('complete arena: a plan-check failure throws like any other backend error', async () => {
+  const { impl } = fakeFetch({ error: { message: 'plan limit reached' } }, { ok: false, status: 402 })
+  await assert.rejects(
+    kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10, arena: { compareToCallId: 'call_A' } }, { fetch: impl }),
+    /402.*plan limit/)
+})
+
 test('complete: no label -> no routing headers', async () => {
   const { impl, last } = fakeFetch(reply('ok'))
   await kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10 }, { fetch: impl })

--- a/scripts/test/llm.test.js
+++ b/scripts/test/llm.test.js
@@ -374,6 +374,37 @@ test('callLLM: "kip" provider routes through the managed backend with routing he
   })
 })
 
+test('callLLM: arena regen threads arenaId + B\'s callId through and records them', async () => {
+  await withEnv({ PROVIDER: 'kip', KIP_API_KEY: 'kip_env', KIP_BASE_URL: 'http://lan.test:8080' }, async () => {
+    telemetry.reset()
+    const { impl, getLastCall } = fakeFetch(
+      { arena_id: 'arena_42', origin: 'regen',
+        b: { model: 'gpt-4o', choices: [{ message: { content: 'B answer' } }], kip_call_id: 'call_B' } },
+      { resHeaders: { 'x-kip-arena-id': 'arena_42' } })
+    const result = await callLLM(
+      { system: 's', prompt: 'p', label: 'peck:answer', arena: { compareToCallId: 'call_A' } },
+      { fetchImpl: impl, vaultRoot: EMPTY_VAULT })
+
+    assert.equal(getLastCall().url, 'http://lan.test:8080/v1/arena/completions')
+    assert.equal(JSON.parse(getLastCall().init.body).compare_to_call_id, 'call_A')
+    assert.equal(result.text, 'B answer')
+    assert.equal(result.callId, 'call_B')
+    assert.equal(result.arenaId, 'arena_42')
+
+    const e = telemetry.entries().at(-1)
+    assert.equal(e.callId, 'call_B')
+    assert.equal(e.arenaId, 'arena_42')
+  })
+})
+
+test('callLLM: a normal call reports arenaId: null', async () => {
+  await withEnv({ PROVIDER: 'local', LOCAL_MODEL: 'llama3.1' }, async () => {
+    const { impl } = fakeFetch({ choices: [{ message: { content: 'x' } }] })
+    const result = await callLLM({ system: 's', prompt: 'p' }, { fetchImpl: impl, vaultRoot: EMPTY_VAULT })
+    assert.equal(result.arenaId, null)
+  })
+})
+
 test('callLLM: "kip" provider needs a key', async () => {
   await withEnv({ PROVIDER: 'kip', KIP_API_KEY: undefined }, async () => {
     await assert.rejects(() => callLLM({ system: 's', prompt: 'p' }, { vaultRoot: EMPTY_VAULT }), /KIP_API_KEY/)

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -395,6 +395,50 @@ test('peckTurn — a question carries the managed backend callId (null for other
   } finally { s.restore() }
 })
 
+test('peckTurn — a regenerate (arenaCompareToCallId) routes the answer through the arena', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  writePage(root, 'concepts', 'sleep', { type: 'concept', body: 'notes on sleep' })
+  rebuildRoost(root)
+
+  const original = global.fetch
+  t.after(() => { global.fetch = original })
+
+  saveLLMConfig({ provider: 'kip', providers: { kip: { apiKey: 'kip_x', baseUrl: 'http://lan.test:3000' } } }, root)
+  let arenaCall = null
+  global.fetch = async (url, init) => {
+    const body = JSON.parse(init.body)
+    if (/\/v1\/arena\/completions$/.test(url)) {
+      arenaCall = { url, body }
+      return {
+        ok: true, status: 200,
+        headers: new Headers({ 'x-kip-arena-id': 'arena_1' }),
+        json: async () => ({
+          arena_id: 'arena_1', origin: 'regen',
+          b: { choices: [{ message: { content: 'A better take, per [[sleep]].' }, finish_reason: 'stop' }], kip_call_id: 'call_B' }
+        })
+      }
+    }
+    // key-terms call still goes to /v1/chat/completions
+    return { ok: true, status: 200, headers: new Headers({ 'x-kip-call-id': 'call_terms' }), json: async () => ({ choices: [{ message: { content: '{"terms":["sleep"]}' }, finish_reason: 'stop' }] }) }
+  }
+
+  const r = await peckTurn('what about sleep?', { vaultRoot: root, arenaCompareToCallId: 'call_A' })
+  assert.equal(r.intent, 'question')
+  assert.equal(r.answer, 'A better take, per [[sleep]].')
+  assert.equal(r.arenaId, 'arena_1')
+  assert.equal(r.callId, 'call_B', 'callId is the regenerated answer\'s own id')
+  assert.ok(arenaCall, 'the answer call went to /v1/arena/completions')
+  assert.equal(arenaCall.body.compare_to_call_id, 'call_A')
+
+  // no arenaCompareToCallId -> normal path, arenaId null
+  const s = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep]], rest.' })
+  try {
+    const r2 = await peckTurn('what about sleep?', { vaultRoot: root })
+    assert.equal(r2.arenaId, null, 'no arena on a plain turn')
+  } finally { s.restore() }
+})
+
 test('peckTurn — an upcoming-event statement routes to the reminders skill, not fact capture', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))


### PR DESCRIPTION
The retrieval-layer half of the arena (epic kip-app#73). A Peck regenerate on the managed backend re-answers the question as arena candidate **B** against the first answer — the backend gets a blind A/B pair from an action the user already takes.

## Changes

- **`kip-connector.js`** — a call carrying `arena: { compareToCallId }` POSTs to `/v1/arena/completions` with `compare_to_call_id` (B only runs). Parses `{ arena_id, origin, b:{…,kip_call_id}, a? }`; returns B's text, `callId = b.kip_call_id`, `arenaId` (body `arena_id` or the `X-Kip-Arena-Id` header). `postJson` extracted so both endpoints share the network + error handling.
- **`llm.js`** — `callLLM` takes `arena` in the call opts, threads `arenaId` out and into telemetry. Return shape is now `{ text, raw, callId, arenaId }`.
- **`prompts.js`** — `answerQuestion` takes optional `{ arena }`.
- **`peck.js`** — `arenaCompareToCallId` on `askQuestion` / `peckTurn`. `answerFromPages` uses the plain `answerQuestion` path when arena is set (skills add per-run variance that muddies a model-vs-model comparison). Turn result carries `arenaId`.
- **`chat.js`** — `--arena-compare-to <callId>` flag.
- **`feedback-poster.js`** — `postArenaVerdict(arenaId, winner, { vaultRoot })`: one-shot POST to `/v1/arena/<id>/verdict`, `winner ∈ a|b|tie|skip`, kip-only, swallows network errors. For the app's `:kipArena` IPC (next PR).

## Verification

Backend contract confirmed deployed (kip-backend `feat/preference-signals` on the LAN test box). Suite **239/239**, 0 failures — new arena cases in `kip-connector.test.js`, `llm.test.js`, `peck.test.js`, `feedback-poster.test.js`.

## Next

kip-app PR: `:kipArena` IPC + `wikiChat` passes `--arena-compare-to` on a managed-backend regenerate + the "was this better? ← A / B →" verdict strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)