### PR TITLE
Peck: fall back to a web search when the nest has no answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Kip. Format loosely follows
 The retrieval layer (this repo) and the desktop app
 ([kip-app](https://github.com/JWE24-code/kip-app)) are released together.
 
+## [Unreleased]
+
+### The retrieval layer (`scripts/`)
+
+- **Peck falls back to a web search when your notes don't have the answer**
+  (kip-app#93) — the answer model now signals `NO_ANSWER` when the retrieved
+  pages can't answer the question; `peck.js` catches it, runs the bundled
+  `web-search` skill, and answers from the results (`answerFromWeb`). The web
+  results are still offered as a savable source. Skipped for a regenerate
+  (arena) and when a skill already searched the web that turn; falls through
+  to the old "nothing in your nest" state when web search is disabled or comes
+  back empty.
+
 ## [0.4.2] — 2026-08-31
 
 ### The retrieval layer (`scripts/`)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -256,6 +256,19 @@ a "save these" affordance on the answer and writes it via the existing
 `buildWebSource`). v1 saves the list + snippets; full page-text fetch is a
 follow-up.
 
+**Auto web-search fallback** (kip-app#93) — `ANSWER_SYSTEM_PROMPT` now tells
+the model to reply with the bare token `NO_ANSWER` when the retrieved pages
+don't cover the question. `peck.js` `answerFromPages` catches it (`isNoAnswer`)
+and calls `webFallback()`: run the bundled `web-search` skill on the question,
+then `answerFromWeb()` (a web-oriented `ANSWER_SYSTEM_PROMPT` sibling) over the
+results. Skipped for arena and when a skill already web-searched this turn.
+The web results still flow into `webSource` (kip-app#81) and a synthetic
+`web-search` step shows in the ⚙ line. If web search is disabled or returns
+nothing the answer is `null` (the app's "not in your nest" state); if it ran
+but didn't produce a clear answer, a short honest line. `chat.js` suppresses a
+partial `NO_ANSWER` from the live stream the same way it holds back a partial
+`<use_skill>` tag.
+
 **Streamed answers** (kip-app#88) — `callLLM({ …, onStream })` takes an
 optional `onStream(chunk, first)`. `llm.js` passes it to the connector as
 `ctx.onDelta` **only for non-json calls**; a json call needs the whole

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -49,13 +49,19 @@ const VALUE_FLAGS = new Set(['--arena-compare-to', '--history'])
 // panel polls.
 const STREAM_WRITE_MS = 120
 
-/** True while the buffer still might be a `<use_skill …>` tag rather than prose
- *  — the skills tool loop streams every turn, and a tool-call turn must show
- *  nothing. Once real prose diverges from the tag prefix this goes false. */
-function looksLikePartialSkillTag (text) {
+/** True while the buffer is still empty or could be the opening of a control
+ *  token the answer model emits — a `<use_skill …>` tool call or `NO_ANSWER`
+ *  (the "not in the nest" signal peck.js catches to fall back to a web search).
+ *  Suppress the partial bubble until the text diverges into real prose. */
+function looksLikeControlToken (text) {
   const s = String(text || '').replace(/^\s+/, '').toLowerCase()
   if (!s) return true
-  return s.startsWith('<use_skill') || '<use_skill'.startsWith(s.slice(0, 10))
+  // a <use_skill> tag: '<' is rare at the start of a real answer, so match it
+  // as a prefix freely.
+  if (s.startsWith('<use_skill') || '<use_skill'.startsWith(s.slice(0, 10))) return true
+  // NO_ANSWER: 'no' is a plausible real answer, so only hold back while the
+  // buffer is still a whitespace-free prefix of the token.
+  return !/\s/.test(s) && 'no_answer'.startsWith(s)
 }
 
 async function main () {
@@ -108,7 +114,7 @@ async function main () {
   const onStream = (chunk, first) => {
     if (first) streamBuf = ''
     streamBuf += chunk
-    if (looksLikePartialSkillTag(streamBuf)) return
+    if (looksLikeControlToken(streamBuf)) return
     const now = Date.now()
     if (now - lastStreamWrite < STREAM_WRITE_MS) return
     lastStreamWrite = now

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -18,9 +18,9 @@ const matter = require('gray-matter')
 
 const { searchPages, upsertPage, regenerateIndexMd, appendLog, extractWikilinkSlugs } = require('./roost')
 const { resolvePage } = require('./pages')
-const { extractKeyTerms, answerQuestion, answerQuestionWithSkills, captureFacts } = require('./prompts')
-const { discoverSkills } = require('./skills')
-const { buildWebSource } = require('./web-sources')
+const { extractKeyTerms, answerQuestion, answerQuestionWithSkills, answerFromWeb, isNoAnswer, captureFacts } = require('./prompts')
+const { discoverSkills, runSkill } = require('./skills')
+const { buildWebSource, parseWebSearchOutput } = require('./web-sources')
 const { looksLikeReminder } = require('./reminders')
 const { DEFAULT_VAULT_ROOT } = require('./paths')
 const telemetry = require('./telemetry')
@@ -216,8 +216,24 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
     answer = await answerQuestion(question, pages, vaultRoot, { history, onStream })
   }
 
-  const citedSlugs = extractCitedSlugs(answer, candidateSlugs)
-  if (fileToNest) {
+  // The nest didn't cover it → search the web and answer from that
+  // (kip-app#93). Not for arena (keeps a model-vs-model compare clean), and
+  // not when a skill already web-searched this turn.
+  let webbed = false
+  if (isNoAnswer(answer)) {
+    if (!arena && !webSearches.length) {
+      const web = await webFallback(question, vaultRoot, { history, onStream })
+      answer = web.answer
+      webSearches = web.webSearches
+      steps = [...steps, ...web.steps]
+      webbed = webSearches.length > 0
+    } else {
+      answer = null
+    }
+  }
+
+  const citedSlugs = answer ? extractCitedSlugs(answer, candidateSlugs) : []
+  if (fileToNest && answer && !webbed) {
     await fileAnswerToNest(question, answer, candidateSlugs, vaultRoot)
   }
   // The managed backend's ids for the answer call, so the app can attach a
@@ -230,6 +246,43 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   // (kip-app#81) — the app shows a "save these" affordance on the answer.
   const webSource = buildWebSource(question, webSearches);
   return { answer, citedSlugs, candidateSlugs, steps, callId, arenaId, webSource: webSource || null }
+}
+
+/**
+ * Auto web-search fallback (kip-app#93): run the bundled `web-search` skill on
+ * the question, then answer from its results. Returns { answer, webSearches }.
+ * `answer` is null when web search isn't available/enabled or returned nothing;
+ * a short honest line when it ran but didn't produce a clear answer.
+ */
+async function webFallback (question, vaultRoot, { history = [], onStream = null } = {}) {
+  let skill
+  try {
+    skill = discoverSkills(vaultRoot).find((s) => s.name === 'web-search')
+  } catch { /* discovery failed — treat as no web search */ }
+  if (!skill) return { answer: null, webSearches: [], steps: [] }
+
+  let res
+  try {
+    res = await runSkill(skill, { query: question }, vaultRoot)
+  } catch (err) {
+    console.error(`Warning: the web-search fallback failed (${err.message}).`)
+    return { answer: null, webSearches: [], steps: [] }
+  }
+
+  const preview = ((res && (res.output || res.error)) || '').replace(/\s+/g, ' ').trim().slice(0, 200)
+  const step = { skill: 'web-search', input: { query: question }, ok: !!(res && res.ok), ms: (res && res.ms) || 0, outputPreview: preview }
+  const parsed = res && res.ok ? parseWebSearchOutput(res.output) : null
+  if (!parsed || !parsed.results.length) return { answer: null, webSearches: [], steps: [step] }
+
+  const answer = await answerFromWeb(question, res.output, vaultRoot, { history, onStream })
+  if (isNoAnswer(answer)) {
+    return {
+      answer: "I couldn't find this in your notes, and a quick web search didn't turn up a clear answer either — try rephrasing?",
+      webSearches: [parsed],
+      steps: [step]
+    }
+  }
+  return { answer, webSearches: [parsed], steps: [step] }
 }
 
 /** callId + arenaId of the newest peck:answer* call at or after `startIdx`. */

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -50,13 +50,35 @@ function formatPagesForPrompt (pages) {
     .join('\n\n---\n\n')
 }
 
+// Emitted verbatim by the answer model when the retrieved pages don't hold the
+// answer — peck.js catches it and falls back to a web search (kip-app#93).
+const NO_ANSWER_TOKEN = 'NO_ANSWER'
+const NO_ANSWER_RE = /^\s*NO_ANSWER\b/i
+/** True when an answer string is the model's "the pages don't cover this" signal. */
+function isNoAnswer (text) {
+  return NO_ANSWER_RE.test(String(text || ''))
+}
+
 const ANSWER_SYSTEM_PROMPT = `You are answering a question from a personal wiki — a second brain for journaling, goals, and health tracking. You are given the full text of the wiki pages retrieved as candidates for this question.
 
-Answer using ONLY the information in these pages — do not use outside knowledge, and do not speculate beyond what's written. If the pages don't contain enough information to answer, say so plainly rather than guessing.
+Answer using ONLY the information in these pages — do not use outside knowledge, and do not speculate beyond what's written.
+
+If the pages don't contain enough to answer, reply with exactly this on its own line and nothing else:
+${NO_ANSWER_TOKEN}
+Do not guess, apologise, or explain — just the token. (Something else will take it from there.)
 
 If a "Conversation so far" section is present, it is only there to tell you what a follow-up question refers to — it is NOT a source, so never cite it or treat it as fact.
 
 Cite every claim back to the specific page it came from using Logseq's wikilink syntax: [[exact-page-slug]], using the exact slug shown in each "### Page: <slug>" heading. Prefer citing inline, next to the claim it supports, over a single list of links at the end.`
+
+const WEB_ANSWER_SYSTEM_PROMPT = `The user asked their personal notes a question, but the notes didn't contain the answer, so a web search was run. You are given the search results.
+
+Answer the question from these results. Keep it tight and factual. Attribute a claim to its source inline as "(via web search)" and include the most useful URL when it helps.
+
+If the results don't actually answer the question either, reply with exactly this on its own line and nothing else:
+${NO_ANSWER_TOKEN}
+
+Do not cite anything with [[wikilink]] syntax here — these are web pages, not nest pages.`
 
 /** Answers a question against a set of candidate wiki pages, with [[slug]]
  *  citations. `arena` (optional): { compareToCallId } runs this as arena
@@ -69,6 +91,20 @@ async function answerQuestion (question, pages, vaultRoot, { arena = null, histo
     (convo ? `${convo}\n\n---\n\n` : '') +
     `Question: ${question}`
   const { text } = await callLLM({ system: ANSWER_SYSTEM_PROMPT, prompt, maxTokens: 4096, label: 'peck:answer', arena, onStream }, { vaultRoot })
+  return text
+}
+
+/** Answer a question from web-search results (the nest didn't have it,
+ *  kip-app#93). `resultsText` is the web-search skill's markdown output.
+ *  Returns the answer, or the NO_ANSWER token if the web didn't help either. */
+async function answerFromWeb (question, resultsText, vaultRoot, { history = [], onStream = null } = {}) {
+  const convo = formatConversation(history)
+  const prompt = `Web search results:\n\n${resultsText}\n\n---\n\n` +
+    (convo ? `${convo}\n\n---\n\n` : '') +
+    `Question: ${question}`
+  const { text } = await callLLM(
+    { system: WEB_ANSWER_SYSTEM_PROMPT, prompt, maxTokens: 4096, label: 'peck:answer:web', onStream },
+    { vaultRoot })
   return text
 }
 
@@ -545,6 +581,9 @@ async function captureFacts (input, existingPages, vaultRoot) {
 module.exports = {
   extractKeyTerms,
   answerQuestion,
+  answerFromWeb,
+  isNoAnswer,
+  NO_ANSWER_TOKEN,
   formatConversation,
   generateMeetingPrep,
   answerQuestionWithSkills,

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -405,6 +405,50 @@ test('peckTurn — a web-search run comes back as a hatchable webSource (kip-app
   } finally { s.restore() }
 })
 
+test('peckTurn — nest miss falls back to a web search (kip-app#93)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'concepts', 'globex', { type: 'concept', body: 'Globex is a client we onboarded in Q2.' })
+  writePage(root, 'concepts', 'globex-project', { type: 'concept', body: 'The Globex project timeline.' })
+  rebuildRoost(root)
+  onlyFixtureSkills(root, ['web-search'])
+  writeFixtureSkill(root, 'web-search',
+    'console.log(`Results for "Globex CEO" (via duckduckgo):\\n\\n- [Globex leadership](https://globex.test/about) — Jane Roe is the CEO`)')
+
+  // the nest pages mention Globex but not its CEO -> the plain answer is
+  // NO_ANSWER, then the web answer takes over.
+  const s = stubPeckFetch({
+    keyTerms: '{"terms":["Globex","CEO"]}',
+    answerFn: (sys) => /Web search results:/.test(sys)
+      ? 'Jane Roe is the CEO of Globex (via web search).'
+      : 'NO_ANSWER'
+  })
+  try {
+    const r = await peckTurn('who is the CEO of Globex?', { vaultRoot: root })
+    assert.equal(r.intent, 'question')
+    assert.match(r.answer, /Jane Roe/)
+    assert.ok(r.webSource, 'the web results are offered as a hatchable source')
+    assert.deepEqual(r.citedSlugs, [], 'no nest pages were cited')
+  } finally { s.restore() }
+})
+
+test('peckTurn — nest miss with no web search available returns a null answer', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'concepts', 'globex', { type: 'concept', body: 'Globex is a client.' })
+  writePage(root, 'concepts', 'globex-two', { type: 'concept', body: 'More on Globex.' })
+  rebuildRoost(root)
+  // makeTempVault already disabled every bundled skill, web-search included.
+  const s = stubPeckFetch({ keyTerms: '{"terms":["Globex"]}', answerFn: () => 'NO_ANSWER' })
+  try {
+    const r = await peckTurn('who is the CEO of Globex?', { vaultRoot: root })
+    assert.equal(r.answer, null)
+    assert.equal(r.webSource, null)
+  } finally { s.restore() }
+})
+
 test('peckTurn — no web-search, no webSource', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))


### PR DESCRIPTION
Closes kip-app#93.

## Why

Ask Peck something your notes don't cover and today you get "not in your nest" — or the model quietly guesses from thin pages. It should just search the web.

## What

- **`ANSWER_SYSTEM_PROMPT`** now instructs the answer model to reply with the bare token `NO_ANSWER` when the retrieved pages can't answer — no guessing, no apology.
- **`peck.js` `answerFromPages`** catches it (`isNoAnswer`) and calls **`webFallback()`**: run the bundled `web-search` skill on the question, then **`answerFromWeb()`** (a web-oriented `ANSWER_SYSTEM_PROMPT` sibling — attributes "(via web search)", no `[[wikilink]]` citations) over the results.
- The web results still flow into **`webSource`** (kip-app#81) so "↓ Save these web results as a source" appears, and a synthetic **`web-search` step** shows in the ⚙ activity line.
- **Skipped** for arena (keeps a regenerate's model-vs-model compare clean) and when a skill already web-searched that turn.
- **Graceful degrade:** `answer: null` (the app's "nothing in your nest" state) when web search is disabled or returns nothing; a short honest line when it ran but produced no clear answer.
- **`chat.js`** suppresses a partial `NO_ANSWER` from the live stream, the same way it holds back a partial `<use_skill>` tag.

No app-side code change — the web answer, the null case, the save-source widget and the ⚙ line all flow through existing plumbing.

## Tests

`scripts/test/peck.test.js` +2: nest miss → web fallback answers (with `webSource`, no nest citations); nest miss + no web-search skill → `answer: null`. Full suite **285**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)