### PR TITLE
peck: fix classification + slugs for non-English nests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to Kip. Format loosely follows
 The retrieval layer (this repo) and the desktop app
 ([kip-app](https://github.com/JWE24-code/kip-app)) are released together.
 
+## [Unreleased]
+
+### The retrieval layer (`scripts/`)
+
+- **Peck works in other languages** (kip-app#97) — two Latin-script bugs:
+  - `classifyPeckInput` only recognised a question by a trailing `?` or an
+    *English* question word, so a German / French / Spanish / … question
+    typed without a `?` was classified as a *statement* and filed into the
+    nest as a fact instead of being answered. It now also matches a `?`
+    anywhere and the interrogatives / imperatives of DE, NL, FR, ES, IT, PT.
+  - `slugify` stripped every non-ASCII character, turning "Größe" into
+    `gr-e` and "北京会議" into an empty (broken) slug. It now keeps any
+    Unicode letter or digit, and an all-punctuation title falls back to a
+    short stable hash. Existing ASCII slugs are unchanged; only pages
+    hatched from non-English titles from here on get the better slug.
+
 ## [0.4.2] — 2026-08-31
 
 ### The retrieval layer (`scripts/`)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -209,7 +209,9 @@ node scripts/peck.js "the CDO of CompanyX is John Doe"      # a fact to remember
 ```
 
 `scripts/lib/peck.js`'s `peckTurn(input, {fileToNest, vaultRoot})`
-classifies the input (`classifyPeckInput`) and dispatches:
+classifies the input (`classifyPeckInput` — a fast heuristic: a `?` anywhere,
+or a leading interrogative / imperative in English or one of the main
+Latin-script languages, DE/NL/FR/ES/IT/PT — kip-app#97) and dispatches:
 
 - **A question** → `askQuestion`: search, read the candidate pages, ask the
   LLM for a `{answer, citedSlugs, candidateSlugs}` with `[[slug]]` citations.

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -59,7 +59,31 @@ function mightNeedSkill (question, pageCount) {
 //     me" verb (make/create/summarize/…) — the last so "build me a deck from the
 //     Q3 sheet" reaches the skills tool loop instead of the fact-capture path.
 //   statement: anything else.
-const QUESTION_START_RE = /^\s*(who|what|whats|when|where|why|how|which|whose|whom|is|are|was|were|do|does|did|can|could|should|would|will|have|has|had|am|tell me|remind me|show me|list|give me|find|search|look up|any\b|make|create|build|generate|draft|write|compose|produce|prepare|compile|convert|summari[sz]e|turn)\b/i
+// Interrogatives / question openers. English, plus the main Latin-script
+// languages (DE/NL/FR/ES/IT/PT) — a nest in another language would otherwise
+// have every question that lacks a trailing "?" filed as a fact (kip-app#97).
+const QUESTION_START_RE = new RegExp('^\\s*(?:' + [
+  // EN
+  'who|what|whats|when|where|why|how|which|whose|whom|is|are|was|were|do|does|did|can|could|should|would|will|have|has|had|am',
+  'tell me|remind me|show me|list|give me|find|search|look up|any\\b',
+  'make|create|build|generate|draft|write|compose|produce|prepare|compile|convert|summari[sz]e|turn',
+  // DE
+  'wer|was|wann|wo|warum|wieso|weshalb|wie|welche[rs]?|wessen|ist|sind|war|waren|hat|haben|kann|können|soll|wird|gibt es|zeig mir|erstelle|fasse?\\b|zusammenfass',
+  // NL
+  'wie|wat|wanneer|waar|waarom|hoe|welke?|is|zijn|was|waren|heeft|hebben|kan|kun(?:nen)?|moet|toon|maak|vat samen|geef',
+  // FR
+  'qui|que|quoi|quel(?:le)?s?|quand|où|pourquoi|comment|combien|est-ce|montre|résume|fais|liste|donne|cherche',
+  // ES
+  'qui[eé]n(?:es)?|qu[eé]|cu[aá]l(?:es)?|cu[aá]ndo|d[oó]nde|ad[oó]nde|por qu[eé]|c[oó]mo|cu[aá]nto[sa]?|mu[eé]strame|resume|haz|lista|busca|dame',
+  // IT
+  'chi|che|cosa|quale|quali|quando|dove|perch[eé]|come|quanto[ei]?|mostrami|riepiloga|fai|elenca|cerca',
+  // PT
+  'quem|que|qual|quais|quando|onde|aonde|por que|porqu[eê]|como|quanto[sa]?|mostre|resuma|fa[çc]a|liste|busque'
+].join('|') + ')\\b', 'i')
+
+// Any question mark anywhere — trailing is the common case, but "Globex, wer
+// ist der CEO?" and fullwidth / inverted marks count too.
+const QUESTION_MARK_RE = /[?？¿؟]/
 
 // A short input right after a Kip answer that reads as "keep going" rather
 // than a new fact — treat these as a question even without a '?' or a
@@ -71,7 +95,7 @@ const CONTINUATION_RE = /^\s*(and\b|also\b|what about|how about|tell me more|say
 function classifyPeckInput (input, history = []) {
   const t = String(input || '').trim()
   if (!t) return 'question'
-  if (t.endsWith('?') || QUESTION_START_RE.test(t)) return 'question'
+  if (QUESTION_MARK_RE.test(t) || QUESTION_START_RE.test(t)) return 'question'
   const lastWasAnswer = Array.isArray(history) && history.length &&
     history[history.length - 1] && history[history.length - 1].role === 'assistant'
   if (lastWasAnswer && CONTINUATION_RE.test(t)) return 'question'

--- a/scripts/lib/roost.js
+++ b/scripts/lib/roost.js
@@ -22,12 +22,20 @@ function toMatchQuery (query) {
     .join(' OR ')
 }
 
+// Keep any Unicode letter or digit — a nest can be in any language, and
+// stripping to [a-z0-9] turned "Größe" into "gr-e" and "北京会議" into "" (an
+// empty slug, i.e. a broken page). Punctuation and whitespace still collapse
+// to a single dash. An all-punctuation / emoji title falls back to a short
+// stable hash so the slug is never empty. (kip-app#97)
 function slugify (title) {
-  return title
+  const s = String(title == null ? '' : title)
+    .normalize('NFC')
     .toLowerCase()
     .trim()
-    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
     .replace(/^-+|-+$/g, '')
+  if (s) return s
+  return 'page-' + crypto.createHash('sha1').update(String(title == null ? '' : title)).digest('hex').slice(0, 8)
 }
 
 function humanize (slug) {

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -218,6 +218,30 @@ test('classifyPeckInput — trailing ? or a leading question word is a question,
   assert.equal(classifyPeckInput(''), 'question')
 })
 
+test('classifyPeckInput — non-English questions without a "?" still classify as questions (kip-app#97)', () => {
+  const questions = [
+    'Wer leitet das Atlas-Projekt',            // DE
+    'Was weiß ich über Schlaf',                // DE
+    'Wie ist der Zeitplan für Q3',             // DE
+    'Wie is de CEO van Globex',                // NL
+    'Wat weet ik over slaap',                  // NL
+    'Qui est le PDG de Globex',                // FR
+    'Résume mes notes de sommeil',             // FR (imperative)
+    'Quién es el director de Globex',          // ES
+    'Muéstrame mis notas de la reunión',       // ES (imperative)
+    'Chi guida il progetto Atlas',             // IT
+    'Quem lidera o projeto Atlas',             // PT
+    'Globex — wer ist eigentlich der CEO? danke' // "?" mid-string
+  ]
+  for (const q of questions) assert.equal(classifyPeckInput(q), 'question', q)
+
+  // genuine declaratives in other languages are still statements
+  for (const s of ['Der neue CDO von CompanyX ist John Doe', 'De lucht is blauw',
+    'Le ciel est bleu', 'CompanyX ha spostato la sede a Rotterdam']) {
+    assert.equal(classifyPeckInput(s), 'statement', s)
+  }
+})
+
 test('classifyPeckInput — a bare follow-up after a Kip answer is a question (kip-app#82)', () => {
   const afterAnswer = [{ role: 'user', text: 'what are the pricing tiers?' },
     { role: 'assistant', text: 'There are three: Free, Pro, Team [[pricing]].' }]
@@ -338,6 +362,26 @@ test('peckTurn — a question is answered and (fileToNest:false) writes nothing'
     assert.deepEqual(r.citedSlugs, ['sleep-hygiene'])
     assert.deepEqual(fs.readdirSync(path.join(root, 'nest', 'concepts')).sort(), ['sleep-hygiene.md'], 'no answer page filed')
     assert.deepEqual(fs.readdirSync(path.join(root, 'clucks')), [], 'an unfiled question is not logged')
+  } finally { s.restore() }
+})
+
+test('peckTurn — a German question with no "?" is answered, not filed as a fact (kip-app#97)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'concepts', 'schlafhygiene', { type: 'concept', tags: [], body: 'Konsistente Schlafenszeit, keine Bildschirme vor dem Schlafengehen.' })
+  rebuildRoost(root)
+
+  const s = stubPeckFetch({
+    keyTerms: '{"terms": ["Schlaf", "Schlafhygiene"]}',
+    answer: 'Laut [[schlafhygiene]]: konsistente Schlafenszeit.'
+  })
+  try {
+    const r = await peckTurn('Was weiß ich über Schlaf', { vaultRoot: root })
+    assert.equal(r.intent, 'question', 'classified as a question, not a statement')
+    assert.match(r.answer, /Schlafenszeit/)
+    // nothing was filed as a "learned" fact
+    assert.deepEqual(fs.readdirSync(path.join(root, 'nest', 'concepts')).sort(), ['schlafhygiene.md'])
   } finally { s.restore() }
 })
 

--- a/scripts/test/roost.test.js
+++ b/scripts/test/roost.test.js
@@ -5,7 +5,7 @@ const os = require('node:os')
 const path = require('node:path')
 
 const { rebuildRoost } = require('../rebuild-roost')
-const { searchPages, findSimilarSlug, getPage, appendLog, recentClucks, regenerateIndexMd } = require('../lib/roost')
+const { searchPages, findSimilarSlug, getPage, appendLog, recentClucks, regenerateIndexMd, slugify } = require('../lib/roost')
 
 function makeTempVault () {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'coop-test-'))
@@ -27,6 +27,24 @@ function writePage (root, dir, slug, { type, tags = [], body = '' }) {
   ].join('\n')
   fs.writeFileSync(path.join(root, 'nest', dir, `${slug}.md`), frontmatter + body + '\n')
 }
+
+test('slugify — ASCII unchanged, Unicode letters kept, never empty (kip-app#97)', () => {
+  // ASCII behaviour is exactly as before
+  assert.equal(slugify('Sleep Hygiene'), 'sleep-hygiene')
+  assert.equal(slugify('  Q3 Planning!!  '), 'q3-planning')
+  assert.equal(slugify('A/B test'), 'a-b-test')
+  // non-English letters and digits survive instead of collapsing to dashes
+  assert.equal(slugify('Größe'), 'größe')
+  assert.equal(slugify('Café-Notizen'), 'café-notizen')
+  assert.equal(slugify('Réunion budget'), 'réunion-budget')
+  assert.equal(slugify('北京会議'), '北京会議')
+  assert.equal(slugify('Año nuevo'), 'año-nuevo')
+  // an all-punctuation / emoji title falls back to a stable non-empty hash
+  const h = slugify('🎉🎊')
+  assert.match(h, /^page-[0-9a-f]{8}$/)
+  assert.equal(slugify('🎉🎊'), h, 'the fallback is deterministic')
+  assert.equal(slugify(''), slugify(''))
+})
 
 test('rebuildRoost + searchPages + findSimilarSlug + clucks', async (t) => {
   const root = makeTempVault()


### PR DESCRIPTION
Closes kip-app#97.

## 1. `classifyPeckInput`

Only recognised a question by a **trailing** `?` or an **English** question word, so a non-English question without a `?` was classified as a *statement* → `captureFacts` filed it into the nest as a fact instead of answering.

Now: a `?` **anywhere** (incl. `？ ¿ ؟`), plus the interrogatives / imperatives of the six main Latin-script languages (DE, NL, FR, ES, IT, PT). Genuine declaratives in those languages still classify as statements.

| input | before | after |
|---|---|---|
| `Wer leitet das Atlas-Projekt` | statement ✗ | question ✓ |
| `Résume mes notes de sommeil` | statement ✗ | question ✓ |
| `Quién es el director de Globex` | statement ✗ | question ✓ |
| `Der neue CDO ist John Doe` | statement | statement ✓ |

## 2. `slugify` (`roost.js`)

`.replace(/[^a-z0-9]+/g, '-')` → `Größe` → `gr-e`, `北京会議` → `""` (empty, broken slug). Corrupts Hatch page names + create-vs-update dedup for non-English nests.

Now keeps `\p{L}\p{N}` (NFC-normalised); an all-punctuation / emoji title falls back to `page-<sha1[0:8]>`. **ASCII slugs are byte-identical** — only non-English titles hatched from here on get the better slug (no migration).

FTS retrieval was already fine for Latin scripts (`unicode61` folds accents).

## Tests

`peck.test.js` +2 (multilingual classification, DE end-to-end peck answers not files), `roost.test.js` +1 (slugify). Suite **286**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)