### PR TITLE
Office & PDF documents as Hatch sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ All notable changes to Kip. Format loosely follows
 The retrieval layer (this repo) and the desktop app
 ([kip-app](https://github.com/JWE24-code/kip-app)) are released together.
 
-## [0.4.0] — 2026-08-31
+## [Unreleased]
+
+### The retrieval layer (`scripts/`)
+
+- **Office & PDF documents as Hatch sources** (kip-app#91) — new
+  `scripts/lib/office.js` + `scripts/office-extract.js` CLI convert a `.docx`,
+  `.xlsx` / `.xls` / `.csv`, `.pptx` or `.pdf` into compact Markdown: Word
+  keeps its headings / lists / tables (`mammoth`), a workbook becomes one
+  Markdown table per sheet (`xlsx`), a deck becomes per-slide bullets plus
+  speaker notes (`pizzip`), a PDF its text layer (`pdf-parse`). Hatch runs the
+  conversion automatically for anything in `eggs/` (idempotent; the original
+  is left in place, the `.md` sibling is what gets hatched), so a document
+  synced in via Dropbox or added by the app all land the same way — and the
+  LLM reads a few KB of prose instead of megabytes of zipped XML. Legacy
+  `.doc` / `.ppt` / OpenDocument are rejected with a "re-save as .docx" hint.
+  New deps: `mammoth`, `pdf-parse`.
 
 ### The retrieval layer (`scripts/`)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -53,6 +53,19 @@ never edits them. (A `whiteboards/*.edn` board becomes a deterministic
 text outline plus a one-call LLM "Context" section; the rest go through the
 full multi-call LLM hatch.)
 
+**Office / PDF sources** (`scripts/lib/office.js`, kip-app#91) — a `.docx`,
+`.xlsx`/`.xls`/`.csv`, `.pptx` or `.pdf` dropped into `eggs/` is converted to
+a compact Markdown sibling (`<stem>.md`) *before* the hatch scan sees it —
+Word keeps headings/lists/tables (`mammoth`), a spreadsheet becomes one table
+per sheet (`xlsx`), a deck becomes per-slide bullets + notes (`pizzip`), a PDF
+its text layer (`pdf-parse`). The scan then skips the original and hatches the
+`.md`. `convertPendingOfficeSources()` runs at the top of `hatchAllSources`,
+`proposeNextPending` and `pendingSourcesSummary`, is idempotent (mtime check),
+and collects per-file failures rather than throwing. `scripts/office-extract.js`
+is the standalone CLI (`--json` / `--stdout`); the app shells out to it on drop
+so the `.md` appears immediately. Legacy `.doc`/`.ppt`/OpenDocument are rejected
+with a "re-save as .docx" hint.
+
 The whole `coop/` tree here is just the default the CLI scripts use. The
 Kip app operates on **whatever folder you open as your graph** — see
 "Pointing it at a coop" below.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "edn-data": "^1.2.2",
         "gray-matter": "^4.0.3",
         "ical.js": "^2.2.1",
+        "mammoth": "^1.12.2",
+        "pdf-parse": "^1.1.4",
         "pizzip": "^3.1.7",
         "pptx-automizer": "^0.7.2",
         "pptxgenjs": "^3.12.0",
@@ -204,6 +206,12 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -441,6 +449,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/docx": {
       "version": "9.7.1",
       "resolved": "https://registry.npmjs.org/docx/-/docx-9.7.1.tgz",
@@ -480,6 +494,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -1534,6 +1557,50 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.2.tgz",
+      "integrity": "sha512-MH2vkgafD/2MYUaEOtoXLKrHQZ7yLYTHGQgyLNtYZHiUxU1K1QQ+8qMFquDAfhBm06wSGSws3J+Q9QTsKtR44g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/@xmldom/xmldom": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1618,6 +1685,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -1668,6 +1741,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/own-keys": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
@@ -1691,6 +1770,31 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
+      "integrity": "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -2438,6 +2542,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
@@ -2569,6 +2679,15 @@
       },
       "bin": {
         "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "peck": "node scripts/peck.js",
     "groom": "node scripts/groom.js",
     "hatch": "node scripts/hatch.js",
-    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/preference-signals.test.js scripts/test/feedback-poster.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js scripts/test/calendar.test.js scripts/test/web-sources.test.js"
+    "test": "node --test scripts/test/roost.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/preference-signals.test.js scripts/test/feedback-poster.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js scripts/test/calendar.test.js scripts/test/web-sources.test.js scripts/test/office.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.70.0",
@@ -21,6 +21,8 @@
     "edn-data": "^1.2.2",
     "gray-matter": "^4.0.3",
     "ical.js": "^2.2.1",
+    "mammoth": "^1.12.2",
+    "pdf-parse": "^1.1.4",
     "pizzip": "^3.1.7",
     "pptx-automizer": "^0.7.2",
     "pptxgenjs": "^3.12.0",

--- a/scripts/hatch-all.js
+++ b/scripts/hatch-all.js
@@ -84,7 +84,7 @@ function parseSkip () {
 
 async function main () {
   if (process.argv.includes('--preview')) {
-    console.log(JSON.stringify(pendingSourcesSummary(DEFAULT_VAULT_ROOT)))
+    console.log(JSON.stringify(await pendingSourcesSummary(DEFAULT_VAULT_ROOT)))
     return
   }
 

--- a/scripts/lib/hatch.js
+++ b/scripts/lib/hatch.js
@@ -14,6 +14,7 @@ const {
 const { resolvePage } = require('./pages')
 const { proposeCandidatePages, generatePageContent, proposeAndDraftPages, describeWhiteboard } = require('./prompts')
 const { parseWhiteboard, whiteboardToOutline } = require('./whiteboard')
+const { isSupported: isOfficeFile, convertFile: convertOfficeFile, markdownNameFor } = require('./office')
 const { DEFAULT_VAULT_ROOT, eggsPath, nestPath, TYPE_DIRS } = require('./paths')
 
 const VALID_TYPES = new Set(Object.keys(TYPE_DIRS))
@@ -279,6 +280,37 @@ function meaningfulTextLength (raw) {
 }
 
 /**
+ * Turn every Office / PDF file dropped into eggs/ into a Markdown sibling
+ * (scripts/lib/office.js) so the normal source scan can read it. Idempotent —
+ * an up-to-date `<stem>.md` is left alone. Best-effort per file: a conversion
+ * failure is collected, not thrown.
+ *
+ * Runs before every hatch entry point (hatchAllSources, proposeNextPending,
+ * pendingSourcesSummary) so a `.docx` synced in through Dropbox, or added by
+ * `office-extract.js`, or dropped in the app all end up hatched the same way.
+ *
+ * @returns {{converted: Array<{source, kind}>, failed: Array<{source, error}>}}
+ */
+async function convertPendingOfficeSources (vaultRoot = DEFAULT_VAULT_ROOT) {
+  const eggsDir = eggsPath(vaultRoot)
+  if (!fs.existsSync(eggsDir)) return { converted: [], failed: [] }
+
+  const converted = []
+  const failed = []
+  for (const entry of fs.readdirSync(eggsDir, { withFileTypes: true })) {
+    if (!entry.isFile() || entry.name.startsWith('.') || !isOfficeFile(entry.name)) continue
+    const absPath = path.join(eggsDir, entry.name)
+    try {
+      const r = await convertOfficeFile(absPath, path.join(eggsDir, markdownNameFor(entry.name)))
+      if (!r.skipped) converted.push({ source: entry.name, kind: r.kind })
+    } catch (err) {
+      failed.push({ source: entry.name, error: (err && err.message) || String(err) })
+    }
+  }
+  return { converted, failed }
+}
+
+/**
  * The deterministic half of "Hatch sources": scans the coop's source dirs
  * (eggs/, journals/, pages/, whiteboards/) and buckets every file. No LLM,
  * no writes.
@@ -309,6 +341,10 @@ function collectPendingSources (vaultRoot = DEFAULT_VAULT_ROOT, { roots = SOURCE
       if (!entry.isFile() || entry.name.startsWith('.')) continue
       const name = entry.name.toLowerCase()
       if (board ? !name.endsWith('.edn') : (root !== 'eggs' && !name.endsWith('.md'))) continue
+      // An Office/PDF file in eggs/ is a *source for* conversion, not a source
+      // to hatch — convertPendingOfficeSources() turns it into a .md sibling
+      // that this scan then picks up on its own. See hatch-all.js / the app.
+      if (root === 'eggs' && isOfficeFile(name)) continue
 
       const absPath = path.join(dir, entry.name)
       const relPath = `${root}/${entry.name}`
@@ -333,14 +369,17 @@ function collectPendingSources (vaultRoot = DEFAULT_VAULT_ROOT, { roots = SOURCE
 /**
  * Preview for the "Hatch sources" UI — what a run would touch, with no LLM
  * calls. `totalKb` is the combined size of `pending`, a rough proxy for how
- * much a full run will cost.
+ * much a full run will cost. Converts any pending Office/PDF file first so it
+ * shows up as its `.md`; `conversionFailed` lists the ones that wouldn't.
  */
-function pendingSourcesSummary (vaultRoot = DEFAULT_VAULT_ROOT, opts = {}) {
+async function pendingSourcesSummary (vaultRoot = DEFAULT_VAULT_ROOT, opts = {}) {
+  const conv = await convertPendingOfficeSources(vaultRoot)
   const { pending, oversized, empty } = collectPendingSources(vaultRoot, opts)
   return {
     pending: pending.map((p) => ({ source: humanizeFilename(p.absPath), kind: p.kind, kb: Math.round(p.bytes / 1024) })),
     oversized: oversized.map((o) => ({ source: o.relPath, kb: Math.round(o.bytes / 1024) })),
     empty,
+    conversionFailed: conv.failed,
     totalKb: Math.round(pending.reduce((sum, p) => sum + p.bytes, 0) / 1024)
   }
 }
@@ -373,6 +412,7 @@ function pendingSourcesSummary (vaultRoot = DEFAULT_VAULT_ROOT, opts = {}) {
  */
 async function hatchAllSources (vaultRoot = DEFAULT_VAULT_ROOT,
   { roots = SOURCE_ROOTS, limit = DEFAULT_BATCH_SIZE, onProgress = () => {}, combined = true } = {}) {
+  const conversion = await convertPendingOfficeSources(vaultRoot)
   const { pending, oversized, empty } = collectPendingSources(vaultRoot, { roots })
   const batch = pending.slice(0, limit)
 
@@ -416,9 +456,14 @@ async function hatchAllSources (vaultRoot = DEFAULT_VAULT_ROOT,
 
   if (hatched.length) regenerateIndexMd(vaultRoot)
 
+  // A file that couldn't be converted (a corrupt .docx, a scanned-image PDF)
+  // is a failure the user should see, same as a bad hatch.
+  for (const f of conversion.failed) failed.push({ source: f.source, error: `couldn't convert: ${f.error}`, ms: 0 })
+
   return {
     hatched,
     failed,
+    converted: conversion.converted,
     oversized: oversized.map((o) => ({ source: o.relPath, kb: Math.round(o.bytes / 1024) })),
     empty,
     remaining: Math.max(0, pending.length - batch.length)
@@ -439,6 +484,7 @@ async function hatchAllSources (vaultRoot = DEFAULT_VAULT_ROOT,
  */
 async function proposeNextPending (vaultRoot = DEFAULT_VAULT_ROOT,
   { roots = SOURCE_ROOTS, limit = DEFAULT_BATCH_SIZE, skip = 0, combined = true } = {}) {
+  await convertPendingOfficeSources(vaultRoot)
   const { pending } = collectPendingSources(vaultRoot, { roots })
   const capped = pending.slice(0, limit)
   const file = capped[skip]
@@ -523,6 +569,7 @@ module.exports = {
   meaningfulTextLength,
   mapLimit,
   collectPendingSources,
+  convertPendingOfficeSources,
   pendingSourcesSummary,
   hatchAllSources,
   hatchWhiteboard,

--- a/scripts/lib/office.js
+++ b/scripts/lib/office.js
@@ -1,0 +1,290 @@
+// Convert an Office / PDF file into Markdown a Hatch pass can actually read.
+//
+// A .docx / .xlsx / .pptx is a zip of XML; a .pdf is a binary stream. Fed to
+// the LLM as "text" they're noise that costs thousands of tokens and produces
+// nothing. This module turns each into compact Markdown — headings, lists and
+// tables for Word; one table per sheet for spreadsheets; per-slide text for
+// decks; the text layer for PDFs — so the same eggs/ → Hatch pipeline works.
+//
+// extractToMarkdown(absPath, opts) -> { markdown, kind, warnings }
+//   kind:      'docx' | 'xlsx' | 'pptx' | 'pdf' | 'csv'
+//   warnings:  human-readable notes (a lossy PDF, a dropped sheet, …)
+//   throws     UnsupportedFormatError for a type we don't handle (with a hint
+//              for the legacy formats: re-save as .docx / .xlsx / .pptx)
+//
+// Deps, all pure-JS and required lazily so a broken install of one doesn't
+// sink the others: mammoth (docx), xlsx (spreadsheets — already a dep), pizzip
+// (pptx — already a dep), pdf-parse (pdf).
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+// Rows/cols past this are dropped from a sheet with a note — a 50k-row export
+// is not something Hatch should try to reason over.
+const MAX_SHEET_ROWS = 200
+const MAX_SHEET_COLS = 40
+
+class UnsupportedFormatError extends Error {
+  constructor (message, ext) {
+    super(message)
+    this.name = 'UnsupportedFormatError'
+    this.ext = ext
+  }
+}
+
+// Legacy / OpenDocument types we don't convert — mapped to the modern format
+// to re-save as. Kept separate from "never heard of it" so the message helps.
+const LEGACY_HINTS = {
+  '.doc': '.docx',
+  '.ppt': '.pptx',
+  '.xls': '.xlsx', // .xls is actually handled below; kept here only as a fallback message if SheetJS can't
+  '.odt': '.docx',
+  '.odp': '.pptx',
+  '.ods': '.xlsx',
+  '.rtf': '.docx',
+  '.pages': '.docx',
+  '.key': '.pptx',
+  '.numbers': '.xlsx'
+}
+
+const SUPPORTED_EXTS = new Set(['.docx', '.xlsx', '.xls', '.xlsm', '.csv', '.tsv', '.pptx', '.pdf'])
+
+/** Is `name`/`path` an Office/PDF file this module knows how to convert? */
+function isSupported (name) {
+  return SUPPORTED_EXTS.has(path.extname(String(name || '')).toLowerCase())
+}
+
+// --- Word -------------------------------------------------------------------
+
+async function docxToMarkdown (absPath) {
+  const mammoth = require('mammoth')
+  const { value, messages } = await mammoth.convertToMarkdown({ path: absPath })
+  const warnings = (messages || [])
+    .filter((m) => m.type === 'warning')
+    .map((m) => m.message)
+  // mammoth leaves runs of blank lines around lists/tables — collapse to two.
+  const markdown = value.replace(/\n{3,}/g, '\n\n').trim()
+  return { markdown, kind: 'docx', warnings }
+}
+
+// --- Spreadsheets ----------------------------------------------------------
+
+function cellText (v) {
+  if (v === null || v === undefined) return ''
+  if (v instanceof Date) return v.toISOString().slice(0, 10)
+  return String(v).replace(/\s+/g, ' ').trim()
+}
+
+function mdTable (rows) {
+  if (!rows.length) return '_(empty)_'
+  const width = Math.min(MAX_SHEET_COLS, Math.max(...rows.map((r) => r.length)))
+  const pad = (r) => {
+    const cells = r.slice(0, width).map((c) => cellText(c).replace(/\|/g, '\\|'))
+    while (cells.length < width) cells.push('')
+    return cells
+  }
+  const header = pad(rows[0])
+  const lines = [
+    '| ' + header.join(' | ') + ' |',
+    '| ' + header.map(() => '---').join(' | ') + ' |'
+  ]
+  for (const r of rows.slice(1)) lines.push('| ' + pad(r).join(' | ') + ' |')
+  return lines.join('\n')
+}
+
+/** Trim fully-empty trailing rows and columns from an array-of-arrays. */
+function trimGrid (grid) {
+  let rows = grid.map((r) => r.map(cellText))
+  while (rows.length && rows[rows.length - 1].every((c) => c === '')) rows.pop()
+  const lastCol = rows.reduce((max, r) => {
+    let i = r.length - 1
+    while (i >= 0 && r[i] === '') i--
+    return Math.max(max, i)
+  }, -1)
+  rows = rows.map((r) => r.slice(0, lastCol + 1))
+  return rows.filter((r) => r.length)
+}
+
+function spreadsheetToMarkdown (absPath, kind) {
+  const XLSX = require('xlsx')
+  const wb = XLSX.readFile(absPath, { cellDates: true })
+  const warnings = []
+  const parts = []
+
+  for (const name of wb.SheetNames) {
+    const raw = XLSX.utils.sheet_to_json(wb.Sheets[name], { header: 1, defval: null, blankrows: false })
+    let rows = trimGrid(raw)
+    if (!rows.length) continue
+
+    if (rows.length > MAX_SHEET_ROWS + 1) {
+      const dropped = rows.length - MAX_SHEET_ROWS - 1
+      rows = rows.slice(0, MAX_SHEET_ROWS + 1)
+      warnings.push(`sheet "${name}": kept the first ${MAX_SHEET_ROWS} rows, dropped ${dropped}`)
+    }
+    if (rows.some((r) => r.length > MAX_SHEET_COLS)) {
+      warnings.push(`sheet "${name}": kept the first ${MAX_SHEET_COLS} columns`)
+    }
+
+    parts.push(wb.SheetNames.length > 1 ? `## ${name}\n\n${mdTable(rows)}` : mdTable(rows))
+  }
+
+  if (!parts.length) return { markdown: '_(the spreadsheet has no non-empty cells)_', kind, warnings }
+  return { markdown: parts.join('\n\n'), kind, warnings }
+}
+
+// --- PowerPoint ----------------------------------------------------------
+
+// Pull visible text from one slide's XML: every <a:t>…</a:t> run, in order,
+// with paragraph (<a:p>) boundaries becoming line breaks.
+function slideXmlToLines (xml) {
+  const paras = xml.split(/<a:p[\s>]/).slice(1)
+  const lines = []
+  for (const p of paras) {
+    const runs = [...p.matchAll(/<a:t>([\s\S]*?)<\/a:t>/g)].map((m) => decodeXml(m[1]))
+    const line = runs.join('').replace(/\s+/g, ' ').trim()
+    if (line) lines.push(line)
+  }
+  return lines
+}
+
+function decodeXml (s) {
+  return s
+    .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(+d))
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&amp;/g, '&')
+}
+
+function pptxToMarkdown (absPath) {
+  const PizZip = require('pizzip')
+  const zip = new PizZip(fs.readFileSync(absPath))
+  const slideFiles = Object.keys(zip.files)
+    .filter((n) => /^ppt\/slides\/slide\d+\.xml$/.test(n))
+    .sort((a, b) => slideNo(a) - slideNo(b))
+  const notesFiles = new Set(Object.keys(zip.files).filter((n) => /^ppt\/notesSlides\/notesSlide\d+\.xml$/.test(n)))
+
+  const warnings = []
+  const parts = []
+  slideFiles.forEach((file, i) => {
+    const n = i + 1
+    const lines = slideXmlToLines(zip.files[file].asText())
+    const block = [`## Slide ${n}`]
+    if (lines.length) block.push('', lines.map((l) => `- ${l}`).join('\n'))
+
+    const notesFile = `ppt/notesSlides/notesSlide${slideNo(file)}.xml`
+    if (notesFiles.has(notesFile)) {
+      const notes = slideXmlToLines(zip.files[notesFile].asText())
+        .filter((l) => l && !/^\d+$/.test(l)) // PowerPoint stuffs the slide number in here
+      if (notes.length) block.push('', `_Notes:_ ${notes.join(' ')}`)
+    }
+    parts.push(block.join('\n'))
+  })
+
+  if (!slideFiles.length) warnings.push('no slides found in the deck')
+  return { markdown: parts.join('\n\n') || '_(no slide text)_', kind: 'pptx', warnings }
+}
+
+function slideNo (name) {
+  const m = name.match(/(\d+)\.xml$/)
+  return m ? +m[1] : 0
+}
+
+// --- PDF -----------------------------------------------------------------
+
+async function pdfToMarkdown (absPath) {
+  const pdfParse = require('pdf-parse')
+  const data = await pdfParse(fs.readFileSync(absPath))
+  const text = String(data.text || '')
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+  const warnings = ['PDF text is extracted from the content layer — tables, columns and scanned pages may come through imperfectly or not at all']
+  if (!text) warnings.push('no extractable text — this PDF is likely scanned images (OCR is not done)')
+  return { markdown: text || '_(no extractable text)_', kind: 'pdf', warnings, pages: data.numpages }
+}
+
+// --- dispatch ----------------------------------------------------------
+
+/**
+ * Convert `absPath` to Markdown. Resolves { markdown, kind, warnings }.
+ * Throws UnsupportedFormatError for a type this module doesn't handle.
+ */
+async function extractToMarkdown (absPath) {
+  const ext = path.extname(absPath).toLowerCase()
+  switch (ext) {
+    case '.docx': return docxToMarkdown(absPath)
+    case '.xlsx':
+    case '.xlsm':
+    case '.xls': return spreadsheetToMarkdown(absPath, 'xlsx')
+    case '.csv':
+    case '.tsv': return spreadsheetToMarkdown(absPath, 'csv')
+    case '.pptx': return pptxToMarkdown(absPath)
+    case '.pdf': return pdfToMarkdown(absPath)
+    default: {
+      const hint = LEGACY_HINTS[ext]
+      throw new UnsupportedFormatError(
+        hint
+          ? `${ext} isn't supported — re-save it as ${hint} and drop that instead.`
+          : `${ext || 'this file'} isn't a document Kip can read (supported: .docx, .xlsx, .xls, .csv, .pptx, .pdf).`,
+        ext)
+    }
+  }
+}
+
+/** The `.md` name a converted `<name>.<ext>` gets: `<name>.md`, ext-stripped. */
+function markdownNameFor (filename) {
+  const ext = path.extname(filename)
+  return filename.slice(0, filename.length - ext.length) + '.md'
+}
+
+/**
+ * The full Markdown document written into eggs/ for a converted file: YAML
+ * front-matter recording the origin (so a hatched page can be traced back),
+ * then the body. `srcName` is the original file's basename.
+ */
+function toHatchSource (srcName, { markdown, kind, warnings = [] }) {
+  const fm = [
+    '---',
+    `source: ${JSON.stringify(srcName)}`,
+    `source_format: ${kind}`,
+    `converted: ${JSON.stringify(new Date().toISOString().slice(0, 10))}`
+  ]
+  if (warnings.length) {
+    fm.push('conversion_notes:')
+    for (const w of warnings) fm.push(`  - ${JSON.stringify(w)}`)
+  }
+  fm.push('---', '')
+  return fm.join('\n') + markdown + '\n'
+}
+
+/**
+ * Convert `absPath` and write the result as `<dir>/<stem>.md` (or `outPath`).
+ * Skips the work when an up-to-date `.md` is already there. Resolves
+ * { outPath, kind, warnings, skipped }. Throws for an unsupported format.
+ */
+async function convertFile (absPath, outPath) {
+  const target = outPath || path.join(path.dirname(absPath), markdownNameFor(path.basename(absPath)))
+  try {
+    if (fs.statSync(target).mtimeMs >= fs.statSync(absPath).mtimeMs) {
+      return { outPath: target, kind: null, warnings: [], skipped: true }
+    }
+  } catch { /* no target yet — convert */ }
+
+  const result = await extractToMarkdown(absPath)
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, toHatchSource(path.basename(absPath), result))
+  return { outPath: target, kind: result.kind, warnings: result.warnings, skipped: false }
+}
+
+module.exports = {
+  extractToMarkdown,
+  convertFile,
+  toHatchSource,
+  isSupported,
+  markdownNameFor,
+  SUPPORTED_EXTS,
+  LEGACY_HINTS,
+  UnsupportedFormatError
+}

--- a/scripts/office-extract.js
+++ b/scripts/office-extract.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Convert one Office / PDF file to Markdown (scripts/lib/office.js) and write
+// it as a Hatch source. The Kip app shells out to this when you drop a .docx /
+// .xlsx / .pptx / .pdf onto the Peck or Hatch view; it also runs standalone.
+//
+//   node scripts/office-extract.js <input> [<output.md>] [--json] [--stdout]
+//
+//   <input>       a .docx / .xlsx / .xls / .csv / .pptx / .pdf
+//   <output.md>   where to write (default: <input dir>/<input name>.md)
+//   --stdout      print the Markdown instead of writing a file
+//   --json        print one line of JSON: { ok, output, kind, chars, warnings }
+//                 (or { ok:false, error, ext } on failure) and exit 0/1
+//
+// The output gets front-matter recording where it came from, so a hatched page
+// can be traced back to the original document.
+
+const fs = require('node:fs')
+const path = require('node:path')
+const { extractToMarkdown, toHatchSource, markdownNameFor, UnsupportedFormatError } = require('./lib/office')
+
+const argv = process.argv.slice(2)
+const asJson = argv.includes('--json')
+const toStdout = argv.includes('--stdout')
+const positionals = argv.filter((a) => !a.startsWith('--'))
+
+function done (obj, human) {
+  if (asJson) {
+    // --json is a machine contract: the result is always on stdout, `ok` says
+    // whether it worked, exit stays 0 so a caller reads the JSON not the code.
+    console.log(JSON.stringify(obj))
+  } else {
+    if (human) console.log(human)
+    if (!obj.ok) console.error(obj.error)
+    process.exitCode = obj.ok ? 0 : 1
+  }
+}
+
+async function main () {
+  const input = positionals[0]
+  if (!input) {
+    done({ ok: false, error: 'usage: office-extract.js <input> [<output.md>] [--json] [--stdout]' })
+    return
+  }
+  const absIn = path.resolve(input)
+  if (!fs.existsSync(absIn)) {
+    done({ ok: false, error: `no such file: ${input}` })
+    return
+  }
+
+  let result
+  try {
+    result = await extractToMarkdown(absIn)
+  } catch (err) {
+    done({
+      ok: false,
+      error: (err && err.message) || String(err),
+      ext: err instanceof UnsupportedFormatError ? err.ext : undefined
+    })
+    return
+  }
+
+  const srcName = path.basename(absIn)
+  const body = toHatchSource(srcName, result)
+
+  if (toStdout) {
+    process.stdout.write(body)
+    done({ ok: true, output: null, kind: result.kind, chars: result.markdown.length, warnings: result.warnings })
+    return
+  }
+
+  const absOut = path.resolve(positionals[1] || path.join(path.dirname(absIn), markdownNameFor(srcName)))
+  fs.mkdirSync(path.dirname(absOut), { recursive: true })
+  fs.writeFileSync(absOut, body)
+  done(
+    { ok: true, output: absOut, kind: result.kind, chars: result.markdown.length, warnings: result.warnings },
+    `Wrote ${absOut} (${result.kind}, ${result.markdown.length} chars)` +
+      (result.warnings.length ? `\n  ${result.warnings.join('\n  ')}` : ''))
+}
+
+main().catch((err) => {
+  done({ ok: false, error: (err && err.stack) || String(err) })
+})

--- a/scripts/test/office.test.js
+++ b/scripts/test/office.test.js
@@ -1,0 +1,198 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { execFileSync } = require('node:child_process')
+
+const { extractToMarkdown, isSupported, markdownNameFor, UnsupportedFormatError } = require('../lib/office')
+
+const CLI = path.join(__dirname, '..', 'office-extract.js')
+
+let dir
+test.before(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'office-test-')) })
+test.after(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+// --- fixtures, built with the deps the retrieval layer already ships --------
+
+async function makeDocx (name) {
+  const { Document, Packer, Paragraph, HeadingLevel, TextRun } = require('docx')
+  const doc = new Document({
+    sections: [{
+      children: [
+        new Paragraph({ text: 'Project Atlas', heading: HeadingLevel.HEADING_1 }),
+        new Paragraph({ children: [new TextRun('Kickoff on '), new TextRun({ text: 'March 3', bold: true })] }),
+        new Paragraph({ text: 'Risks', heading: HeadingLevel.HEADING_2 }),
+        new Paragraph({ text: 'Budget not confirmed', bullet: { level: 0 } })
+      ]
+    }]
+  })
+  const p = path.join(dir, name)
+  fs.writeFileSync(p, await Packer.toBuffer(doc))
+  return p
+}
+
+function makeXlsx (name) {
+  const XLSX = require('xlsx')
+  const wb = XLSX.utils.book_new()
+  XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet([
+    ['Name', 'Role'], ['Alice', 'PM'], ['Bob', 'Dev'], [], []
+  ]), 'Team')
+  XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet([['Q', 'Amount'], ['Q1', 1000]]), 'Budget')
+  const p = path.join(dir, name)
+  XLSX.writeFile(wb, p)
+  return p
+}
+
+async function makePptx (name) {
+  const PptxGen = require('pptxgenjs')
+  const deck = new PptxGen()
+  deck.addSlide().addText('Roadmap 2026', { x: 1, y: 1 })
+  const s = deck.addSlide()
+  s.addText('Q1 — ship sync', { x: 1, y: 1 })
+  s.addNotes('Dropbox first')
+  const p = path.join(dir, name)
+  await deck.writeFile({ fileName: p })
+  return p
+}
+
+/** Smallest PDF with an extractable text layer, built by hand. */
+function makePdf (name) {
+  const objs = []
+  objs[1] = '<< /Type /Catalog /Pages 2 0 R >>'
+  objs[2] = '<< /Type /Pages /Kids [3 0 R] /Count 1 >>'
+  objs[3] = '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 200] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>'
+  const stream = 'BT /F1 18 Tf 20 150 Td (Hello from a PDF.) Tj 0 -24 Td (Second line here.) Tj ET'
+  objs[4] = `<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`
+  objs[5] = '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>'
+  let pdf = '%PDF-1.4\n'
+  const off = []
+  for (let i = 1; i <= 5; i++) { off[i] = pdf.length; pdf += `${i} 0 obj\n${objs[i]}\nendobj\n` }
+  const xref = pdf.length
+  pdf += 'xref\n0 6\n0000000000 65535 f \n'
+  for (let i = 1; i <= 5; i++) pdf += `${String(off[i]).padStart(10, '0')} 00000 n \n`
+  pdf += `trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF`
+  const p = path.join(dir, name)
+  fs.writeFileSync(p, pdf, 'latin1')
+  return p
+}
+
+// --- extractToMarkdown ------------------------------------------------------
+
+test('docx → markdown keeps headings, bold and bullets', async () => {
+  const { markdown, kind, warnings } = await extractToMarkdown(await makeDocx('a.docx'))
+  assert.equal(kind, 'docx')
+  assert.match(markdown, /^# Project Atlas/m)
+  assert.match(markdown, /## Risks/)
+  assert.match(markdown, /- Budget not confirmed/)
+  assert.match(markdown, /March 3/)
+  assert.ok(Array.isArray(warnings))
+})
+
+test('xlsx → one markdown table per non-empty sheet, blank rows/cols trimmed', async () => {
+  const { markdown, kind } = await extractToMarkdown(makeXlsx('a.xlsx'))
+  assert.equal(kind, 'xlsx')
+  assert.match(markdown, /## Team/)
+  assert.match(markdown, /## Budget/)
+  assert.match(markdown, /\| Name \| Role \|/)
+  assert.match(markdown, /\| Alice \| PM \|/)
+  // the two trailing empty rows and the padding column are gone
+  assert.doesNotMatch(markdown, /\|\s*\|\s*\|\s*\|/)
+})
+
+test('csv → a single markdown table, no sheet heading', async () => {
+  const p = path.join(dir, 'n.csv')
+  fs.writeFileSync(p, 'topic,owner\nonboarding,Alice\nsecurity,Bob\n')
+  const { markdown, kind } = await extractToMarkdown(p)
+  assert.equal(kind, 'csv')
+  assert.doesNotMatch(markdown, /^## /m)
+  assert.match(markdown, /\| topic \| owner \|/)
+  assert.match(markdown, /\| security \| Bob \|/)
+})
+
+test('pptx → per-slide bullets plus speaker notes', async () => {
+  const { markdown, kind } = await extractToMarkdown(await makePptx('a.pptx'))
+  assert.equal(kind, 'pptx')
+  assert.match(markdown, /## Slide 1/)
+  assert.match(markdown, /- Roadmap 2026/)
+  assert.match(markdown, /## Slide 2/)
+  assert.match(markdown, /- Q1 — ship sync/)
+  assert.match(markdown, /_Notes:_ Dropbox first/)
+})
+
+test('pdf → the text layer, with a fidelity warning', () => {
+  // via the CLI (a fresh process): pdf-parse bundles an old pdf.js whose
+  // global state doesn't survive sharing a process with the other loaders.
+  const src = makePdf('a.pdf')
+  const res = JSON.parse(execFileSync('node', [CLI, src, '--json'], { encoding: 'utf8' }))
+  assert.equal(res.ok, true)
+  assert.equal(res.kind, 'pdf')
+  assert.ok(res.warnings.some((w) => /content layer/.test(w)))
+  const md = fs.readFileSync(res.output, 'utf8')
+  assert.match(md, /Hello from a PDF\./)
+  assert.match(md, /Second line here\./)
+})
+
+test('a legacy format throws UnsupportedFormatError with a re-save hint', async () => {
+  const p = path.join(dir, 'old.doc')
+  fs.writeFileSync(p, 'stub')
+  await assert.rejects(() => extractToMarkdown(p), (err) => {
+    assert.ok(err instanceof UnsupportedFormatError)
+    assert.equal(err.ext, '.doc')
+    assert.match(err.message, /re-save it as \.docx/)
+    return true
+  })
+})
+
+test('an unknown extension throws with the supported list', async () => {
+  const p = path.join(dir, 'x.foo')
+  fs.writeFileSync(p, 'stub')
+  await assert.rejects(() => extractToMarkdown(p), /supported: \.docx/)
+})
+
+test('isSupported / markdownNameFor', () => {
+  assert.equal(isSupported('report.DOCX'), true)
+  assert.equal(isSupported('a.pdf'), true)
+  assert.equal(isSupported('notes.md'), false)
+  assert.equal(isSupported('archive.doc'), false)
+  assert.equal(markdownNameFor('Q3 Report.docx'), 'Q3 Report.md')
+  assert.equal(markdownNameFor('data.xlsx'), 'data.md')
+})
+
+// --- the CLI --------------------------------------------------------------
+
+test('office-extract CLI writes <name>.md with provenance front-matter', async () => {
+  const src = await makeDocx('cli.docx')
+  const out = execFileSync('node', [CLI, src, '--json'], { encoding: 'utf8' })
+  const res = JSON.parse(out)
+  assert.equal(res.ok, true)
+  assert.equal(res.kind, 'docx')
+  assert.equal(res.output, path.join(dir, 'cli.md'))
+  const md = fs.readFileSync(res.output, 'utf8')
+  assert.match(md, /^---\n/)
+  assert.match(md, /source: "cli\.docx"/)
+  assert.match(md, /source_format: docx/)
+  assert.match(md, /# Project Atlas/)
+})
+
+test('office-extract CLI --stdout prints markdown and does not write', async () => {
+  const src = makeXlsx('so.xlsx')
+  const out = execFileSync('node', [CLI, src, '--stdout'], { encoding: 'utf8' })
+  assert.match(out, /## Team/)
+  assert.equal(fs.existsSync(path.join(dir, 'so.md')), false)
+})
+
+test('office-extract CLI --json reports an unsupported file as { ok:false }, exit 0', () => {
+  const src = path.join(dir, 'bad.rtf')
+  fs.writeFileSync(src, 'stub')
+  const res = JSON.parse(execFileSync('node', [CLI, src, '--json'], { encoding: 'utf8' }))
+  assert.equal(res.ok, false)
+  assert.equal(res.ext, '.rtf')
+})
+
+test('office-extract CLI without --json exits 1 on an unsupported file', () => {
+  const src = path.join(dir, 'bad2.rtf')
+  fs.writeFileSync(src, 'stub')
+  assert.throws(() => execFileSync('node', [CLI, src], { encoding: 'utf8', stdio: 'pipe' }),
+    (err) => err.status === 1)
+})


### PR DESCRIPTION
Pairs with kip-app#91.

## Why

Drop a `.docx` into `eggs/` today and Hatch reads it as UTF-8 — a zip of XML, so it's thousands of wasted tokens and no usable content. This converts Office/PDF files to compact Markdown first.

## What

**`scripts/lib/office.js`** — `extractToMarkdown(absPath) -> { markdown, kind, warnings }`:

| input | conversion |
|---|---|
| `.docx` | `mammoth` — headings, lists, tables, bold preserved |
| `.xlsx` / `.xls` / `.csv` / `.tsv` | `xlsx` (already a dep) — one Markdown table per sheet, blank rows/cols trimmed, 200-row / 40-col cap with a note |
| `.pptx` | `pizzip` (already a dep) — `## Slide N` + bullets + speaker notes, no new dep |
| `.pdf` | `pdf-parse` — the text layer, with a "tables/columns/scans may be imperfect" warning |

Legacy `.doc` / `.ppt` / `.odt` / `.odp` / `.ods` / `.rtf` → `UnsupportedFormatError` with a "re-save as .docx/.xlsx/.pptx" hint.

**`scripts/office-extract.js`** — standalone CLI, `--json` / `--stdout`. Writes `<name>.md` with YAML front-matter (`source:`, `source_format:`, `converted:`, any `conversion_notes:`). The Kip app shells out to this on drop so the `.md` appears immediately.

**`scripts/lib/hatch.js`** — `convertPendingOfficeSources(vaultRoot)` runs at the top of `hatchAllSources`, `proposeNextPending` and `pendingSourcesSummary`. Idempotent (skips an up-to-date `.md` via mtime). The original file stays in `eggs/`; the scan skips it and hatches the `.md` sibling. Per-file failures collected into `failed` / `conversionFailed`, never thrown. `pendingSourcesSummary` becomes async.

So a document dropped in the app, synced in through Dropbox, or added by CLI all hatch the same way.

## Tests

`scripts/test/office.test.js` — 11 cases: each format end to end (fixtures built with the deps already present), the legacy/unknown error paths, `isSupported` / `markdownNameFor`, and the CLI (`--json`, `--stdout`, exit codes). Full suite **273**.

New deps: `mammoth` (~2 MB, pure JS), `pdf-parse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)