### PR TITLE
Calendar: ICS subscriptions → reminders (kip-app#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to Kip. Format loosely follows
 The retrieval layer (this repo) and the desktop app
 ([kip-app](https://github.com/JWE24-code/kip-app)) are released together.
 
+## [Unreleased]
+
+### The retrieval layer (`scripts/`)
+
+- **Calendar subscriptions** (kip-app#70) — `scripts/calendar.js` subscribes
+  to a live ICS / `webcal://` feed (Google / Outlook / Fastmail "secret iCal
+  address"). `lib/calendar.js` fetches and parses it (RFC 5545 via `ical.js`,
+  a zero-dependency parser), expands recurrences to a rolling 14-day window,
+  and reconciles the upcoming events into `reminders.json` as
+  `source: "calendar"` rows — so each one gets the same nest-retrieval prep
+  brief and lead-time notification a hand-typed reminder does. `CANCELLED`,
+  past, and `EXDATE` occurrences are dropped; an event that moves is updated
+  in place; one that vanishes has its still-pending reminder pruned.
+  Subscriptions live in `<graph>/.henhouse/calendars.json` (ICS URLs are
+  bearer secrets). New dependency: `ical.js`.
+
 ## [0.3.7] — 2026-08-30
 
 ### The retrieval layer (`scripts/`)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -247,6 +247,31 @@ update-don't-duplicate routing are all tested in
 `scripts/test/peck.test.js` against a mocked LLM (`PROVIDER=local` + a
 mocked `fetch`).
 
+#### `calendar.js` — ICS subscriptions → reminders (kip-app#70)
+
+```powershell
+node scripts/calendar.js add https://calendar.google.com/…/basic.ics --label Work --lead 15
+node scripts/calendar.js list
+node scripts/calendar.js sync --json     # fetch every feed, reconcile into reminders.json
+node scripts/calendar.js remove 1        # / enable 1 / disable 1
+```
+
+The **ingestion** side of calendar integration — the scheduling / prep /
+notification half is `reminders.js`, untouched. `lib/calendar.js`:
+`fetchIcs` (accepts `webcal://`), `parseCalendar` (RFC 5545 via `ical.js`,
+a zero-dependency pure-JS parser — recurrences expanded to a rolling
+14-day window, `CANCELLED` / past / `EXDATE` occurrences dropped),
+`refreshCalendars` (fetch all enabled feeds, rewrite
+`.roost/calendar-events.json`, record `lastError` per feed), and
+`syncCalendarReminders` (reconcile the cache into `reminders.json` as
+`source: "calendar"` rows — one per upcoming event, updated in place on a
+time change, pruned when the event vanishes; hand-typed and already-fired
+reminders are never touched). Subscriptions live in
+`<graph>/.henhouse/calendars.json` (ICS URLs are bearer secrets, kept out
+of the graph). The app's `electron.calendar` runs `sync` every 20 min;
+`electron.reminders` then fires the calendar rows like any other. Tested
+in `scripts/test/calendar.test.js` (fixture ICS + a mocked `fetch`).
+
 ##### Skills — Peck's tool loop
 
 When answering a **question**, if the graph has any enabled **skill**, the

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "kip",
       "version": "0.1.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.70.0",
         "better-sqlite3": "^12.11.1",
@@ -16,6 +17,7 @@
         "dotenv": "^16.4.5",
         "edn-data": "^1.2.2",
         "gray-matter": "^4.0.3",
+        "ical.js": "^2.2.1",
         "pizzip": "^3.1.7",
         "pptx-automizer": "^0.7.2",
         "pptxgenjs": "^3.12.0",
@@ -1014,6 +1016,12 @@
       "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
       "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
       "license": "ISC"
+    },
+    "node_modules/ical.js": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
+      "integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==",
+      "license": "MPL-2.0"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "peck": "node scripts/peck.js",
     "groom": "node scripts/groom.js",
     "hatch": "node scripts/hatch.js",
-    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/preference-signals.test.js scripts/test/feedback-poster.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js"
+    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/preference-signals.test.js scripts/test/feedback-poster.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js scripts/test/calendar.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.70.0",
@@ -20,6 +20,7 @@
     "dotenv": "^16.4.5",
     "edn-data": "^1.2.2",
     "gray-matter": "^4.0.3",
+    "ical.js": "^2.2.1",
     "pizzip": "^3.1.7",
     "pptx-automizer": "^0.7.2",
     "pptxgenjs": "^3.12.0",

--- a/scripts/calendar.js
+++ b/scripts/calendar.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Calendar CLI (kip-app#70) — the ingestion side of calendar integration.
+// Subscribe to a live ICS feed; Kip expands upcoming events into the same
+// reminders pipeline that a hand-typed reminder uses (prep brief from the
+// nest + a lead-time notification).
+//
+//   node scripts/calendar.js add <ics-url> [--label "Work"] [--lead 15] [--refresh 30] [--json]
+//   node scripts/calendar.js list [--json]
+//   node scripts/calendar.js remove <id>
+//   node scripts/calendar.js enable <id> | disable <id>
+//   node scripts/calendar.js refresh [--json]   # fetch every feed, rebuild the cache
+//   node scripts/calendar.js sync [--json]      # refresh, then reconcile into reminders.json
+//
+// Storage: <coop>/.henhouse/calendars.json (the subscription list — ICS URLs
+// are bearer secrets), <coop>/.roost/calendar-events.json (the event cache).
+// KIP_COOP_ROOT points at the open graph, as with every bundled script.
+require('dotenv').config()
+
+const { DEFAULT_VAULT_ROOT } = require('./lib/paths')
+const {
+  addCalendar, removeCalendar, setCalendarEnabled, loadCalendars,
+  loadCachedEvents, refreshCalendars, syncCalendarReminders
+} = require('./lib/calendar')
+
+const argv = process.argv.slice(2)
+const has = (f) => argv.includes(f)
+const flagVal = (f) => { const i = argv.indexOf(f); return i >= 0 ? argv[i + 1] : undefined }
+const FLAGS_WITH_VALUES = new Set(['--label', '--lead', '--refresh'])
+const positionals = argv.filter((a, i) => !a.startsWith('--') && !FLAGS_WITH_VALUES.has(argv[i - 1]))
+const asJson = has('--json')
+
+function out (obj, human) {
+  if (asJson) console.log(JSON.stringify(obj))
+  else console.log(human)
+}
+
+const fmtEventLine = (e) =>
+  `${new Date(e.start).toLocaleString()}  ${e.title}${e.calLabel ? `  · ${e.calLabel}` : ''}`
+
+async function main () {
+  const root = DEFAULT_VAULT_ROOT
+  const cmd = positionals[0] || 'list'
+
+  if (cmd === 'add') {
+    const url = positionals[1]
+    if (!url) { console.error('usage: calendar.js add <ics-url> [--label ..] [--lead 15] [--refresh 30]'); process.exitCode = 1; return }
+    const row = addCalendar(root, {
+      url, label: flagVal('--label'), leadMin: flagVal('--lead'), refreshMin: flagVal('--refresh')
+    })
+    out({ calendar: row }, `Subscribed to "${row.label}" (#${row.id}) — ${row.leadMin} min lead, refresh every ${row.refreshMin} min.`)
+    return
+  }
+
+  if (cmd === 'remove') {
+    const id = positionals[1]
+    const gone = removeCalendar(root, id)
+    out({ removed: !!gone }, gone ? `Removed calendar #${id}.` : `No calendar #${id}.`)
+    if (!gone) process.exitCode = 1
+    return
+  }
+
+  if (cmd === 'enable' || cmd === 'disable') {
+    const id = positionals[1]
+    const row = setCalendarEnabled(root, id, cmd === 'enable')
+    out({ calendar: row || null }, row ? `${cmd === 'enable' ? 'Enabled' : 'Disabled'} "${row.label}".` : `No calendar #${id}.`)
+    if (!row) process.exitCode = 1
+    return
+  }
+
+  if (cmd === 'refresh' || cmd === 'sync') {
+    const res = await refreshCalendars(root)
+    let reconciled = null
+    if (cmd === 'sync') reconciled = syncCalendarReminders(root)
+    const cals = loadCalendars(root)
+    const errors = cals.filter((c) => c.lastError).map((c) => `${c.label}: ${c.lastError}`)
+    out(
+      { ...res, reconciled, errors },
+      [`Refreshed ${res.ok}/${res.calendars} calendars — ${res.events} events in the window.`,
+        reconciled && `Reminders: +${reconciled.added} ~${reconciled.updated} -${reconciled.removed}.`,
+        ...errors.map((e) => `  ⚠ ${e}`)].filter(Boolean).join('\n'))
+    return
+  }
+
+  // list
+  const cals = loadCalendars(root)
+  const events = loadCachedEvents(root)
+  out(
+    { calendars: cals, events },
+    (cals.length
+      ? cals.map((c) => `#${c.id}  ${c.label}  (${c.enabled === false ? 'disabled' : 'on'}, ${c.leadMin}m lead)` +
+          `${c.lastError ? `  ⚠ ${c.lastError}` : c.lastFetchedAt ? `  · last ${new Date(c.lastFetchedAt).toLocaleString()}` : ''}`).join('\n')
+      : 'No calendar subscriptions.') +
+    (events.length ? `\n\nUpcoming:\n${events.slice(0, 20).map(fmtEventLine).join('\n')}` : ''))
+}
+
+main().catch((err) => {
+  const msg = (err && err.message) || String(err)
+  if (asJson) {
+    // stay exit 0 so the caller (electron.wiki run-node-script!) gets the
+    // structured error instead of a bare "exited with code 1"
+    console.log(JSON.stringify({ error: msg }))
+  } else {
+    console.error(err.stack || msg)
+    process.exitCode = 1
+  }
+})

--- a/scripts/lib/calendar.js
+++ b/scripts/lib/calendar.js
@@ -1,0 +1,348 @@
+// Calendar ingestion (kip-app#70). Subscribe to a live ICS URL (Google /
+// Outlook / Fastmail "secret iCal address", any webcal:// feed); expand the
+// next-N-days window of events; hand them to the existing reminders pipeline
+// so each upcoming event gets the same nest-retrieval prep brief + lead-time
+// notification a hand-typed reminder does (scripts/lib/reminders.js).
+//
+// This module is the *ingestion* half only — fetch, parse, expand, store,
+// and reconcile into reminders.json. The scheduling / notification / prep
+// half already exists and is untouched.
+//
+// Storage:
+//   <coop>/.henhouse/calendars.json   the subscription list — ICS URLs are
+//                                      bearer secrets, kept out of the graph
+//   <coop>/.roost/calendar-events.json the expanded event cache (derived;
+//                                      a rebuild-roost may delete it)
+const fs = require('node:fs')
+const ICAL = require('ical.js')
+
+const { DEFAULT_VAULT_ROOT, calendarsConfigPath, calendarCachePath } = require('./paths')
+
+const DEFAULT_WINDOW_DAYS = 14
+const DEFAULT_REFRESH_MIN = 30
+const DEFAULT_LEAD_MIN = 15
+const MAX_EVENTS_PER_CAL = 250
+
+// ---------------------------------------------------------------------------
+// fetch
+// ---------------------------------------------------------------------------
+
+/** webcal:// (and webcals://) are just http(s) with a calendar MIME hint. */
+function normalizeIcsUrl (url) {
+  return String(url || '').trim()
+    .replace(/^webcals:\/\//i, 'https://')
+    .replace(/^webcal:\/\//i, 'https://')
+}
+
+/** GET an ICS feed, returning its text. Throws a readable error otherwise. */
+async function fetchIcs (url, { fetchImpl, signal } = {}) {
+  const doFetch = fetchImpl || ((...a) => fetch(...a))
+  const real = normalizeIcsUrl(url)
+  if (!/^https?:\/\//i.test(real)) throw new Error(`Not an http(s)/webcal URL: ${url}`)
+  let res
+  try {
+    res = await doFetch(real, { headers: { Accept: 'text/calendar, text/plain, */*' }, signal, redirect: 'follow' })
+  } catch (err) {
+    throw new Error(`Couldn't reach the calendar feed (${(err && err.message) || err}).`)
+  }
+  if (!res.ok) throw new Error(`The calendar feed returned ${res.status} ${res.statusText || ''}`.trim())
+  const text = await res.text()
+  if (!/BEGIN:VCALENDAR/i.test(text)) throw new Error('That URL did not return an iCalendar (.ics) feed.')
+  return text
+}
+
+// ---------------------------------------------------------------------------
+// parse + expand
+// ---------------------------------------------------------------------------
+
+const iso = (icalTime) => icalTime.toJSDate().toISOString()
+
+function attendeeNames (vevent) {
+  return vevent.getAllProperties('attendee').map((p) => {
+    const cn = p.getParameter('cn')
+    if (cn) return String(cn)
+    const v = String(p.getFirstValue() || '')
+    return v.replace(/^mailto:/i, '')
+  }).filter(Boolean)
+}
+
+function organizerName (vevent) {
+  const p = vevent.getFirstProperty('organizer')
+  if (!p) return ''
+  return String(p.getParameter('cn') || String(p.getFirstValue() || '').replace(/^mailto:/i, '') || '')
+}
+
+function normalizeOccurrence (event, vevent, startTime, endTime) {
+  return {
+    uid: String(event.uid || ''),
+    // recurrence instances share a uid — the start disambiguates them
+    id: `${event.uid || 'evt'}@${startTime.toString()}`,
+    title: String(event.summary || '').trim() || '(untitled event)',
+    start: iso(startTime),
+    end: iso(endTime),
+    allDay: !!(event.startDate && event.startDate.isDate),
+    location: String(event.location || '').trim(),
+    description: String(event.description || '').trim(),
+    organizer: organizerName(vevent),
+    attendees: attendeeNames(vevent),
+    status: String(vevent.getFirstPropertyValue('status') || '').toUpperCase() || null
+  }
+}
+
+/**
+ * Parse an ICS document and return the normalized event occurrences that
+ * overlap [now, now + windowDays]. Recurring events are expanded; cancelled
+ * occurrences and events with no usable start are dropped.
+ */
+function parseCalendar (icsText, { windowDays = DEFAULT_WINDOW_DAYS, now = new Date(), max = MAX_EVENTS_PER_CAL } = {}) {
+  const comp = new ICAL.Component(ICAL.parse(icsText))
+  const vevents = comp.getAllSubcomponents('vevent')
+
+  const rangeStart = ICAL.Time.fromJSDate(now, false)
+  const rangeEnd = ICAL.Time.fromJSDate(new Date(now.getTime() + windowDays * 86400000), false)
+
+  const out = []
+  for (const vevent of vevents) {
+    let event
+    try { event = new ICAL.Event(vevent) } catch { continue }
+    if (!event.startDate) continue
+    // a modified single instance (RECURRENCE-ID) is emitted by its parent's
+    // expansion — skip the standalone copy
+    if (event.isRecurrenceException()) continue
+
+    if (event.isRecurring()) {
+      let iter
+      try { iter = event.iterator() } catch { continue }
+      let next
+      while ((next = iter.next())) {
+        if (next.compare(rangeEnd) > 0) break
+        let occ
+        try { occ = event.getOccurrenceDetails(next) } catch { continue }
+        if (occ.endDate.compare(rangeStart) < 0) continue
+        const row = normalizeOccurrence(event, occ.item ? occ.item.component : vevent, occ.startDate, occ.endDate)
+        if (row.status !== 'CANCELLED') out.push(row)
+        if (out.length >= max) break
+      }
+    } else {
+      const endDate = event.endDate || event.startDate
+      if (endDate.compare(rangeStart) < 0 || event.startDate.compare(rangeEnd) > 0) continue
+      const row = normalizeOccurrence(event, vevent, event.startDate, endDate)
+      if (row.status !== 'CANCELLED') out.push(row)
+    }
+    if (out.length >= max) break
+  }
+  return out.sort((a, b) => new Date(a.start) - new Date(b.start))
+}
+
+// ---------------------------------------------------------------------------
+// subscription store  (<coop>/.henhouse/calendars.json)
+// ---------------------------------------------------------------------------
+
+/** { calendars: [ { id, url, label, leadMin, refreshMin, enabled,
+ *  lastFetchedAt, lastError } ] } — [] on any read problem. */
+function loadCalendars (vaultRoot = DEFAULT_VAULT_ROOT) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(calendarsConfigPath(vaultRoot), 'utf8'))
+    return Array.isArray(parsed && parsed.calendars) ? parsed.calendars : []
+  } catch {
+    return []
+  }
+}
+
+function saveCalendars (vaultRoot, calendars) {
+  const file = calendarsConfigPath(vaultRoot)
+  fs.mkdirSync(require('node:path').dirname(file), { recursive: true })
+  fs.writeFileSync(file, JSON.stringify({ calendars }, null, 2) + '\n')
+}
+
+function nextCalId (calendars) {
+  return calendars.reduce((max, c) => Math.max(max, Number(c.id) || 0), 0) + 1
+}
+
+function addCalendar (vaultRoot = DEFAULT_VAULT_ROOT, { url, label, leadMin, refreshMin } = {}) {
+  const real = normalizeIcsUrl(url)
+  if (!/^https?:\/\//i.test(real)) throw new Error('A calendar subscription needs an http(s):// or webcal:// URL.')
+  const calendars = loadCalendars(vaultRoot)
+  if (calendars.some((c) => normalizeIcsUrl(c.url) === real)) throw new Error('That calendar is already subscribed.')
+  const row = {
+    id: nextCalId(calendars),
+    url: String(url).trim(),
+    label: (label && String(label).trim()) || hostLabel(real),
+    leadMin: Number.isFinite(+leadMin) ? Math.max(0, Math.round(+leadMin)) : DEFAULT_LEAD_MIN,
+    refreshMin: Number.isFinite(+refreshMin) ? Math.max(5, Math.round(+refreshMin)) : DEFAULT_REFRESH_MIN,
+    enabled: true,
+    lastFetchedAt: null,
+    lastError: null
+  }
+  calendars.push(row)
+  saveCalendars(vaultRoot, calendars)
+  return row
+}
+
+function removeCalendar (vaultRoot = DEFAULT_VAULT_ROOT, id) {
+  const calendars = loadCalendars(vaultRoot)
+  const kept = calendars.filter((c) => String(c.id) !== String(id))
+  if (kept.length === calendars.length) return null
+  saveCalendars(vaultRoot, kept)
+  return { id }
+}
+
+function setCalendarEnabled (vaultRoot = DEFAULT_VAULT_ROOT, id, enabled) {
+  const calendars = loadCalendars(vaultRoot)
+  const row = calendars.find((c) => String(c.id) === String(id))
+  if (!row) return null
+  row.enabled = !!enabled
+  saveCalendars(vaultRoot, calendars)
+  return row
+}
+
+const hostLabel = (url) => {
+  try { return new URL(url).hostname.replace(/^www\./, '') } catch { return 'Calendar' }
+}
+
+// ---------------------------------------------------------------------------
+// event cache  (<coop>/.roost/calendar-events.json)
+// ---------------------------------------------------------------------------
+
+function loadCachedEvents (vaultRoot = DEFAULT_VAULT_ROOT) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(calendarCachePath(vaultRoot), 'utf8'))
+    return Array.isArray(parsed && parsed.events) ? parsed.events : []
+  } catch {
+    return []
+  }
+}
+
+function saveCachedEvents (vaultRoot, events) {
+  const file = calendarCachePath(vaultRoot)
+  fs.mkdirSync(require('node:path').dirname(file), { recursive: true })
+  fs.writeFileSync(file, JSON.stringify({ refreshedAt: new Date().toISOString(), events }, null, 2) + '\n')
+}
+
+// ---------------------------------------------------------------------------
+// refresh — fetch every enabled subscription, expand, rewrite the cache
+// ---------------------------------------------------------------------------
+
+async function refreshCalendars (vaultRoot = DEFAULT_VAULT_ROOT, { fetchImpl, now = new Date(), windowDays = DEFAULT_WINDOW_DAYS, signal } = {}) {
+  const calendars = loadCalendars(vaultRoot)
+  const all = []
+  let ok = 0
+  for (const cal of calendars) {
+    if (cal.enabled === false) continue
+    try {
+      const text = await fetchIcs(cal.url, { fetchImpl, signal })
+      const events = parseCalendar(text, { windowDays, now }).map((e) => ({ ...e, calId: cal.id, calLabel: cal.label, leadMin: cal.leadMin }))
+      all.push(...events)
+      cal.lastFetchedAt = new Date().toISOString()
+      cal.lastError = null
+      ok++
+    } catch (err) {
+      cal.lastError = (err && err.message) || String(err)
+    }
+  }
+  saveCalendars(vaultRoot, calendars)
+  all.sort((a, b) => new Date(a.start) - new Date(b.start))
+  saveCachedEvents(vaultRoot, all)
+  return { calendars: calendars.length, ok, events: all.length }
+}
+
+// ---------------------------------------------------------------------------
+// reconcile cached events -> reminders.json  (source: "calendar")
+// ---------------------------------------------------------------------------
+
+/**
+ * Make reminders.json reflect the calendar cache: one pending reminder per
+ * upcoming event (source "calendar", eventKey = the occurrence id). Events
+ * that disappeared or were cancelled get their still-pending calendar
+ * reminders dropped; ones already notified are left alone. Hand-typed
+ * reminders (source "peck"/"skill") are never touched.
+ *
+ * Returns { added, updated, removed }.
+ */
+function syncCalendarReminders (vaultRoot = DEFAULT_VAULT_ROOT, { now = new Date() } = {}) {
+  const reminders = require('./reminders')
+  const events = loadCachedEvents(vaultRoot)
+  const rows = reminders.loadReminders(vaultRoot)
+
+  const liveById = new Map(events.map((e) => [e.id, e]))
+  const nowMs = now.getTime()
+
+  let added = 0
+  let updated = 0
+  let removed = 0
+
+  // drop calendar reminders whose event is gone and which haven't fired
+  const kept = rows.filter((r) => {
+    if (r.source !== 'calendar' || r.status !== 'pending') return true
+    if (liveById.has(r.eventKey)) return true
+    removed++
+    return false
+  })
+
+  const byKey = new Map(kept.filter((r) => r.source === 'calendar').map((r) => [r.eventKey, r]))
+  let maxId = rows.reduce((m, r) => Math.max(m, Number(r.id) || 0), 0)
+
+  for (const e of events) {
+    if (new Date(e.start).getTime() < nowMs) continue // already started/past
+    const leadMin = Number.isFinite(+e.leadMin) ? +e.leadMin : DEFAULT_LEAD_MIN
+    const notifyAt = new Date(new Date(e.start).getTime() - leadMin * 60_000).toISOString()
+    const existing = byKey.get(e.id)
+    if (existing) {
+      if (existing.status !== 'pending') continue
+      if (existing.eventAt !== e.start || existing.title !== e.title || existing.notifyAt !== notifyAt) {
+        existing.eventAt = e.start
+        existing.title = e.title
+        existing.notifyAt = notifyAt
+        existing.leadMin = leadMin
+        existing.body = calendarBody(e)
+        updated++
+      }
+    } else {
+      kept.push({
+        id: ++maxId,
+        created: new Date().toISOString(),
+        title: e.title,
+        body: calendarBody(e),
+        eventAt: e.start,
+        leadMin,
+        notifyAt,
+        status: 'pending',
+        sound: true,
+        source: 'calendar',
+        eventKey: e.id,
+        calLabel: e.calLabel || null
+      })
+      added++
+    }
+  }
+
+  reminders.saveReminders(vaultRoot, kept)
+  return { added, updated, removed }
+}
+
+function calendarBody (e) {
+  const parts = []
+  if (e.location) parts.push(`Location: ${e.location}`)
+  if (e.organizer) parts.push(`Organizer: ${e.organizer}`)
+  if (e.attendees && e.attendees.length) parts.push(`Attendees: ${e.attendees.slice(0, 20).join(', ')}`)
+  if (e.description) parts.push('', e.description)
+  return parts.join('\n')
+}
+
+module.exports = {
+  DEFAULT_WINDOW_DAYS,
+  DEFAULT_REFRESH_MIN,
+  DEFAULT_LEAD_MIN,
+  normalizeIcsUrl,
+  fetchIcs,
+  parseCalendar,
+  loadCalendars,
+  saveCalendars,
+  addCalendar,
+  removeCalendar,
+  setCalendarEnabled,
+  loadCachedEvents,
+  saveCachedEvents,
+  refreshCalendars,
+  syncCalendarReminders
+}

--- a/scripts/lib/paths.js
+++ b/scripts/lib/paths.js
@@ -71,6 +71,18 @@ function remindersPath (vaultRoot = DEFAULT_VAULT_ROOT) {
   return path.join(vaultRoot, 'reminders.json')
 }
 
+// Calendar subscriptions (kip-app#70) — ICS URLs are bearer secrets, so the
+// subscription list lives under .henhouse/ alongside llm.json, never in the
+// graph's Markdown. The expanded event cache is derived state and goes under
+// .roost/ (safe to delete; a refresh rebuilds it).
+function calendarsConfigPath (vaultRoot = DEFAULT_VAULT_ROOT) {
+  return path.join(henhousePath(vaultRoot), 'calendars.json')
+}
+
+function calendarCachePath (vaultRoot = DEFAULT_VAULT_ROOT) {
+  return path.join(vaultRoot, '.roost', 'calendar-events.json')
+}
+
 // Single source of truth for the page-type <-> nest subfolder mapping.
 // type -> dir (used when writing a page for a known type)
 const TYPE_DIRS = { entity: 'entities', concept: 'concepts', source: 'sources' }
@@ -91,6 +103,8 @@ module.exports = {
   connectorsConfigPath,
   exportsPath,
   remindersPath,
+  calendarsConfigPath,
+  calendarCachePath,
   TYPE_DIRS,
   DIR_TYPES
 }

--- a/scripts/test/calendar.test.js
+++ b/scripts/test/calendar.test.js
@@ -1,0 +1,238 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const cal = require('../lib/calendar')
+const reminders = require('../lib/reminders')
+
+function tmpVault () {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kip-cal-test-'))
+  fs.mkdirSync(path.join(root, '.henhouse'), { recursive: true })
+  fs.mkdirSync(path.join(root, '.roost'), { recursive: true })
+  return root
+}
+
+const ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+UID:single-1
+SUMMARY:Coffee with Sam
+DTSTART:20260901T090000Z
+DTEND:20260901T093000Z
+LOCATION:Blue Bottle
+ORGANIZER;CN=Sam Lee:mailto:sam@example.com
+ATTENDEE;CN=Jo:mailto:jo@example.com
+ATTENDEE:mailto:pat@example.com
+DESCRIPTION:Catch up on Q3
+END:VEVENT
+BEGIN:VEVENT
+UID:weekly-1
+SUMMARY:Team standup
+DTSTART:20260902T140000Z
+DTEND:20260902T141500Z
+RRULE:FREQ=WEEKLY;COUNT=8
+EXDATE:20260909T140000Z
+END:VEVENT
+BEGIN:VEVENT
+UID:allday-1
+SUMMARY:Conference
+DTSTART;VALUE=DATE:20260903
+DTEND;VALUE=DATE:20260905
+END:VEVENT
+BEGIN:VEVENT
+UID:cancelled-1
+SUMMARY:Dead meeting
+DTSTART:20260903T100000Z
+STATUS:CANCELLED
+END:VEVENT
+BEGIN:VEVENT
+UID:past-1
+SUMMARY:Last week
+DTSTART:20260820T090000Z
+DTEND:20260820T093000Z
+END:VEVENT
+END:VCALENDAR`
+
+const NOW = new Date('2026-08-30T00:00:00Z')
+
+test('normalizeIcsUrl: webcal(s):// -> https://', () => {
+  assert.equal(cal.normalizeIcsUrl('webcal://p.example.com/a.ics'), 'https://p.example.com/a.ics')
+  assert.equal(cal.normalizeIcsUrl('WEBCALS://x/y'), 'https://x/y')
+  assert.equal(cal.normalizeIcsUrl('  https://x/y  '), 'https://x/y')
+})
+
+test('parseCalendar: single event — all fields normalized', () => {
+  const events = cal.parseCalendar(ICS, { now: NOW, windowDays: 14 })
+  const coffee = events.find((e) => e.uid === 'single-1')
+  assert.ok(coffee)
+  assert.equal(coffee.title, 'Coffee with Sam')
+  assert.equal(coffee.start, '2026-09-01T09:00:00.000Z')
+  assert.equal(coffee.location, 'Blue Bottle')
+  assert.equal(coffee.organizer, 'Sam Lee')
+  assert.deepEqual(coffee.attendees, ['Jo', 'pat@example.com'])
+  assert.equal(coffee.allDay, false)
+})
+
+test('parseCalendar: recurrence expanded + windowed, EXDATE skipped', () => {
+  const events = cal.parseCalendar(ICS, { now: NOW, windowDays: 14 }).filter((e) => e.uid === 'weekly-1')
+  const starts = events.map((e) => e.start)
+  assert.deepEqual(starts, ['2026-09-02T14:00:00.000Z', '2026-09-13T14:00:00.000Z'].slice(0, starts.length))
+  assert.ok(starts.includes('2026-09-02T14:00:00.000Z'))
+  assert.ok(!starts.includes('2026-09-09T14:00:00.000Z'), 'the EXDATE occurrence is gone')
+  assert.ok(starts.every((s) => new Date(s) <= new Date('2026-09-13T00:00:00Z')), 'nothing past the 14-day window')
+})
+
+test('parseCalendar: all-day flag, cancelled + past events dropped', () => {
+  const events = cal.parseCalendar(ICS, { now: NOW, windowDays: 14 })
+  assert.ok(events.find((e) => e.uid === 'allday-1').allDay)
+  assert.ok(!events.some((e) => e.uid === 'cancelled-1'), 'STATUS:CANCELLED dropped')
+  assert.ok(!events.some((e) => e.uid === 'past-1'), 'a fully-past event is outside the window')
+})
+
+test('parseCalendar: events come back sorted by start', () => {
+  const events = cal.parseCalendar(ICS, { now: NOW, windowDays: 30 })
+  const starts = events.map((e) => +new Date(e.start))
+  assert.deepEqual(starts, [...starts].sort((a, b) => a - b))
+})
+
+// --- fetch --------------------------------------------------------------------
+
+function fetchStub (body, { ok = true, status = 200 } = {}) {
+  const calls = []
+  const impl = async (url, init) => {
+    calls.push({ url, init })
+    return { ok, status, statusText: ok ? 'OK' : 'Not Found', text: async () => body }
+  }
+  return { impl, calls }
+}
+
+test('fetchIcs: normalizes webcal, sends Accept, returns the body', async () => {
+  const { impl, calls } = fetchStub(ICS)
+  const text = await cal.fetchIcs('webcal://cal.example.com/feed.ics', { fetchImpl: impl })
+  assert.match(text, /BEGIN:VCALENDAR/)
+  assert.equal(calls[0].url, 'https://cal.example.com/feed.ics')
+  assert.match(calls[0].init.headers.Accept, /text\/calendar/)
+})
+
+test('fetchIcs: a non-2xx and a non-ICS body both throw readably', async () => {
+  await assert.rejects(cal.fetchIcs('https://x/y', { fetchImpl: fetchStub('', { ok: false, status: 404 }).impl }), /404/)
+  await assert.rejects(cal.fetchIcs('https://x/y', { fetchImpl: fetchStub('<html>nope</html>').impl }), /did not return an iCalendar/)
+})
+
+// --- subscription store ------------------------------------------------------
+
+test('addCalendar / removeCalendar / dedup / bad URL', () => {
+  const root = tmpVault()
+  const row = cal.addCalendar(root, { url: 'webcal://cal.example.com/a.ics', leadMin: 20 })
+  assert.equal(row.id, 1)
+  assert.equal(row.leadMin, 20)
+  assert.equal(row.label, 'cal.example.com')
+  assert.equal(cal.loadCalendars(root).length, 1)
+
+  assert.throws(() => cal.addCalendar(root, { url: 'webcal://cal.example.com/a.ics' }), /already subscribed/)
+  assert.throws(() => cal.addCalendar(root, { url: 'not-a-url' }), /http\(s\)/)
+
+  assert.ok(cal.removeCalendar(root, 1))
+  assert.equal(cal.loadCalendars(root).length, 0)
+  assert.equal(cal.removeCalendar(root, 99), null)
+})
+
+test('setCalendarEnabled toggles the flag', () => {
+  const root = tmpVault()
+  cal.addCalendar(root, { url: 'https://x/a.ics' })
+  assert.equal(cal.setCalendarEnabled(root, 1, false).enabled, false)
+  assert.equal(cal.loadCalendars(root)[0].enabled, false)
+})
+
+// --- refresh ----------------------------------------------------------------
+
+test('refreshCalendars: writes the cache, records per-calendar lastError', async () => {
+  const root = tmpVault()
+  cal.addCalendar(root, { url: 'https://good/a.ics', label: 'Good' })
+  cal.addCalendar(root, { url: 'https://bad/b.ics', label: 'Bad' })
+
+  const impl = async (url) => url.includes('good')
+    ? { ok: true, status: 200, text: async () => ICS }
+    : { ok: false, status: 500, statusText: 'Server Error', text: async () => '' }
+
+  const res = await cal.refreshCalendars(root, { fetchImpl: impl, now: NOW })
+  assert.equal(res.calendars, 2)
+  assert.equal(res.ok, 1)
+  assert.ok(res.events > 0)
+
+  const cals = cal.loadCalendars(root)
+  assert.ok(cals.find((c) => c.label === 'Good').lastFetchedAt)
+  assert.equal(cals.find((c) => c.label === 'Good').lastError, null)
+  assert.match(cals.find((c) => c.label === 'Bad').lastError, /500/)
+
+  const cached = cal.loadCachedEvents(root)
+  assert.ok(cached.length > 0)
+  assert.ok(cached.every((e) => e.calLabel === 'Good'))
+})
+
+// --- reconcile into reminders.json -----------------------------------------
+
+test('syncCalendarReminders: adds one reminder per upcoming event, updates on change, prunes vanished', () => {
+  const root = tmpVault()
+
+  // a hand-typed reminder must survive every sync untouched
+  reminders.saveReminders(root, [{
+    id: 1, created: 'x', title: 'Call mum', body: '', eventAt: '2026-09-01T18:00:00.000Z',
+    leadMin: 60, notifyAt: '2026-09-01T17:00:00.000Z', status: 'pending', sound: true, source: 'peck'
+  }])
+
+  cal.saveCachedEvents(root, [
+    { id: 'evt-a', title: 'Design review', start: '2026-09-02T14:00:00.000Z', end: '2026-09-02T15:00:00.000Z', leadMin: 15, calLabel: 'Work', location: 'Room 2', attendees: ['Ana'] },
+    { id: 'evt-b', title: 'Lunch', start: '2026-09-03T12:00:00.000Z', end: '2026-09-03T13:00:00.000Z', leadMin: 30, calLabel: 'Personal' }
+  ])
+
+  let res = cal.syncCalendarReminders(root, { now: NOW })
+  assert.deepEqual(res, { added: 2, updated: 0, removed: 0 })
+
+  let rows = reminders.loadReminders(root)
+  assert.equal(rows.length, 3)
+  assert.ok(rows.find((r) => r.source === 'peck' && r.title === 'Call mum'), 'hand-typed reminder untouched')
+  const a = rows.find((r) => r.eventKey === 'evt-a')
+  assert.equal(a.source, 'calendar')
+  assert.equal(a.notifyAt, '2026-09-02T13:45:00.000Z') // 15 min before
+  assert.match(a.body, /Room 2/)
+
+  // idempotent
+  res = cal.syncCalendarReminders(root, { now: NOW })
+  assert.deepEqual(res, { added: 0, updated: 0, removed: 0 })
+  assert.equal(reminders.loadReminders(root).length, 3)
+
+  // event B moved 1h later -> the reminder is updated in place
+  cal.saveCachedEvents(root, [
+    { id: 'evt-a', title: 'Design review', start: '2026-09-02T14:00:00.000Z', end: '2026-09-02T15:00:00.000Z', leadMin: 15, calLabel: 'Work' },
+    { id: 'evt-b', title: 'Lunch', start: '2026-09-03T13:00:00.000Z', end: '2026-09-03T14:00:00.000Z', leadMin: 30, calLabel: 'Personal' }
+  ])
+  res = cal.syncCalendarReminders(root, { now: NOW })
+  assert.deepEqual(res, { added: 0, updated: 1, removed: 0 })
+  assert.equal(reminders.loadReminders(root).find((r) => r.eventKey === 'evt-b').eventAt, '2026-09-03T13:00:00.000Z')
+
+  // event A disappears from the feed -> its still-pending reminder is pruned
+  cal.saveCachedEvents(root, [
+    { id: 'evt-b', title: 'Lunch', start: '2026-09-03T13:00:00.000Z', end: '2026-09-03T14:00:00.000Z', leadMin: 30, calLabel: 'Personal' }
+  ])
+  res = cal.syncCalendarReminders(root, { now: NOW })
+  assert.deepEqual(res, { added: 0, updated: 0, removed: 1 })
+  rows = reminders.loadReminders(root)
+  assert.ok(!rows.some((r) => r.eventKey === 'evt-a'))
+  assert.equal(rows.length, 2)
+})
+
+test('syncCalendarReminders: a notified calendar reminder is kept even if the event vanishes', () => {
+  const root = tmpVault()
+  reminders.saveReminders(root, [{
+    id: 5, created: 'x', title: 'Old standup', body: '', eventAt: '2026-09-01T09:00:00.000Z',
+    leadMin: 15, notifyAt: '2026-09-01T08:45:00.000Z', status: 'notified', source: 'calendar', eventKey: 'gone'
+  }])
+  cal.saveCachedEvents(root, [])
+  const res = cal.syncCalendarReminders(root, { now: NOW })
+  assert.deepEqual(res, { added: 0, updated: 0, removed: 0 })
+  assert.equal(reminders.loadReminders(root).length, 1)
+})


### PR DESCRIPTION
**Draft — targeting v0.4.0.** The retrieval-layer half of calendar integration (#70). App-side branch: `feat/calendar-app` on kip-app.

Reuses the reminders pipeline exactly as #70 planned: an upcoming calendar event *becomes* a reminder (`source: "calendar"`), so it gets the same nest-retrieval prep brief and lead-time notification a hand-typed one does. No new scheduling / notification code.

## `lib/calendar.js`

- `fetchIcs(url)` — accepts `webcal://` / `webcals://`, checks the body is really iCalendar
- `parseCalendar(ics, {windowDays, now})` — RFC 5545 via **`ical.js`** (pure JS, zero transitive deps). Recurrences expanded to a rolling 14-day window; `CANCELLED` / past / `EXDATE` occurrences dropped; timezones handled by ical.js
- `refreshCalendars(vaultRoot)` — fetch every enabled feed, rewrite `.roost/calendar-events.json`, record `lastError` per feed (one bad feed doesn't sink the others)
- `syncCalendarReminders(vaultRoot)` — reconcile the cache into `reminders.json`: one row per upcoming event, updated in place on a time change, pruned when the event vanishes. Hand-typed (`source: "peck"/"skill"`) and already-notified rows are never touched

## `scripts/calendar.js`

`add` / `list` / `remove` / `enable` / `disable` / `refresh` / `sync`. Subscriptions in `<graph>/.henhouse/calendars.json` (ICS URLs are bearer secrets, kept out of the graph).

## Not in this PR

- The synthetic "Calendar" source type for Peck retrieval (cite an event directly) — #70's "events as context sources". Follow-up.

## Verification

Suite **251/251** — `scripts/test/calendar.test.js` (12 cases: parse, recurrence + EXDATE, all-day, fetch errors, subscription CRUD + dedup, refresh with a failing feed, the full reconcile lifecycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)