### PR TITLE
Peck: stream the answer as it's generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ The retrieval layer (this repo) and the desktop app
   current/external info or a generated document). Both are recoverable with
   Regenerate. Most "what do I know about X" questions now cost a single LLM
   call.
+- **Streamed Peck answers** — `callLLM()` takes an optional `onStream(chunk,
+  first)` callback; the Anthropic and OpenAI-compatible connectors honour it
+  by requesting an SSE stream and forwarding text deltas as they arrive
+  (json calls and the managed `kip` connector are unchanged — they still
+  return whole). `peckTurn()` threads it through, and `scripts/chat.js`
+  writes the accumulating answer to `peck-progress.json` as `partialAnswer`
+  so the app can render it live. In the skills tool loop every turn streams;
+  a turn that turns out to be a `<use_skill>` tag is held back by the
+  consumer until the text proves to be prose.
 
 ## [0.4.0] — 2026-08-31
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -243,6 +243,21 @@ a "save these" affordance on the answer and writes it via the existing
 `buildWebSource`). v1 saves the list + snippets; full page-text fetch is a
 follow-up.
 
+**Streamed answers** (kip-app#88) — `callLLM({ …, onStream })` takes an
+optional `onStream(chunk, first)`. `llm.js` passes it to the connector as
+`ctx.onDelta` **only for non-json calls**; a json call needs the whole
+string for fence-stripping and has no partial value. The `anthropic` and
+OpenAI-compatible connectors honour it — they request an SSE stream
+(`stream: true`) and forward text deltas; other connectors (the managed
+`kip` backend) ignore it and return whole, unchanged. `answerQuestion` /
+`answerQuestionWithSkills` thread it through; in the skills loop **every
+turn** streams (a turn is either a `<use_skill>` tag or the final prose),
+and `first` is `true` on the first chunk of each turn so the consumer can
+reset its buffer. `scripts/chat.js` accumulates the deltas and throttle-
+writes them to `peck-progress.json` as `partialAnswer` (holding back
+anything that still looks like a partial `<use_skill …>` tag); the app
+polls that and renders the answer live.
+
 - **Tell it about an upcoming event** ("I have a meeting with Acme on Friday
   at 15h", "remind me to email Bob tomorrow") → `peckTurn` detects the
   reminder intent and routes to the `reminders` skill instead of fact

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -17,9 +17,10 @@
 // `steps` (question only) is what the skills tool loop ran, if anything:
 //   [{ skill, input, ok, ms, outputPreview }, ...].
 //
-// During the turn it writes <coop>/.roost/peck-progress.json (a content-free
-// rolling activity feed + running metrics, for the panel to poll) and, on
-// completion, <coop>/.roost/peck-metrics.json. With --trace (or
+// During the turn it writes <coop>/.roost/peck-progress.json (a rolling
+// activity feed + running metrics + the accumulating answer as `partialAnswer`
+// while it streams, for the panel to poll) and, on completion,
+// <coop>/.roost/peck-metrics.json. With --trace (or
 // KIP_PECK_TRACE=1) it also streams every LLM + skill call, full I/O included,
 // to <coop>/.roost/peck-trace.jsonl.
 //
@@ -42,6 +43,20 @@ const ROOST_DIR = path.join(DEFAULT_VAULT_ROOT, '.roost')
 const traceOn = process.argv.includes('--trace') || process.env.KIP_PECK_TRACE === '1'
 
 const VALUE_FLAGS = new Set(['--arena-compare-to', '--history'])
+
+// How often the accumulating answer is written to peck-progress.json while it
+// streams. Fast enough to read as live, slow enough not to thrash the file the
+// panel polls.
+const STREAM_WRITE_MS = 120
+
+/** True while the buffer still might be a `<use_skill …>` tag rather than prose
+ *  — the skills tool loop streams every turn, and a tool-call turn must show
+ *  nothing. Once real prose diverges from the tag prefix this goes false. */
+function looksLikePartialSkillTag (text) {
+  const s = String(text || '').replace(/^\s+/, '').toLowerCase()
+  if (!s) return true
+  return s.startsWith('<use_skill') || '<use_skill'.startsWith(s.slice(0, 10))
+}
 
 async function main () {
   const args = process.argv.slice(2)
@@ -84,8 +99,26 @@ async function main () {
   reporter.setProgress({ phase: 'peck' })
   reporter.flush(true)
 
+  // Stream the answer into peck-progress.json as `partialAnswer` so the panel
+  // can render it live. `first` resets the buffer at the start of every LLM
+  // turn (the skills loop streams each turn); partial `<use_skill>` tags are
+  // held back until the text proves to be prose.
+  let streamBuf = ''
+  let lastStreamWrite = 0
+  const onStream = (chunk, first) => {
+    if (first) streamBuf = ''
+    streamBuf += chunk
+    if (looksLikePartialSkillTag(streamBuf)) return
+    const now = Date.now()
+    if (now - lastStreamWrite < STREAM_WRITE_MS) return
+    lastStreamWrite = now
+    reporter.setProgress({ partialAnswer: streamBuf.replace(/^\s+/, '') })
+    reporter.flush(true)
+  }
+
   try {
-    const result = await peckTurn(input, { fileToNest: false, vaultRoot: DEFAULT_VAULT_ROOT, arenaCompareToCallId, history })
+    const result = await peckTurn(input, { fileToNest: false, vaultRoot: DEFAULT_VAULT_ROOT, arenaCompareToCallId, history, onStream })
+    reporter.setProgress({ partialAnswer: null })
     reporter.flush(false)
     reporter.writeMetrics()
     reporter.close()

--- a/scripts/lib/connectors.js
+++ b/scripts/lib/connectors.js
@@ -81,7 +81,7 @@ function stripCodeFences (text) {
 }
 
 /** Anthropic has no forced-JSON mode: for json:true, ask for it in the system prompt and strip fences after. */
-async function callAnthropic ({ system, prompt, json, maxTokens, apiKey }, AnthropicClient) {
+async function callAnthropic ({ system, prompt, json, maxTokens, apiKey, onDelta }, AnthropicClient) {
   const Anthropic = AnthropicClient || require('@anthropic-ai/sdk')
   // Only pass an explicit apiKey when we have one (from the config file or
   // ANTHROPIC_API_KEY) — an explicit undefined can short-circuit the SDK's
@@ -93,12 +93,41 @@ async function callAnthropic ({ system, prompt, json, maxTokens, apiKey }, Anthr
     ? (system ? `${system}\n\n${JSON_MODE_INSTRUCTION}` : JSON_MODE_INSTRUCTION)
     : system
 
-  const response = await client.messages.create({
+  const createArgs = {
     model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: maxTokens,
     system: finalSystem,
     messages: [{ role: 'user', content: prompt }]
-  })
+  }
+
+  // Non-JSON + a delta sink ⇒ stream: iterate the SSE events, forward text
+  // deltas, and rebuild the same response shape the non-streaming path returns.
+  if (!json && typeof onDelta === 'function') {
+    const stream = await client.messages.create({ ...createArgs, stream: true })
+    let text = ''
+    let usage = null
+    let stopReason = null
+    let first = true
+    for await (const event of stream) {
+      if (!event || typeof event !== 'object') continue
+      if (event.type === 'content_block_delta' && event.delta && event.delta.type === 'text_delta') {
+        text += event.delta.text
+        try { onDelta(event.delta.text, first) } catch { /* best-effort */ }
+        first = false
+      } else if (event.type === 'message_start' && event.message && event.message.usage) {
+        usage = { ...event.message.usage }
+      } else if (event.type === 'message_delta') {
+        if (event.usage) usage = { ...(usage || {}), ...event.usage }
+        if (event.delta && event.delta.stop_reason) stopReason = event.delta.stop_reason
+      }
+    }
+    return {
+      text: text.trim(),
+      raw: { content: [{ type: 'text', text }], usage: usage || undefined, stop_reason: stopReason }
+    }
+  }
+
+  const response = await client.messages.create(createArgs)
 
   const rawText = response.content
     .filter((b) => b.type === 'text')
@@ -128,6 +157,97 @@ async function postChatCompletion (baseUrl, apiKey, body, doFetch) {
   return response.json()
 }
 
+/** Iterate a fetch response body as chunks, whether it's an async iterable
+ *  (undici) or a web ReadableStream (getReader). Yields nothing for a null
+ *  body (a fake fetch that only implements json()/text()). */
+async function * iterateBody (body) {
+  if (!body) return
+  if (typeof body[Symbol.asyncIterator] === 'function') {
+    yield * body
+    return
+  }
+  if (typeof body.getReader === 'function') {
+    const reader = body.getReader()
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) return
+      yield value
+    }
+  }
+}
+
+/**
+ * POST /chat/completions with stream:true and consume the SSE deltas, calling
+ * onDelta(textChunk, isFirst) as prose arrives. Returns the SAME shape
+ * postChatCompletion resolves to — { choices: [{ message: { content },
+ * finish_reason }], usage, model } — so every downstream reader (rawText
+ * extraction, extractUsage, responseWasTruncated) works unchanged.
+ */
+async function streamChatCompletion (baseUrl, apiKey, body, doFetch, onDelta) {
+  const headers = { 'Content-Type': 'application/json' }
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`
+
+  // No `stream_options: {include_usage}` — OpenAI needs it to report usage
+  // while streaming, but stricter OpenAI-compatible servers (some Ollama
+  // builds) 400 on the unknown field. A streamed Peck answer loses its token
+  // counts in telemetry; that's the trade for working everywhere.
+  const response = await doFetch(`${baseUrl.replace(/\/$/, '')}/chat/completions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ ...body, stream: true })
+  })
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => response.status)
+    const err = new Error(`${baseUrl} request failed (${response.status}): ${errText}`)
+    err.status = response.status
+    throw err
+  }
+
+  let text = ''
+  let usage = null
+  let model
+  let finishReason = null
+  let first = true
+  let buf = ''
+  const decoder = new TextDecoder()
+
+  const handleData = (payload) => {
+    if (payload === '[DONE]') return
+    let j
+    try { j = JSON.parse(payload) } catch { return }
+    if (j.model) model = j.model
+    if (j.usage) usage = j.usage
+    const choice = j.choices && j.choices[0]
+    if (!choice) return
+    if (choice.finish_reason) finishReason = choice.finish_reason
+    const delta = choice.delta && choice.delta.content
+    if (delta) {
+      text += delta
+      try { onDelta(delta, first) } catch { /* best-effort */ }
+      first = false
+    }
+  }
+
+  for await (const chunk of iterateBody(response.body)) {
+    buf += decoder.decode(chunk, { stream: true })
+    let nl
+    while ((nl = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, nl).trim()
+      buf = buf.slice(nl + 1)
+      if (line.startsWith('data:')) handleData(line.slice(5).trim())
+    }
+  }
+  const tail = buf.trim()
+  if (tail.startsWith('data:')) handleData(tail.slice(5).trim())
+
+  return {
+    choices: [{ message: { content: text }, finish_reason: finishReason }],
+    usage,
+    model
+  }
+}
+
 /**
  * One generic client for every OpenAI-compatible chat completions API
  * (openai, deepseek, local/Ollama, "other", and future connectors) — only
@@ -141,7 +261,7 @@ async function postChatCompletion (baseUrl, apiKey, body, doFetch) {
  * first call. Either way json:true costs one round-trip, not two, on every
  * call after (at most) one.
  */
-async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, json, maxTokens }, fetchImpl) {
+async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, json, maxTokens, onDelta }, fetchImpl) {
   const doFetch = fetchImpl || fetch
 
   const buildMessages = (sys) => {
@@ -164,7 +284,13 @@ async function callOpenAICompatible ({ baseUrl, apiKey, model, system, prompt, j
     isReasoningModel(model) || learnedNoResponseFormat.has(jsonModeKey(baseUrl, model))
 
   let data
-  if (!json) {
+  if (!json && typeof onDelta === 'function') {
+    data = await streamChatCompletion(baseUrl, apiKey, {
+      model,
+      max_tokens: maxTokens,
+      messages: buildMessages(system)
+    }, doFetch, onDelta)
+  } else if (!json) {
     data = await postChatCompletion(baseUrl, apiKey, {
       model,
       max_tokens: maxTokens,
@@ -214,7 +340,8 @@ function builtinSpecs ({ anthropicClient, fetchImpl } = {}) {
       system: call.system,
       prompt: call.prompt,
       json: call.json,
-      maxTokens: call.maxTokens
+      maxTokens: call.maxTokens,
+      onDelta: ctx && ctx.onDelta
     }, fetchImpl || (ctx && ctx.fetch))
 
   return [
@@ -228,9 +355,16 @@ function builtinSpecs ({ anthropicClient, fetchImpl } = {}) {
       ],
       envDefaults: { apiKey: 'ANTHROPIC_API_KEY' },
       isReady: () => true,
-      async complete (resolved, call) {
+      async complete (resolved, call, ctx) {
         return callAnthropic(
-          { system: call.system, prompt: call.prompt, json: call.json, maxTokens: call.maxTokens, apiKey: resolved.apiKey },
+          {
+            system: call.system,
+            prompt: call.prompt,
+            json: call.json,
+            maxTokens: call.maxTokens,
+            apiKey: resolved.apiKey,
+            onDelta: ctx && ctx.onDelta
+          },
           anthropicClient
         )
       }

--- a/scripts/lib/llm.js
+++ b/scripts/lib/llm.js
@@ -144,7 +144,7 @@ function assertConfigured (spec, resolved) {
  * `label` (optional) tags the call in scripts/lib/telemetry.js — e.g.
  * "hatch:propose", "hatch:generate:entity", "peck:answer".
  */
-async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label, arena = null }, overrides = {}) {
+async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label, arena = null, onStream = null }, overrides = {}) {
   const vaultRoot = overrides.vaultRoot || DEFAULT_VAULT_ROOT
   const { spec, resolved } = resolveActive(vaultRoot, {
     anthropicClient: overrides.AnthropicClient,
@@ -156,7 +156,11 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label,
   const ctx = {
     fetch: overrides.fetchImpl || fetch,
     signal: overrides.signal,
-    logger: overrides.logger || console
+    logger: overrides.logger || console,
+    // Streaming is prose-only: a json:true call has no partial value and its
+    // fence-stripping wants the whole string. Connectors that can't stream
+    // simply ignore this.
+    onDelta: (!json && typeof onStream === 'function') ? onStream : null
   }
 
   const started = Date.now()

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -178,7 +178,7 @@ async function fileAnswerToNest (question, answer, candidateSlugs, vaultRoot = D
  * can call them mid-answer — `steps` records what it ran. Skill discovery and
  * the whole tool loop are best-effort: a failure downgrades to a plain answer.
  */
-async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena = null, history = [] }) {
+async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena = null, history = [], onStream = null }) {
   const candidateSlugs = pages.map((p) => p.slug)
   const telemetryStart = telemetry.entries().length
 
@@ -206,14 +206,14 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
     answer = await answerQuestion(question, pages, vaultRoot, { arena, history })
   } else if (wantSkills) {
     try {
-      ({ answer, steps, webSearches } = await answerQuestionWithSkills(question, pages, skills, vaultRoot, { history }))
+      ({ answer, steps, webSearches } = await answerQuestionWithSkills(question, pages, skills, vaultRoot, { history, onStream }))
     } catch (err) {
       console.error(`Warning: the skills tool loop failed (${err.message}); falling back to a plain answer.`)
-      answer = await answerQuestion(question, pages, vaultRoot, { history })
+      answer = await answerQuestion(question, pages, vaultRoot, { history, onStream })
       steps = []
     }
   } else {
-    answer = await answerQuestion(question, pages, vaultRoot, { history })
+    answer = await answerQuestion(question, pages, vaultRoot, { history, onStream })
   }
 
   const citedSlugs = extractCitedSlugs(answer, candidateSlugs)
@@ -289,14 +289,14 @@ function fileCapturedFacts (proposedPages, vaultRoot = DEFAULT_VAULT_ROOT) {
  *
  * @returns {{answer: string|null, citedSlugs: string[], candidateSlugs: string[], steps: Array, callId: string|null, arenaId: string|null}}
  */
-async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_VAULT_ROOT, arenaCompareToCallId = null, history = [] } = {}) {
+async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_VAULT_ROOT, arenaCompareToCallId = null, history = [], onStream = null } = {}) {
   const candidates = await retrieveCandidates(question, vaultRoot, { history })
   if (candidates.length === 0 && !anySkills(vaultRoot)) {
     return { answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
   }
   const pages = readPageBodies(vaultRoot, candidates)
   const arena = arenaCompareToCallId ? { compareToCallId: arenaCompareToCallId } : null
-  return answerFromPages(question, pages, { fileToNest, vaultRoot, arena, history })
+  return answerFromPages(question, pages, { fileToNest, vaultRoot, arena, history, onStream })
 }
 
 /**
@@ -311,7 +311,7 @@ async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_V
  *              shape as question; the `reminders` skill did the work and its
  *              confirmation is in `answer`.
  */
-async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = false, arenaCompareToCallId = null, history = [] } = {}) {
+async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = false, arenaCompareToCallId = null, history = [], onStream = null } = {}) {
   // An upcoming event the user wants reminding about ("I have a meeting Friday
   // at 15h", "remind me to …") — route to the skills path (the `reminders`
   // skill creates it), NOT fact-capture, which would file it as a nest page.
@@ -337,7 +337,7 @@ async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = f
     return { intent: 'question', answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
   }
   const arena = arenaCompareToCallId ? { compareToCallId: arenaCompareToCallId } : null
-  return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena, history })) }
+  return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena, history, onStream })) }
 }
 
 module.exports = { askQuestion, peckTurn, classifyPeckInput, fileAnswerToNest, fileCapturedFacts, extractCitedSlugs }

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -63,12 +63,12 @@ Cite every claim back to the specific page it came from using Logseq's wikilink 
  *  candidate B against an earlier answer — the regenerate free-rider
  *  (kip-app#73). `history` (optional): recent {role,text} turns for
  *  follow-up context (kip-app#82). */
-async function answerQuestion (question, pages, vaultRoot, { arena = null, history = [] } = {}) {
+async function answerQuestion (question, pages, vaultRoot, { arena = null, history = [], onStream = null } = {}) {
   const convo = formatConversation(history)
   const prompt = `${formatPagesForPrompt(pages)}\n\n---\n\n` +
     (convo ? `${convo}\n\n---\n\n` : '') +
     `Question: ${question}`
-  const { text } = await callLLM({ system: ANSWER_SYSTEM_PROMPT, prompt, maxTokens: 4096, label: 'peck:answer', arena }, { vaultRoot })
+  const { text } = await callLLM({ system: ANSWER_SYSTEM_PROMPT, prompt, maxTokens: 4096, label: 'peck:answer', arena, onStream }, { vaultRoot })
   return text
 }
 
@@ -146,9 +146,9 @@ function formatSkillsBlock (skills) {
  * With no skills it's just answerQuestion(). Any unexpected throw is the
  * caller's (peck.js's) to catch and downgrade.
  */
-async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { runSkillFn = runSkill, history = [] } = {}) {
+async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { runSkillFn = runSkill, history = [], onStream = null } = {}) {
   if (!skills || !skills.length) {
-    return { answer: await answerQuestion(question, pages, vaultRoot, { history }), steps: [], webSearches: [] }
+    return { answer: await answerQuestion(question, pages, vaultRoot, { history, onStream }), steps: [], webSearches: [] }
   }
 
   const byName = new Map(skills.map((s) => [s.name, s]))
@@ -161,11 +161,16 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
   const webSearches = []   // parsed results of every web-search run this turn (kip-app#81)
 
   for (let turn = 0; turn <= MAX_SKILL_ITERATIONS; turn++) {
+    // Stream every turn: a turn is either a <use_skill> tag or the final
+    // prose. The consumer keys off the `first` flag to reset its buffer each
+    // turn and suppresses anything that still looks like a partial skill tag,
+    // so a tool-call turn shows nothing and the answer turn streams clean.
     const { text, raw } = await callLLM({
       system,
       prompt: transcript,
       maxTokens: 4096,
-      label: turn === 0 ? 'peck:answer' : 'peck:skill-turn'
+      label: turn === 0 ? 'peck:answer' : 'peck:skill-turn',
+      onStream
     }, { vaultRoot })
 
     const call = parseSkillCall(text)
@@ -181,7 +186,8 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
         system: ANSWER_SYSTEM_PROMPT,
         prompt: `${transcript}\n\nAnswer the question now with what you have.`,
         maxTokens: 4096,
-        label: 'peck:answer:final'
+        label: 'peck:answer:final',
+        onStream
       }, { vaultRoot })
       return { answer: final, steps, webSearches }
     }
@@ -217,7 +223,7 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
   }
 
   // unreachable (the turn === MAX branch returns), but be safe
-  return { answer: await answerQuestion(question, pages, vaultRoot), steps, webSearches }
+  return { answer: await answerQuestion(question, pages, vaultRoot, { history, onStream }), steps, webSearches }
 }
 
 /**

--- a/scripts/test/llm.test.js
+++ b/scripts/test/llm.test.js
@@ -39,13 +39,21 @@ async function withEnv (vars, fn) {
   }
 }
 
-function fakeAnthropicClient (responseText) {
+function fakeAnthropicClient (responseText, { streamDeltas } = {}) {
   let lastCall = null
   class FakeAnthropic {
     constructor () {
       this.messages = {
         create: async (args) => {
           lastCall = args
+          if (args.stream) {
+            const deltas = streamDeltas || [responseText]
+            return (async function * () {
+              yield { type: 'message_start', message: { usage: { input_tokens: 3, output_tokens: 0 } } }
+              for (const d of deltas) yield { type: 'content_block_delta', delta: { type: 'text_delta', text: d } }
+              yield { type: 'message_delta', usage: { output_tokens: 5 }, delta: { stop_reason: 'end_turn' } }
+            })()
+          }
           return { content: [{ type: 'text', text: responseText }] }
         }
       }
@@ -59,6 +67,22 @@ function fakeFetch (responseBody, { ok = true, status = 200, resHeaders = {} } =
   const impl = async (url, init) => {
     lastCall = { url, init }
     return { ok, status, headers: new Headers(resHeaders), json: async () => responseBody, text: async () => JSON.stringify(responseBody) }
+  }
+  return { impl, getLastCall: () => lastCall }
+}
+
+/** A fake fetch whose response body streams OpenAI-shaped SSE chunks — one
+ *  `data:` line per delta, a final line with finish_reason + usage, [DONE]. */
+function fakeStreamFetch (deltas, { finishReason = 'stop' } = {}) {
+  let lastCall = null
+  const impl = async (url, init) => {
+    lastCall = { url, init }
+    const lines = deltas.map((d) =>
+      `data: ${JSON.stringify({ choices: [{ delta: { content: d } }] })}\n\n`)
+    lines.push(`data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: finishReason }], usage: { prompt_tokens: 3, completion_tokens: 5 } })}\n\n`)
+    lines.push('data: [DONE]\n\n')
+    const body = (async function * () { for (const l of lines) yield Buffer.from(l) })()
+    return { ok: true, status: 200, headers: new Headers(), body, json: async () => ({}), text: async () => '' }
   }
   return { impl, getLastCall: () => lastCall }
 }
@@ -123,6 +147,54 @@ test('callLLM: switching PROVIDER changes which code path gets hit', async () =>
     callLLM({ system: 's', prompt: 'p' }, { AnthropicClient: FakeAnthropic, fetchImpl: impl, vaultRoot: EMPTY_VAULT }))
   assert.equal(openaiResult.text, 'openai reply')
   assert.ok(getFetchCall(), 'fetch path should have been hit for PROVIDER=openai')
+})
+
+test('callLLM: onStream streams OpenAI-compatible deltas and still returns the full text', async () => {
+  await withEnv({ PROVIDER: 'openai', OPENAI_API_KEY: 'k', OPENAI_MODEL: 'gpt-test' }, async () => {
+    const { impl, getLastCall } = fakeStreamFetch(['Hel', 'lo ', 'world'])
+    const seen = []
+    const result = await callLLM(
+      { system: 's', prompt: 'p', onStream: (c, first) => seen.push([c, first]) },
+      { fetchImpl: impl, vaultRoot: EMPTY_VAULT })
+    assert.equal(result.text, 'Hello world')
+    assert.deepEqual(seen, [['Hel', true], ['lo ', false], ['world', false]])
+    assert.equal(JSON.parse(getLastCall().init.body).stream, true)
+  })
+})
+
+test('callLLM: onStream is ignored for json:true (whole string needed, no partial value)', async () => {
+  await withEnv({ PROVIDER: 'openai', OPENAI_API_KEY: 'k', OPENAI_MODEL: 'gpt-test' }, async () => {
+    const { impl, getLastCall } = fakeFetch({ choices: [{ message: { content: '{"a":1}' } }] })
+    const seen = []
+    const result = await callLLM(
+      { system: 's', prompt: 'p', json: true, onStream: (c) => seen.push(c) },
+      { fetchImpl: impl, vaultRoot: EMPTY_VAULT })
+    assert.equal(result.text, '{"a":1}')
+    assert.equal(seen.length, 0)
+    assert.ok(!JSON.parse(getLastCall().init.body).stream)
+  })
+})
+
+test('callLLM: onStream streams Anthropic text deltas and returns the joined text', async () => {
+  await withEnv({ PROVIDER: 'anthropic' }, async () => {
+    const { FakeAnthropic, getLastCall } = fakeAnthropicClient(null, { streamDeltas: ['Hel', 'lo'] })
+    const seen = []
+    const result = await callLLM(
+      { system: 's', prompt: 'p', onStream: (c, first) => seen.push([c, first]) },
+      { AnthropicClient: FakeAnthropic, vaultRoot: EMPTY_VAULT })
+    assert.equal(result.text, 'Hello')
+    assert.deepEqual(seen, [['Hel', true], ['lo', false]])
+    assert.equal(getLastCall().stream, true)
+  })
+})
+
+test('callLLM: without onStream the non-streaming path is used', async () => {
+  await withEnv({ PROVIDER: 'openai', OPENAI_API_KEY: 'k', OPENAI_MODEL: 'gpt-test' }, async () => {
+    const { impl, getLastCall } = fakeFetch({ choices: [{ message: { content: 'plain' } }] })
+    const result = await callLLM({ system: 's', prompt: 'p' }, { fetchImpl: impl, vaultRoot: EMPTY_VAULT })
+    assert.equal(result.text, 'plain')
+    assert.ok(!JSON.parse(getLastCall().init.body).stream)
+  })
 })
 
 test('callLLM: json:true on anthropic appends the JSON instruction and strips code fences', async () => {

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -168,6 +168,40 @@ test('askQuestion', async (t) => {
       global.fetch = originalFetch
     }
   })
+
+  await t.test('onStream forwards the answer deltas from the provider (kip-app#88)', async () => {
+    writePage(root, 'concepts', 'sailing', { type: 'concept', tags: [], body: 'Started sailing this summer.' })
+    rebuildRoost(root)
+    saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+
+    const originalFetch = global.fetch
+    global.fetch = async (url, init) => {
+      const body = JSON.parse(init.body)
+      const isKeyTerms = body.messages.some((m) => m.content.includes('key search terms'))
+      if (isKeyTerms) {
+        return { ok: true, status: 200, json: async () => ({ choices: [{ message: { content: '{"terms":["sailing"]}' } }] }) }
+      }
+      // the answer call arrives with stream:true — reply with SSE
+      assert.equal(body.stream, true, 'the answer call should be a streaming request')
+      const parts = ['I ', 'sail ', '[[sailing]].']
+      const lines = parts.map((p) => `data: ${JSON.stringify({ choices: [{ delta: { content: p } }] })}\n\n`)
+      lines.push('data: [DONE]\n\n')
+      const bodyStream = (async function * () { for (const l of lines) yield Buffer.from(l) })()
+      return { ok: true, status: 200, headers: new Headers(), body: bodyStream, json: async () => ({}), text: async () => '' }
+    }
+
+    try {
+      const chunks = []
+      const result = await askQuestion('what do I know about sailing?', {
+        vaultRoot: root,
+        onStream: (c) => chunks.push(c)
+      })
+      assert.equal(chunks.join(''), 'I sail [[sailing]].')
+      assert.equal(result.answer, 'I sail [[sailing]].')
+    } finally {
+      global.fetch = originalFetch
+    }
+  })
 })
 
 test('classifyPeckInput — trailing ? or a leading question word is a question, else a statement', () => {


### PR DESCRIPTION
Stacked on #26 (`feat/peck-latency`) — review/merge that first.

## What

A Peck answer now appears token by token as the model writes it, instead of after a wait then all at once.

- **`callLLM({ …, onStream })`** — optional `onStream(chunk, first)`. `llm.js` passes it to the connector as `ctx.onDelta`, **non-json calls only** (a json call needs the whole string for fence-stripping and has no partial value).
- **Connectors** — `anthropic` and the OpenAI-compatible family (`openai` / `deepseek` / `local` / `other`) honour it: request `stream: true`, parse the SSE deltas, forward text, and rebuild the same response shape the non-streaming path returns (so `extractUsage` / `responseWasTruncated` / rawText extraction all work unchanged). Other connectors — including the managed `kip` backend — ignore `onDelta` and return whole, exactly as before. (Managed-backend streaming needs a backend change; follow-up.)
- **`answerQuestion` / `answerQuestionWithSkills`** thread it through. In the skills loop **every turn** streams — a turn is either a `<use_skill>` tag or the final prose — and `first` is `true` on the first chunk of each turn so the consumer resets its buffer and holds back a partial tag until the text proves to be prose.
- **`scripts/chat.js`** accumulates the deltas and throttle-writes them (~120 ms) to `peck-progress.json` as `partialAnswer`, suppressing anything that still looks like a partial `<use_skill …>` tag. The Kip app polls that file (kip-app#88) and renders the answer live.

No `stream_options: {include_usage}` is sent — OpenAI needs it to report usage while streaming but stricter OpenAI-compatible servers 400 on the unknown field. A streamed Peck answer loses its token counts in telemetry; that's the trade for working everywhere.

## Tests

`scripts/test/llm.test.js` — OpenAI-compat streaming forwards deltas + returns full text; `json:true` ignores `onStream`; Anthropic streaming; no-`onStream` still uses the non-streaming path. `scripts/test/peck.test.js` — `askQuestion({ onStream })` forwards the provider's answer deltas end to end. Suite 271/271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)