### PR TITLE
Peck: cut the serial LLM calls on the common path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Kip. Format loosely follows
 The retrieval layer (this repo) and the desktop app
 ([kip-app](https://github.com/JWE24-code/kip-app)) are released together.
 
+## [Unreleased]
+
+### The retrieval layer (`scripts/`)
+
+- **Faster Peck** — a turn used to make two-plus serial LLM calls no matter
+  what. Now: the key-term expansion pass is skipped when the direct
+  full-text search already found enough pages (≥ 3), and the skills tool
+  loop is skipped — along with its bigger prompt — unless a skill is
+  plausibly needed (retrieval was thin, or the question asks for
+  current/external info or a generated document). Both are recoverable with
+  Regenerate. Most "what do I know about X" questions now cost a single LLM
+  call.
+
 ## [0.4.0] — 2026-08-31
 
 ### The retrieval layer (`scripts/`)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -198,11 +198,20 @@ node scripts/peck.js "the CDO of CompanyX is John Doe"      # a fact to remember
 `scripts/lib/peck.js`'s `peckTurn(input, {fileToNest, vaultRoot})`
 classifies the input (`classifyPeckInput`) and dispatches:
 
-- **A question** → `askQuestion`: search (direct + key-term pass, unioned),
-  read the candidate pages, ask the LLM for a `{answer, citedSlugs,
-  candidateSlugs}` with `[[slug]]` citations. The CLI prints it and asks
-  (y/n) whether to file it as a `concept` page; the app does not file
-  answers.
+- **A question** → `askQuestion`: search, read the candidate pages, ask the
+  LLM for a `{answer, citedSlugs, candidateSlugs}` with `[[slug]]` citations.
+  The CLI prints it and asks (y/n) whether to file it as a `concept` page;
+  the app does not file answers.
+  - *Retrieval* is a direct FTS pass plus — **only if the direct pass found
+    fewer than `DIRECT_HIT_CONFIDENCE` (3)** — an LLM key-term expansion pass,
+    unioned. Skipping the expansion when the direct search is already
+    confident saves a round-trip.
+  - *The skills tool loop* (`answerQuestionWithSkills`) is entered **only when
+    `mightNeedSkill(question, pageCount)`** — retrieval was thin (< 2 pages)
+    or the question matches `SKILL_HINT_RE` (asks for current/external info,
+    a generated document, or a Kip action). Otherwise it's a plain
+    `answerQuestion` — one call, small prompt. A wrong skip is recoverable
+    with the app's Regenerate.
 - **A statement** → `captureFacts` + `fileCapturedFacts`: it files the fact
   onto the relevant existing page (appended under a dated `_Update_`
   section) or plainly creates an `entity`/`concept` page — same

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -28,6 +28,29 @@ const telemetry = require('./telemetry')
 const BROAD_SEARCH_LIMIT = 15
 const CAPTURE_TYPES = new Set(['entity', 'concept'])
 
+// Latency: both the key-term expansion pass and the skills tool loop cost an
+// LLM round-trip. Skip each when it's very unlikely to change the answer.
+
+// The direct FTS search already found this many ranked hits -> skip the LLM
+// key-term pass (it mostly earns its keep when the question shares few nouns
+// with the nest).
+const DIRECT_HIT_CONFIDENCE = 3
+
+// The question plausibly needs a skill (external/current info, a generated
+// document, a Kip action). Retrieval being thin also triggers the skills path.
+const SKILL_HINT_RE = new RegExp(
+  '\\b(latest|current(?:ly)?|today|tonight|recent(?:ly)?|nowadays|as of \\d|up[- ]?to[- ]?date|this (?:week|month|year))\\b' +
+  '|\\b(?:search|look ?up|google|web ?search|find (?:online|on the web)|on the (?:web|internet))\\b' +
+  '|\\bnews\\b|\\bweather\\b|\\bprice of\\b|\\bstock price\\b|\\bwho (?:won|is winning|leads)\\b|\\bscore of\\b' +
+  '|\\b(?:make|create|draft|generate|build|produce|compose|prepare|export|convert|turn)\\b[^.?!]{0,50}' +
+    '\\b(?:doc|document|word|\\.docx|deck|slides?|presentation|powerpoint|\\.pptx|spreadsheet|sheet|excel|\\.xlsx|\\.csv|chart|graph|report|email|letter|brief)\\b' +
+  '|\\b(?:hatch|groom|rebuild[- ]?roost|coop status|open settings)\\b',
+  'i')
+
+function mightNeedSkill (question, pageCount) {
+  return pageCount < 2 || SKILL_HINT_RE.test(String(question || ''))
+}
+
 // A Peck turn is a 'question' (answer it — running a skill first if that helps)
 // or a 'statement' (a fact to file into the nest). Heuristic on purpose: fast,
 // free, deterministic, and not at the mercy of a weak model mis-reading a plain
@@ -99,11 +122,15 @@ async function retrieveCandidates (question, vaultRoot, { history = [] } = {}) {
     .slice(-3).map((t) => t.text).join(' ')
   const direct = searchPages(`${recentUser} ${question}`.trim(), {}, vaultRoot)
 
+  // Skip the LLM key-term pass when the direct search already found enough —
+  // one fewer round-trip per turn, and a tighter set of pages to answer over.
   let keyTerms = []
-  try {
-    keyTerms = await extractKeyTerms(question, vaultRoot, { history })
-  } catch (err) {
-    console.error(`Warning: key-term extraction failed (${err.message}); continuing with the direct search only.`)
+  if (direct.length < DIRECT_HIT_CONFIDENCE) {
+    try {
+      keyTerms = await extractKeyTerms(question, vaultRoot, { history })
+    } catch (err) {
+      console.error(`Warning: key-term extraction failed (${err.message}); continuing with the direct search only.`)
+    }
   }
   const broad = keyTerms.length ? searchPages(keyTerms.join(' '), { limit: BROAD_SEARCH_LIMIT }, vaultRoot) : []
 
@@ -155,12 +182,19 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   const candidateSlugs = pages.map((p) => p.slug)
   const telemetryStart = telemetry.entries().length
 
+  // The skills tool loop adds a bigger system prompt and, when a skill runs,
+  // extra round-trips. Only take that path — or even look for skills — when
+  // one is plausibly needed; otherwise answer straight from the nest. A miss
+  // is recoverable with the Regenerate button.
   let skills = []
-  try {
-    skills = discoverSkills(vaultRoot)
-  } catch (err) {
-    console.error(`Warning: skill discovery failed (${err.message}); answering without skills.`)
+  if (!arena && mightNeedSkill(question, pages.length)) {
+    try {
+      skills = discoverSkills(vaultRoot)
+    } catch (err) {
+      console.error(`Warning: skill discovery failed (${err.message}); answering without skills.`)
+    }
   }
+  const wantSkills = skills.length > 0
 
   let answer
   let steps = []
@@ -170,7 +204,7 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
     // per-run variance that would muddy a model-vs-model comparison, and a
     // regen is "answer this again, differently" — not "re-run the tool loop".
     answer = await answerQuestion(question, pages, vaultRoot, { arena, history })
-  } else if (skills.length) {
+  } else if (wantSkills) {
     try {
       ({ answer, steps, webSearches } = await answerQuestionWithSkills(question, pages, skills, vaultRoot, { history }))
     } catch (err) {

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -420,6 +420,83 @@ test('peckTurn — with no skills, only peck:answer is called (no skill-turn)', 
   } finally { s.restore() }
 })
 
+test('peckTurn — skips the key-term LLM pass when the direct search is confident', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  for (const slug of ['sleep-hygiene', 'sleep-quality', 'sleep-tracking', 'sleep-debt']) {
+    writePage(root, 'concepts', slug, { type: 'concept', body: 'notes about sleep and rest' })
+  }
+  rebuildRoost(root)
+
+  const s = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep-hygiene]], rest more.' })
+  try {
+    const r = await peckTurn('what do I know about sleep?', { vaultRoot: root })
+    assert.equal(r.answer, 'Per [[sleep-hygiene]], rest more.')
+    assert.ok(!s.calls.some((c) => /key search terms/i.test(c)),
+      'the key-term extraction call was skipped — direct FTS had enough hits')
+  } finally { s.restore() }
+})
+
+test('peckTurn — thin retrieval still runs the key-term pass', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'concepts', 'sleep', { type: 'concept', body: 'notes on sleep' })
+  rebuildRoost(root)
+
+  const s = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep]], rest.' })
+  try {
+    await peckTurn('what about sleep?', { vaultRoot: root })
+    assert.ok(s.calls.some((c) => /key search terms/i.test(c)),
+      'one matching page (< the confidence threshold) → key-term expansion runs')
+  } finally { s.restore() }
+})
+
+test('peckTurn — skills are skipped when the nest answers and the question is not skill-ish', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  onlyFixtureSkills(root, ['web-search'])
+  writeFixtureSkill(root, 'web-search', 'console.log("Results for \\"x\\" (via duckduckgo):\\n\\n- [a](https://a) — s")')
+  for (const slug of ['acme-corp', 'acme-pricing', 'acme-contacts']) {
+    writePage(root, 'entities', slug, { type: 'entity', body: 'Acme is a client we work with.' })
+  }
+  rebuildRoost(root)
+
+  const s = stubPeckFetch({ answer: 'Per [[acme-corp]], they are a client.' })
+  try {
+    const r = await peckTurn('what do we know about Acme?', { vaultRoot: root })
+    assert.equal(r.answer, 'Per [[acme-corp]], they are a client.')
+    assert.deepEqual(r.steps, [])
+    assert.ok(!s.calls.some((c) => /Available skills:/.test(c)), 'no skills block was sent')
+  } finally { s.restore() }
+})
+
+test('peckTurn — a skill-ish question still gets the skills tool loop', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  onlyFixtureSkills(root, ['web-search'])
+  writeFixtureSkill(root, 'web-search',
+    'console.log("Results for \\"latest\\" (via duckduckgo):\\n\\n- [a page](https://a.test) — snip")')
+  for (const slug of ['topic-a', 'topic-b', 'topic-c']) {
+    writePage(root, 'concepts', slug, { type: 'concept', body: 'some notes on the topic' })
+  }
+  rebuildRoost(root)
+
+  const s = stubPeckFetch({
+    answerFn: (sys) => !/<skill_result name="web-search"/.test(sys)
+      ? '<use_skill name="web-search">{"query":"latest news"}</use_skill>'
+      : 'Per the web, ... (via web-search).'
+  })
+  try {
+    const r = await peckTurn('what is the latest news on the topic?', { vaultRoot: root })
+    assert.ok(s.calls.some((c) => /Available skills:/.test(c)), '"latest news" is skill-ish → skills block sent')
+    assert.ok(r.steps.some((x) => x.skill === 'web-search'))
+  } finally { s.restore() }
+})
+
 test('peckTurn — a follow-up carries the conversation history into key-terms + the answer (kip-app#82)', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))


### PR DESCRIPTION
Peck made **2+ serial LLM round-trips per turn** regardless of the question. This skips the ones that rarely change the answer.

## Changes

- **`retrieveCandidates`** — skip `extractKeyTerms` (an LLM call, on the critical path before answering) when the direct FTS search already returned **≥ 3** ranked hits. The key-term expansion earns its keep when the question shares few nouns with the nest; when direct search is confident it just adds a round-trip and bloats the answer prompt.
- **`answerFromPages`** — only enter `answerQuestionWithSkills` (bigger system prompt, plus extra round-trips when a skill actually runs) when `mightNeedSkill(question, pageCount)`: retrieval was thin (< 2 pages) or the question matches `SKILL_HINT_RE` (current/external info, a generated document, a Kip action). Otherwise it's a plain `answerQuestion` — one call, small prompt. Also skips `discoverSkills` on that path. A wrong skip is recoverable with the app's **Regenerate**.

Net: most *"what do I know about X"* questions now cost **one** LLM call instead of two or three.

## Not in this PR

Streaming the answer to the panel (the biggest *perceived*-latency win) — its own piece, touches every connector + `callLLM` + `chat.js` + the Peck panel.

## Verification

Suite **266/266** (+4: key-term skip on confident retrieval / kept on thin; skills skipped on a nest-answerable non-skill-ish question / kept on "latest news …").

🤖 Generated with [Claude Code](https://claude.com/claude-code)