### PR TITLE
Peck: a short conversation-context buffer for follow-ups (kip-app#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Kip. Format loosely follows
 The retrieval layer (this repo) and the desktop app
 ([kip-app](https://github.com/JWE24-code/kip-app)) are released together.
 
+## [Unreleased]
+
+### The retrieval layer (`scripts/`)
+
+- **Peck remembers the last few turns** (kip-app#82) — `peckTurn` /
+  `chat.js` take a `--history` buffer of recent `{role, text}` turns.
+  A follow-up ("expand on that", "and their salary?", "the second one")
+  now resolves what it refers to: the recent turns are folded into
+  retrieval (so a question with no shared nouns still finds pages) and
+  passed to the answer as a *"Conversation so far"* block (marked
+  not-a-source). A bare continuation right after a Kip answer also
+  classifies as a question rather than a new fact. Session-only.
+
 ## [0.3.7] — 2026-08-30
 
 ### The retrieval layer (`scripts/`)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -213,6 +213,18 @@ classifies the input (`classifyPeckInput`) and dispatches:
 `scripts/chat.js` (the app's Peck panel backend) calls `peckTurn` with
 `fileToNest: false`.
 
+**Follow-up context** (kip-app#82) — `peckTurn(input, { history })` /
+`chat.js --history '<json>'` takes a short buffer of recent turns
+(`[{ role, text }]`, oldest→newest, clipped by the app). It flows into
+`classifyPeckInput` (a bare "tell me more" / "the second one" after a Kip
+answer classifies as a question, not a statement), `extractKeyTerms` +
+`retrieveCandidates` (so a follow-up with no shared nouns still retrieves —
+the recent user turns are folded into the direct FTS query and the
+pronouns are resolved for the key-term pass), and `answerQuestion` /
+`answerQuestionWithSkills` (a "Conversation so far:" block, marked
+not-a-source). `prompts.formatConversation` does the clipping/formatting.
+Session-only; the app resets the buffer when the Peck conversation clears.
+
 - **Tell it about an upcoming event** ("I have a meeting with Acme on Friday
   at 15h", "remind me to email Bob tomorrow") → `peckTurn` detects the
   reminder intent and routes to the `reminders` skill instead of fact

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -24,6 +24,9 @@
 // to <coop>/.roost/peck-trace.jsonl.
 //
 // Usage: node scripts/chat.js "your question — or a fact to remember" [--trace]
+//        [--arena-compare-to <callId>] [--history '<json>']
+//   --history: [{ "role": "user"|"assistant", "text": "…" }] oldest→newest, a
+//     short buffer of recent turns so a follow-up can resolve what it refers to.
 //   (set KIP_COOP_ROOT to point at a graph other than this repo's ./coop)
 require('dotenv').config()
 const path = require('node:path')
@@ -38,11 +41,13 @@ const { installFeedbackPoster } = require('./lib/feedback-poster')
 const ROOST_DIR = path.join(DEFAULT_VAULT_ROOT, '.roost')
 const traceOn = process.argv.includes('--trace') || process.env.KIP_PECK_TRACE === '1'
 
+const VALUE_FLAGS = new Set(['--arena-compare-to', '--history'])
+
 async function main () {
   const args = process.argv.slice(2)
-  const input = args.find((a) => !a.startsWith('--'))
+  const input = args.find((a, i) => !a.startsWith('--') && !VALUE_FLAGS.has(args[i - 1]))
   if (!input || !input.trim()) {
-    console.error('Usage: node scripts/chat.js "your question — or a fact to remember" [--trace] [--arena-compare-to <callId>]')
+    console.error('Usage: node scripts/chat.js "your question — or a fact to remember" [--trace] [--arena-compare-to <callId>] [--history <json>]')
     process.exitCode = 1
     return
   }
@@ -50,6 +55,17 @@ async function main () {
   // as arena candidate B against the first answer's callId.
   const acIdx = args.indexOf('--arena-compare-to')
   const arenaCompareToCallId = acIdx >= 0 ? args[acIdx + 1] : null
+
+  // A short buffer of recent Peck turns for follow-up context (kip-app#82) —
+  // [{ role: "user"|"assistant", text }], oldest→newest, clipped by the app.
+  const hIdx = args.indexOf('--history')
+  let history = []
+  if (hIdx >= 0 && args[hIdx + 1]) {
+    try {
+      const parsed = JSON.parse(args[hIdx + 1])
+      if (Array.isArray(parsed)) history = parsed
+    } catch { /* malformed history — answer without it */ }
+  }
 
   console.error(describeProvider())
 
@@ -69,7 +85,7 @@ async function main () {
   reporter.flush(true)
 
   try {
-    const result = await peckTurn(input, { fileToNest: false, vaultRoot: DEFAULT_VAULT_ROOT, arenaCompareToCallId })
+    const result = await peckTurn(input, { fileToNest: false, vaultRoot: DEFAULT_VAULT_ROOT, arenaCompareToCallId, history })
     reporter.flush(false)
     reporter.writeMetrics()
     reporter.close()

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -37,11 +37,21 @@ const CAPTURE_TYPES = new Set(['entity', 'concept'])
 //   statement: anything else.
 const QUESTION_START_RE = /^\s*(who|what|whats|when|where|why|how|which|whose|whom|is|are|was|were|do|does|did|can|could|should|would|will|have|has|had|am|tell me|remind me|show me|list|give me|find|search|look up|any\b|make|create|build|generate|draft|write|compose|produce|prepare|compile|convert|summari[sz]e|turn)\b/i
 
-/** 'question' vs 'statement' for a Peck turn. */
-function classifyPeckInput (input) {
+// A short input right after a Kip answer that reads as "keep going" rather
+// than a new fact — treat these as a question even without a '?' or a
+// question word (kip-app#82).
+const CONTINUATION_RE = /^\s*(and\b|also\b|what about|how about|tell me more|say more|go on|elaborate|expand|more\b|why\b|the (first|second|third|fourth|last|next|other|previous) one|that one|those|it\?|really\?|source\??|says who\??)/i
+
+/** 'question' vs 'statement' for a Peck turn. `history` (optional) lets a
+ *  bare follow-up after a Kip answer classify as a question (kip-app#82). */
+function classifyPeckInput (input, history = []) {
   const t = String(input || '').trim()
   if (!t) return 'question'
-  return (t.endsWith('?') || QUESTION_START_RE.test(t)) ? 'question' : 'statement'
+  if (t.endsWith('?') || QUESTION_START_RE.test(t)) return 'question'
+  const lastWasAnswer = Array.isArray(history) && history.length &&
+    history[history.length - 1] && history[history.length - 1].role === 'assistant'
+  if (lastWasAnswer && CONTINUATION_RE.test(t)) return 'question'
+  return 'statement'
 }
 
 /**
@@ -79,12 +89,18 @@ function anySkills (vaultRoot) {
   }
 }
 
-async function retrieveCandidates (question, vaultRoot) {
-  const direct = searchPages(question, {}, vaultRoot)
+async function retrieveCandidates (question, vaultRoot, { history = [] } = {}) {
+  // A follow-up ("tell me more about the second one") often shares no nouns
+  // with the nest — fold in the recent user turns so the direct FTS pass has
+  // something to match (kip-app#82).
+  const recentUser = (Array.isArray(history) ? history : [])
+    .filter((t) => t && t.role === 'user' && typeof t.text === 'string')
+    .slice(-3).map((t) => t.text).join(' ')
+  const direct = searchPages(`${recentUser} ${question}`.trim(), {}, vaultRoot)
 
   let keyTerms = []
   try {
-    keyTerms = await extractKeyTerms(question, vaultRoot)
+    keyTerms = await extractKeyTerms(question, vaultRoot, { history })
   } catch (err) {
     console.error(`Warning: key-term extraction failed (${err.message}); continuing with the direct search only.`)
   }
@@ -134,7 +150,7 @@ async function fileAnswerToNest (question, answer, candidateSlugs, vaultRoot = D
  * can call them mid-answer — `steps` records what it ran. Skill discovery and
  * the whole tool loop are best-effort: a failure downgrades to a plain answer.
  */
-async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena = null }) {
+async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena = null, history = [] }) {
   const candidateSlugs = pages.map((p) => p.slug)
   const telemetryStart = telemetry.entries().length
 
@@ -151,17 +167,17 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
     // A regenerate free-rider (kip-app#73): plain answer only. Skills add
     // per-run variance that would muddy a model-vs-model comparison, and a
     // regen is "answer this again, differently" — not "re-run the tool loop".
-    answer = await answerQuestion(question, pages, vaultRoot, { arena })
+    answer = await answerQuestion(question, pages, vaultRoot, { arena, history })
   } else if (skills.length) {
     try {
-      ({ answer, steps } = await answerQuestionWithSkills(question, pages, skills, vaultRoot))
+      ({ answer, steps } = await answerQuestionWithSkills(question, pages, skills, vaultRoot, { history }))
     } catch (err) {
       console.error(`Warning: the skills tool loop failed (${err.message}); falling back to a plain answer.`)
-      answer = await answerQuestion(question, pages, vaultRoot)
+      answer = await answerQuestion(question, pages, vaultRoot, { history })
       steps = []
     }
   } else {
-    answer = await answerQuestion(question, pages, vaultRoot)
+    answer = await answerQuestion(question, pages, vaultRoot, { history })
   }
 
   const citedSlugs = extractCitedSlugs(answer, candidateSlugs)
@@ -234,14 +250,14 @@ function fileCapturedFacts (proposedPages, vaultRoot = DEFAULT_VAULT_ROOT) {
  *
  * @returns {{answer: string|null, citedSlugs: string[], candidateSlugs: string[], steps: Array, callId: string|null, arenaId: string|null}}
  */
-async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_VAULT_ROOT, arenaCompareToCallId = null } = {}) {
-  const candidates = await retrieveCandidates(question, vaultRoot)
+async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_VAULT_ROOT, arenaCompareToCallId = null, history = [] } = {}) {
+  const candidates = await retrieveCandidates(question, vaultRoot, { history })
   if (candidates.length === 0 && !anySkills(vaultRoot)) {
     return { answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
   }
   const pages = readPageBodies(vaultRoot, candidates)
   const arena = arenaCompareToCallId ? { compareToCallId: arenaCompareToCallId } : null
-  return answerFromPages(question, pages, { fileToNest, vaultRoot, arena })
+  return answerFromPages(question, pages, { fileToNest, vaultRoot, arena, history })
 }
 
 /**
@@ -256,7 +272,7 @@ async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_V
  *              shape as question; the `reminders` skill did the work and its
  *              confirmation is in `answer`.
  */
-async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = false, arenaCompareToCallId = null } = {}) {
+async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = false, arenaCompareToCallId = null, history = [] } = {}) {
   // An upcoming event the user wants reminding about ("I have a meeting Friday
   // at 15h", "remind me to …") — route to the skills path (the `reminders`
   // skill creates it), NOT fact-capture, which would file it as a nest page.
@@ -264,11 +280,11 @@ async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = f
     return { intent: 'reminder', ...(await answerFromPages(input, [], { fileToNest: false, vaultRoot })) }
   }
 
-  const candidates = await retrieveCandidates(input, vaultRoot)
+  const candidates = await retrieveCandidates(input, vaultRoot, { history })
   const pages = readPageBodies(vaultRoot, candidates)
   const candidateSlugs = pages.map((p) => p.slug)
 
-  if (classifyPeckInput(input) === 'statement') {
+  if (classifyPeckInput(input, history) === 'statement') {
     const capture = await captureFacts(input, pages, vaultRoot)
     const results = capture.learned ? fileCapturedFacts(capture.pages, vaultRoot) : []
     const touched = [...new Set(results.map((r) => r.slug))]
@@ -282,7 +298,7 @@ async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = f
     return { intent: 'question', answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
   }
   const arena = arenaCompareToCallId ? { compareToCallId: arenaCompareToCallId } : null
-  return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena })) }
+  return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena, history })) }
 }
 
 module.exports = { askQuestion, peckTurn, classifyPeckInput, fileAnswerToNest, fileCapturedFacts, extractCitedSlugs }

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -7,13 +7,34 @@
 const { callLLM } = require('./llm')
 const { runSkill, parseSkillCall, scrubInput } = require('./skills')
 
-/** Extracts key search terms from a question, for a broader secondary searchPages() pass. */
-async function extractKeyTerms (question, vaultRoot) {
-  const system = 'Extract 3-8 short key search terms/phrases from a question, for a full-text ' +
-    'search over a personal wiki. Strip stopwords; choose terms that maximize search recall. ' +
-    'Respond with a JSON object of exactly this shape: {"terms": ["term1", "term2", ...]}.'
+// --- conversation context (kip-app#82) --------------------------------------
+// A short buffer of recent Peck turns so a follow-up ("expand on that", "and
+// his salary?") can resolve what it refers to. The renderer clips each turn;
+// we re-clip here as a backstop and cap the number of turns.
+const HISTORY_TURN_CLIP = 700
+const HISTORY_MAX_TURNS = 6
 
-  const { text } = await callLLM({ system, prompt: `Question: ${question}`, json: true, maxTokens: 1024, label: 'peck:key-terms' }, { vaultRoot })
+/** history: [{ role: "user"|"assistant", text }] oldest→newest, or falsy. */
+function formatConversation (history, { heading = 'Conversation so far' } = {}) {
+  if (!Array.isArray(history) || !history.length) return ''
+  const lines = history
+    .filter((t) => t && typeof t.text === 'string' && t.text.trim())
+    .slice(-HISTORY_MAX_TURNS)
+    .map((t) => `${t.role === 'assistant' ? 'Kip' : 'User'}: ${t.text.trim().replace(/\s+/g, ' ').slice(0, HISTORY_TURN_CLIP)}`)
+  return lines.length ? `${heading}:\n${lines.join('\n')}` : ''
+}
+
+/** Extracts key search terms from a question, for a broader secondary searchPages() pass. */
+async function extractKeyTerms (question, vaultRoot, { history = [] } = {}) {
+  const convo = formatConversation(history)
+  const system = 'Extract 3-8 short key search terms/phrases for a full-text search over a ' +
+    'personal wiki, to answer the user\'s current question. Strip stopwords; choose terms that ' +
+    'maximize search recall. If the question is a follow-up, resolve its pronouns and references ' +
+    'from the conversation and include the real subjects as terms. ' +
+    'Respond with a JSON object of exactly this shape: {"terms": ["term1", "term2", ...]}.'
+  const prompt = convo ? `${convo}\n\nCurrent question: ${question}` : `Question: ${question}`
+
+  const { text } = await callLLM({ system, prompt, json: true, maxTokens: 1024, label: 'peck:key-terms' }, { vaultRoot })
   try {
     const parsed = JSON.parse(text)
     return Array.isArray(parsed.terms) ? parsed.terms : []
@@ -32,14 +53,20 @@ const ANSWER_SYSTEM_PROMPT = `You are answering a question from a personal wiki 
 
 Answer using ONLY the information in these pages — do not use outside knowledge, and do not speculate beyond what's written. If the pages don't contain enough information to answer, say so plainly rather than guessing.
 
+If a "Conversation so far" section is present, it is only there to tell you what a follow-up question refers to — it is NOT a source, so never cite it or treat it as fact.
+
 Cite every claim back to the specific page it came from using Logseq's wikilink syntax: [[exact-page-slug]], using the exact slug shown in each "### Page: <slug>" heading. Prefer citing inline, next to the claim it supports, over a single list of links at the end.`
 
 /** Answers a question against a set of candidate wiki pages, with [[slug]]
  *  citations. `arena` (optional): { compareToCallId } runs this as arena
  *  candidate B against an earlier answer — the regenerate free-rider
- *  (kip-app#73). Only meaningful on the managed kip connector. */
-async function answerQuestion (question, pages, vaultRoot, { arena = null } = {}) {
-  const prompt = `${formatPagesForPrompt(pages)}\n\n---\n\nQuestion: ${question}`
+ *  (kip-app#73). `history` (optional): recent {role,text} turns for
+ *  follow-up context (kip-app#82). */
+async function answerQuestion (question, pages, vaultRoot, { arena = null, history = [] } = {}) {
+  const convo = formatConversation(history)
+  const prompt = `${formatPagesForPrompt(pages)}\n\n---\n\n` +
+    (convo ? `${convo}\n\n---\n\n` : '') +
+    `Question: ${question}`
   const { text } = await callLLM({ system: ANSWER_SYSTEM_PROMPT, prompt, maxTokens: 4096, label: 'peck:answer', arena }, { vaultRoot })
   return text
 }
@@ -118,14 +145,17 @@ function formatSkillsBlock (skills) {
  * With no skills it's just answerQuestion(). Any unexpected throw is the
  * caller's (peck.js's) to catch and downgrade.
  */
-async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { runSkillFn = runSkill } = {}) {
+async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { runSkillFn = runSkill, history = [] } = {}) {
   if (!skills || !skills.length) {
-    return { answer: await answerQuestion(question, pages, vaultRoot), steps: [] }
+    return { answer: await answerQuestion(question, pages, vaultRoot, { history }), steps: [] }
   }
 
   const byName = new Map(skills.map((s) => [s.name, s]))
   const system = ANSWER_WITH_SKILLS_SYSTEM_PROMPT + formatSkillsBlock(skills)
-  let transcript = `${formatPagesForPrompt(pages)}\n\n---\n\nQuestion: ${question}`
+  const convo = formatConversation(history)
+  let transcript = `${formatPagesForPrompt(pages)}\n\n---\n\n` +
+    (convo ? `${convo}\n\n---\n\n` : '') +
+    `Question: ${question}`
   const steps = []
 
   for (let turn = 0; turn <= MAX_SKILL_ITERATIONS; turn++) {
@@ -501,6 +531,7 @@ async function captureFacts (input, existingPages, vaultRoot) {
 module.exports = {
   extractKeyTerms,
   answerQuestion,
+  formatConversation,
   generateMeetingPrep,
   answerQuestionWithSkills,
   formatSkillsBlock,

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -184,6 +184,18 @@ test('classifyPeckInput — trailing ? or a leading question word is a question,
   assert.equal(classifyPeckInput(''), 'question')
 })
 
+test('classifyPeckInput — a bare follow-up after a Kip answer is a question (kip-app#82)', () => {
+  const afterAnswer = [{ role: 'user', text: 'what are the pricing tiers?' },
+    { role: 'assistant', text: 'There are three: Free, Pro, Team [[pricing]].' }]
+  for (const q of ['tell me more', 'the second one', 'what about Team', 'and the price?', 'why', 'says who']) {
+    assert.equal(classifyPeckInput(q, afterAnswer), 'question', q)
+  }
+  // with no history, the same short inputs still read as statements
+  assert.equal(classifyPeckInput('the second one'), 'statement')
+  // a real new fact after an answer is still a statement
+  assert.equal(classifyPeckInput('the CDO of CompanyX is John Doe', afterAnswer), 'statement')
+})
+
 test('captureFacts returns a safe default on unusable output', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
@@ -362,6 +374,32 @@ test('peckTurn — with no skills, only peck:answer is called (no skill-turn)', 
     assert.equal(r.answer, 'Per [[sleep]], sleep more.')
     assert.deepEqual(r.steps, [])
     assert.ok(!s.calls.some((c) => /Available skills:/.test(c)), 'no skills block was ever sent')
+  } finally { s.restore() }
+})
+
+test('peckTurn — a follow-up carries the conversation history into key-terms + the answer (kip-app#82)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'entities', 'acme', { type: 'entity', body: 'Acme pays $120k for the senior role.' })
+  rebuildRoost(root)
+
+  const s = stubPeckFetch({ keyTerms: '{"terms":["Acme","salary"]}', answer: 'Per [[acme]], $120k.' })
+  try {
+    const history = [
+      { role: 'user', text: 'what do we know about Acme?' },
+      { role: 'assistant', text: 'Acme is a prospective client [[acme]].' }
+    ]
+    const r = await peckTurn('and their salary?', { vaultRoot: root, history })
+    assert.equal(r.intent, 'question')
+    assert.equal(r.answer, 'Per [[acme]], $120k.')
+    // stubPeckFetch collects each call's joined system+user text in .calls
+    const keyTermsCall = s.calls.find((p) => /key search terms/i.test(p))
+    assert.ok(keyTermsCall && /Acme is a prospective client/.test(keyTermsCall) && /Current question: and their salary\?/.test(keyTermsCall),
+      'the key-terms prompt carried the recent turns + the follow-up')
+    const answerCall = s.calls.find((p) => !/key search terms/i.test(p) && !/told their personal wiki/i.test(p))
+    assert.ok(answerCall && /Conversation so far:/.test(answerCall) && /Acme is a prospective client/.test(answerCall),
+      'the answer prompt carried a "Conversation so far" block')
   } finally { s.restore() }
 })
 


### PR DESCRIPTION
**Draft — targeting v0.4.0.** Retrieval-layer half of #82. App-side branch to follow.

Every Peck turn was stateless — `chat.js` → `peckTurn(input)` got only the current line, so a follow-up like *"expand on that"* / *"and their salary?"* / *"the second one"* had nothing to resolve against.

## Changes

- **`prompts.js`** — `formatConversation(history)` clips + formats recent `{role,text}` turns. `extractKeyTerms` and `answerQuestion` / `answerQuestionWithSkills` take an optional `{ history }`:
  - key-term extraction resolves pronouns from the recent turns (the important one — a follow-up with no shared nouns retrieved *nothing* before)
  - the answer gets a **"Conversation so far:"** block; the system prompt marks it as context, not a source (never cited)
- **`peck.js`** — `peckTurn` / `askQuestion` take `{ history }`, threaded into classify / retrieve / answer.
  - `classifyPeckInput(input, history)` — a bare continuation (`tell me more`, `the second one`, `why`, `says who`) right after a Kip answer classifies as a **question**, not a new fact
  - `retrieveCandidates` folds the last few user turns into the direct FTS query
- **`chat.js`** — `--history '<json>'` (`[{role,text}]` oldest→newest, clipped by the app). Value-flag parsing so the JSON isn't mistaken for the question.

Session-only — the app resets the buffer when the conversation clears.

## Verification

Suite **241/241** (+2: `classifyPeckInput` with history, and an end-to-end `peckTurn` follow-up asserting the history reaches both the key-terms and the answer prompts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)