### PR TITLE
Peck: web-search results come back as a hatchable source (kip-app#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to Kip. Format loosely follows
 The retrieval layer (this repo) and the desktop app
 ([kip-app](https://github.com/JWE24-code/kip-app)) are released together.
 
+## [Unreleased]
+
+### The retrieval layer (`scripts/`)
+
+- **Web-search results can be kept** (kip-app#81) — when Peck runs the
+  `web-search` skill to answer a question, the turn result now carries a
+  `webSource` (front-matter + the result list, ready for `eggs/`). The app
+  offers to save it, so a search you found useful becomes reference material
+  in the nest instead of vanishing with the turn. `lib/web-sources.js`.
+
 ## [0.3.7] — 2026-08-30
 
 ### The retrieval layer (`scripts/`)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -213,6 +213,15 @@ classifies the input (`classifyPeckInput`) and dispatches:
 `scripts/chat.js` (the app's Peck panel backend) calls `peckTurn` with
 `fileToNest: false`.
 
+**Web-search → source** (kip-app#81) — if the skills loop ran `web-search`
+(or any skill whose output is a `Results for "…" (via …)` list), the turn
+result carries a `webSource` `{ filename, content }`: a front-matter'd
+Markdown doc of the result list, ready to drop into `eggs/`. The app shows
+a "save these" affordance on the answer and writes it via the existing
+`:wikiAddEgg` IPC. `lib/web-sources.js` (`parseWebSearchOutput`,
+`buildWebSource`). v1 saves the list + snippets; full page-text fetch is a
+follow-up.
+
 - **Tell it about an upcoming event** ("I have a meeting with Acme on Friday
   at 15h", "remind me to email Bob tomorrow") → `peckTurn` detects the
   reminder intent and routes to the `reminders` skill instead of fact

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "peck": "node scripts/peck.js",
     "groom": "node scripts/groom.js",
     "hatch": "node scripts/hatch.js",
-    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/preference-signals.test.js scripts/test/feedback-poster.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js"
+    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/preference-signals.test.js scripts/test/feedback-poster.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js scripts/test/web-sources.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.70.0",

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -20,6 +20,7 @@ const { searchPages, upsertPage, regenerateIndexMd, appendLog, extractWikilinkSl
 const { resolvePage } = require('./pages')
 const { extractKeyTerms, answerQuestion, answerQuestionWithSkills, captureFacts } = require('./prompts')
 const { discoverSkills } = require('./skills')
+const { buildWebSource } = require('./web-sources')
 const { looksLikeReminder } = require('./reminders')
 const { DEFAULT_VAULT_ROOT } = require('./paths')
 const telemetry = require('./telemetry')
@@ -147,6 +148,7 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
 
   let answer
   let steps = []
+  let webSearches = []
   if (arena) {
     // A regenerate free-rider (kip-app#73): plain answer only. Skills add
     // per-run variance that would muddy a model-vs-model comparison, and a
@@ -154,7 +156,7 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
     answer = await answerQuestion(question, pages, vaultRoot, { arena })
   } else if (skills.length) {
     try {
-      ({ answer, steps } = await answerQuestionWithSkills(question, pages, skills, vaultRoot))
+      ({ answer, steps, webSearches } = await answerQuestionWithSkills(question, pages, skills, vaultRoot))
     } catch (err) {
       console.error(`Warning: the skills tool loop failed (${err.message}); falling back to a plain answer.`)
       answer = await answerQuestion(question, pages, vaultRoot)
@@ -174,7 +176,10 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   // arenaId per PR kip-app#73) rather than threaded through answerQuestion's
   // string return — bounded to the calls THIS invocation just made.
   const { callId, arenaId } = answerCallSince(telemetryStart)
-  return { answer, citedSlugs, candidateSlugs, steps, callId, arenaId }
+  // If this turn ran web-search, offer its results as a hatchable source
+  // (kip-app#81) — the app shows a "save these" affordance on the answer.
+  const webSource = buildWebSource(question, webSearches);
+  return { answer, citedSlugs, candidateSlugs, steps, callId, arenaId, webSource: webSource || null }
 }
 
 /** callId + arenaId of the newest peck:answer* call at or after `startIdx`. */

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -6,6 +6,7 @@
 // in scripts/lib/llm.js — nothing here is provider-specific.
 const { callLLM } = require('./llm')
 const { runSkill, parseSkillCall, scrubInput } = require('./skills')
+const { parseWebSearchOutput } = require('./web-sources')
 
 /** Extracts key search terms from a question, for a broader secondary searchPages() pass. */
 async function extractKeyTerms (question, vaultRoot) {
@@ -120,13 +121,14 @@ function formatSkillsBlock (skills) {
  */
 async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { runSkillFn = runSkill } = {}) {
   if (!skills || !skills.length) {
-    return { answer: await answerQuestion(question, pages, vaultRoot), steps: [] }
+    return { answer: await answerQuestion(question, pages, vaultRoot), steps: [], webSearches: [] }
   }
 
   const byName = new Map(skills.map((s) => [s.name, s]))
   const system = ANSWER_WITH_SKILLS_SYSTEM_PROMPT + formatSkillsBlock(skills)
   let transcript = `${formatPagesForPrompt(pages)}\n\n---\n\nQuestion: ${question}`
   const steps = []
+  const webSearches = []   // parsed results of every web-search run this turn (kip-app#81)
 
   for (let turn = 0; turn <= MAX_SKILL_ITERATIONS; turn++) {
     const { text, raw } = await callLLM({
@@ -140,7 +142,7 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
     // No <use_skill> tag (⇒ text is the final answer), or the model was cut
     // off (⇒ answer with what came back rather than loop on a partial tag).
     if (!call || responseWasTruncated(raw)) {
-      return { answer: text, steps }
+      return { answer: text, steps, webSearches }
     }
 
     // model still wants a tool on the last allowed turn — force a final answer
@@ -151,7 +153,7 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
         maxTokens: 4096,
         label: 'peck:answer:final'
       }, { vaultRoot })
-      return { answer: final, steps }
+      return { answer: final, steps, webSearches }
     }
 
     const skill = byName.get(call.name)
@@ -174,12 +176,18 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
       ms: res.ms,
       outputPreview: (res.output || res.error || '').replace(/\s+/g, ' ').trim().slice(0, 500)
     })
+    // Any skill whose output is a web-search result list (the built-in
+    // web-search, or a user's own) — capture it as a savable source (kip-app#81).
+    if (res.ok) {
+      const parsed = parseWebSearchOutput(res.output)
+      if (parsed && parsed.results.length) webSearches.push(parsed)
+    }
     const body = res.ok ? String(res.output || '').slice(0, 6000) : `ERROR: ${res.error}`
     transcript += `\n\n<skill_result name="${skill.name}" ok="${res.ok}">\n${body}\n</skill_result>\nCall another skill or write your final answer now.`
   }
 
   // unreachable (the turn === MAX branch returns), but be safe
-  return { answer: await answerQuestion(question, pages, vaultRoot), steps }
+  return { answer: await answerQuestion(question, pages, vaultRoot), steps, webSearches }
 }
 
 /**

--- a/scripts/lib/web-sources.js
+++ b/scripts/lib/web-sources.js
@@ -1,0 +1,82 @@
+// Turns a Peck turn's web-search results into a hatchable source doc
+// (kip-app#81). When Peck runs the `web-search` skill to answer a question,
+// the results otherwise vanish with the turn; this lets the app offer to save
+// them into eggs/ so they become reference material in the nest.
+//
+// v1 saves the result list (title / url / snippet). Fetching the full text of
+// each page is a follow-up.
+
+const SLUG_MAX = 60
+
+function slugify (s) {
+  return String(s || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, SLUG_MAX)
+    .replace(/-+$/g, '') || 'query'
+}
+
+/**
+ * Parse one `web-search` skill run's stdout back into structured results.
+ * The skill prints:
+ *   Results for "<query>" (via <backend>):
+ *
+ *   - [title](url) — snippet
+ *   ...
+ * or `No results for "<query>" (via <backend>).`
+ * Returns { query, backend, results: [{title, url, snippet}] } or null.
+ */
+function parseWebSearchOutput (text) {
+  const s = String(text || '')
+  const head = s.match(/^(?:Results|No results) for "([^"]*)" \(via ([^)]+)\)/m)
+  if (!head) return null
+  const query = head[1]
+  const backend = head[2].trim()
+  const results = []
+  const line = /^-\s+\[([^\]]+)\]\(([^)]+)\)(?:\s+[—-]\s+(.*))?$/gm
+  let m
+  while ((m = line.exec(s))) {
+    results.push({ title: m[1].trim(), url: m[2].trim(), snippet: (m[3] || '').trim() })
+  }
+  return { query, backend, results }
+}
+
+/**
+ * Build the source doc (front-matter + markdown) for one Peck turn's web
+ * searches. `question` is the user's original question; `searches` is the
+ * array of parsed { query, backend, results } (one per web-search run).
+ * Returns { filename, content } or null when there's nothing worth saving.
+ */
+function buildWebSource (question, searches, { now = new Date() } = {}) {
+  const kept = (searches || []).filter((x) => x && Array.isArray(x.results) && x.results.length)
+  if (!kept.length) return null
+
+  const date = now.toISOString().slice(0, 10)
+  const filename = `web-search-${date}-${slugify(question || kept[0].query)}.md`
+
+  const fm = [
+    '---',
+    'source: web-search',
+    `question: ${JSON.stringify(String(question || '').trim())}`,
+    `saved: "${date}"`,
+    `backends: [${[...new Set(kept.map((s) => JSON.stringify(s.backend)))].join(', ')}]`,
+    '---',
+    ''
+  ]
+
+  const body = [`# Web search — ${String(question || kept[0].query).trim()}`, '',
+    `Saved ${date}. These are search results (title, link, snippet), not the full page text.`, '']
+
+  for (const s of kept) {
+    if (kept.length > 1) body.push(`## "${s.query}" (via ${s.backend})`, '')
+    for (const r of s.results) {
+      body.push(`- [${r.title}](${r.url})${r.snippet ? ` — ${r.snippet}` : ''}`)
+    }
+    body.push('')
+  }
+
+  return { filename, content: fm.join('\n') + body.join('\n').trimEnd() + '\n' }
+}
+
+module.exports = { parseWebSearchOutput, buildWebSource, slugify }

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -329,6 +329,49 @@ test('peckTurn — the model calls a skill, then answers with its output', async
   } finally { s.restore() }
 })
 
+test('peckTurn — a web-search run comes back as a hatchable webSource (kip-app#81)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'concepts', 'topic', { type: 'concept', body: 'placeholder' })
+  rebuildRoost(root)
+  // a graph-local fixture named web-search (overrides the built-in), emitting
+  // the built-in's output format. Set the skills-config *before* the fixture
+  // so writeFixtureSkill's setSkillApproval isn't clobbered.
+  onlyFixtureSkills(root, ['web-search'])
+  writeFixtureSkill(root, 'web-search',
+    'console.log(`Results for "latest on X" (via duckduckgo):\\n\\n- [A page](https://a.test) — a snippet\\n- [B page](https://b.test) — b snippet`)')
+
+  const s = stubPeckFetch({
+    keyTerms: '{"terms":["topic"]}',
+    answerFn: (sys) => !/<skill_result name="web-search"/.test(sys)
+      ? '<use_skill name="web-search">{"query":"latest on X"}</use_skill>'
+      : 'Per the web, A and B (via web-search).'
+  })
+  try {
+    const r = await peckTurn('what is the latest on X?', { vaultRoot: root })
+    assert.equal(r.intent, 'question')
+    assert.ok(r.webSource, 'the turn carries a webSource')
+    assert.match(r.webSource.filename, /^web-search-\d{4}-\d{2}-\d{2}-what-is-the-latest-on-x\.md$/)
+    assert.match(r.webSource.content, /source: web-search/)
+    assert.match(r.webSource.content, /\[A page\]\(https:\/\/a\.test\)/)
+    assert.match(r.webSource.content, /\[B page\]\(https:\/\/b\.test\)/)
+  } finally { s.restore() }
+})
+
+test('peckTurn — no web-search, no webSource', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'concepts', 'sleep', { type: 'concept', body: 'notes on sleep' })
+  rebuildRoost(root)
+  const s = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep]], rest.' })
+  try {
+    const r = await peckTurn('what about sleep?', { vaultRoot: root })
+    assert.equal(r.webSource, null)
+  } finally { s.restore() }
+})
+
 test('peckTurn — a failing skill does not break the answer', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))

--- a/scripts/test/web-sources.test.js
+++ b/scripts/test/web-sources.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const matter = require('gray-matter')
+
+const { parseWebSearchOutput, buildWebSource, slugify } = require('../lib/web-sources')
+
+const OUTPUT = `Results for "how do mRNA vaccines work" (via duckduckgo):
+
+- [mRNA vaccines explained](https://example.com/mrna) — They deliver a strand of mRNA that codes for a viral protein.
+- [CDC: Understanding mRNA](https://cdc.gov/mrna) — Overview of the mechanism and safety.
+- [No dash here](https://example.com/plain)`
+
+test('parseWebSearchOutput: pulls query, backend, and the result list', () => {
+  const r = parseWebSearchOutput(OUTPUT)
+  assert.equal(r.query, 'how do mRNA vaccines work')
+  assert.equal(r.backend, 'duckduckgo')
+  assert.equal(r.results.length, 3)
+  assert.deepEqual(r.results[0], {
+    title: 'mRNA vaccines explained',
+    url: 'https://example.com/mrna',
+    snippet: 'They deliver a strand of mRNA that codes for a viral protein.'
+  })
+  assert.equal(r.results[2].snippet, '')
+})
+
+test('parseWebSearchOutput: a "No results" line parses with an empty list', () => {
+  const r = parseWebSearchOutput('No results for "obscure thing" (via brave).')
+  assert.equal(r.query, 'obscure thing')
+  assert.equal(r.backend, 'brave')
+  assert.deepEqual(r.results, [])
+})
+
+test('parseWebSearchOutput: junk returns null', () => {
+  assert.equal(parseWebSearchOutput('the web-search skill is not configured'), null)
+  assert.equal(parseWebSearchOutput(''), null)
+})
+
+test('buildWebSource: one search → a hatchable eggs doc', () => {
+  const now = new Date('2026-08-31T10:00:00Z')
+  const src = buildWebSource('How do mRNA vaccines work?', [parseWebSearchOutput(OUTPUT)], { now })
+  assert.equal(src.filename, 'web-search-2026-08-31-how-do-mrna-vaccines-work.md')
+
+  const { data, content } = matter(src.content)
+  assert.equal(data.source, 'web-search')
+  assert.equal(data.question, 'How do mRNA vaccines work?')
+  assert.equal(data.saved, '2026-08-31')
+  assert.match(content, /# Web search — How do mRNA vaccines work\?/)
+  assert.match(content, /\[mRNA vaccines explained\]\(https:\/\/example\.com\/mrna\)/)
+  assert.match(content, /not the full page text/)
+})
+
+test('buildWebSource: multiple searches get per-query sections', () => {
+  const a = parseWebSearchOutput(OUTPUT)
+  const b = { query: 'vaccine side effects', backend: 'brave', results: [{ title: 'T', url: 'https://x', snippet: 's' }] }
+  const src = buildWebSource('vaccines', [a, b], { now: new Date('2026-08-31') })
+  assert.match(src.content, /## "how do mRNA vaccines work" \(via duckduckgo\)/)
+  assert.match(src.content, /## "vaccine side effects" \(via brave\)/)
+  assert.deepEqual(new Set(matter(src.content).data.backends), new Set(['duckduckgo', 'brave']))
+})
+
+test('buildWebSource: nothing worth saving → null', () => {
+  assert.equal(buildWebSource('q', []), null)
+  assert.equal(buildWebSource('q', [{ query: 'x', backend: 'y', results: [] }]), null)
+  assert.equal(buildWebSource('q', null), null)
+})
+
+test('slugify: lowercases, dashes, trims, caps length', () => {
+  assert.equal(slugify('How do mRNA vaccines work?'), 'how-do-mrna-vaccines-work')
+  assert.equal(slugify('   '), 'query')
+  assert.ok(slugify('a'.repeat(200)).length <= 60)
+})


### PR DESCRIPTION
**Draft — targeting v0.4.0.** Retrieval-layer half of #81. App-side branch to follow.

When Peck answers a question using `web-search`, the results otherwise vanish with the turn. Now the turn result carries a **`webSource`** — a front-matter'd Markdown doc of the result list, ready to drop into `eggs/` and hatch into the nest as reference material.

## Changes

- **`lib/web-sources.js`** (new) — `parseWebSearchOutput` (the skill's stdout → `{query, backend, results[]}`), `buildWebSource` (question + searches → the `eggs/` doc: `web-search-<date>-<slug>.md` with `source: web-search` front-matter), `slugify`.
- **`prompts.js`** `answerQuestionWithSkills` — collects `webSearches` from every successful skill run whose output parses as a search-result list (the built-in `web-search`, or a user's own).
- **`peck.js`** `answerFromPages` — builds `webSource` and returns it; flows through `peckTurn` / `chat.js` JSON unchanged.

## Scope

**v1 saves the result list + snippets.** Fetching the full text of each linked page (better reference material, but needs readability extraction + failure handling) is a follow-up.

## Verification

Suite **248/248** (+9: `web-sources.test.js` parse/build/slug, + 2 `peckTurn` end-to-end — webSource present with web-search, absent without).

🤖 Generated with [Claude Code](https://claude.com/claude-code)