### PR TITLE
Hatch update deltas (#114) + groom findings at answer time (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ All notable changes to Kip. Format loosely follows
 The retrieval layer (this repo) and the desktop app
 ([kip-app](https://github.com/JWE24-code/kip-app)) are released together.
 
+## [Unreleased]
+
+### The retrieval layer (`scripts/`)
+
+- **Peck can file an answer back into the nest** (kip-app#112) — a settled
+  answer that came from your notes (not a web search, and with at least one
+  candidate page) can be kept as a `concept` page tagged `from-peck` via a new
+  `chat.js --file-answer` entrypoint. Hardening: the derived slug is capped
+  (long / CJK questions can't blow filename limits), an existing page's index
+  summary is left intact on update, and the `from-peck` marker survives an
+  update. Every question turn from the app now also writes exactly one `peck`
+  activity row, matching the CLI — asked-but-never-kept questions are visible
+  in the Coop activity view.
+- **Hatch updates are deltas, not restatements** (kip-app#114) — on the
+  default combined hatch path a page resolved to `update` was appended with a
+  body the model drafted without ever seeing that page, manufacturing exactly
+  the redundancy and superseded-claim issues groom reports later.
+  `commitHatchPlan` now makes one existing-content-aware `generatePageContent`
+  call for every update (combined path or classic), the way the classic path
+  already did — the write references or contrasts with the prior content
+  instead of restating it. Pure creates still cost one LLM call per file.
+- **Peck names disagreements instead of picking a side** (kip-app#116) — the
+  answer prompt (plain and skills-loop) now has an explicit rule: when the
+  cited pages disagree on a date, a value or a claim, say so and cite both
+  rather than returning one side as settled fact.
+- **Groom's findings reach Peck at answer time** (kip-app#116) — every groom
+  run now writes a compact `.roost/lint.json` (slug → findings). A Peck answer
+  intersects it with the pages it cited and returns `lintWarnings`, surfaced
+  in the CLI and the app panel, so an answer drawn from a page groom flagged
+  as orphaned / contradicted / a near-duplicate says so. Groom's stored
+  contradiction findings for the pages in play are also fed into the answer
+  prompt as a short "known disagreements" block. Strictly additive — Peck
+  never writes lint state, and a clean answer adds no LLM call.
+
 ## [0.4.3] — 2026-08-31
 
 ### The retrieval layer (`scripts/`)

--- a/scripts/groom.js
+++ b/scripts/groom.js
@@ -381,6 +381,71 @@ async function runGroom (vaultRoot = DEFAULT_VAULT_ROOT, {
   return report
 }
 
+/**
+ * Inverts a groom report into a slug → findings map for answer-time use
+ * (kip-app#116). Peck intersects this with the pages an answer cited and warns
+ * when it drew on a page groom flagged. Every finding is `{ kind, note }`, plus
+ * `slugs` for the pairwise ones (contradiction, near-duplicate, merge). No LLM
+ * — just a re-shape of what runGroom already computed.
+ */
+function buildLintIndex (report) {
+  const idx = {}
+  const add = (slug, finding) => {
+    if (!slug) return
+    ;(idx[slug] = idx[slug] || []).push(finding)
+  }
+
+  for (const slug of report.orphans || []) {
+    add(slug, { kind: 'orphan', note: 'nothing links to this page' })
+  }
+  for (const d of report.nearDuplicates || []) {
+    add(d.slugs[0], { kind: 'near-duplicate', note: `near-duplicate slug of ${d.slugs[1]} (similarity ${d.score})`, slugs: d.slugs })
+    add(d.slugs[1], { kind: 'near-duplicate', note: `near-duplicate slug of ${d.slugs[0]} (similarity ${d.score})`, slugs: d.slugs })
+  }
+  for (const m of (report.drift && report.drift.missingFiles) || []) {
+    add(m.slug, { kind: 'drift', note: 'in the index but missing on disk — run rebuild-roost' })
+  }
+  for (const c of report.contradictions || []) {
+    for (const slug of c.slugs || []) add(slug, { kind: 'contradiction', note: c.description, slugs: c.slugs })
+  }
+  // deep-only findings
+  for (const c of report.pageCoherence || []) {
+    add(c.slug, { kind: 'coherence', note: c.issues.join(' ') || 'internal inconsistency across its _Update_ sections' })
+  }
+  for (const s of report.summaryDrift || []) {
+    add(s.slug, { kind: 'summary-drift', note: `its index summary no longer fits${s.suggested ? ` (suggested: ${s.suggested})` : ''}` })
+  }
+  for (const b of report.brokenLinks || []) {
+    add(b.slug, { kind: 'broken-link', note: `links to non-existent page(s): ${b.badTargets.join(', ')}` })
+  }
+  for (const slug of report.deadEnds || []) {
+    add(slug, { kind: 'dead-end', note: 'links out to no other page' })
+  }
+  for (const m of report.mergeCandidates || []) {
+    add(m.slugs[0], { kind: 'merge-candidate', note: `possible duplicate of ${m.slugs[1]}: ${m.reason}`, slugs: m.slugs })
+    add(m.slugs[1], { kind: 'merge-candidate', note: `possible duplicate of ${m.slugs[0]}: ${m.reason}`, slugs: m.slugs })
+  }
+  return idx
+}
+
+/**
+ * Writes <coop>/.roost/lint.json — a compact slug → findings map from the
+ * groom report, for Peck to consult at answer time (kip-app#116). Written on
+ * every run (quick and deep); a quick run carries only the deterministic
+ * findings. Returns its path.
+ */
+function writeLintJson (vaultRoot, report) {
+  const dir = path.join(vaultRoot, '.roost')
+  fs.mkdirSync(dir, { recursive: true })
+  const file = path.join(dir, 'lint.json')
+  fs.writeFileSync(file, JSON.stringify({
+    generated: new Date().toISOString(),
+    deep: !!report.deep,
+    findings: buildLintIndex(report)
+  }, null, 2) + '\n')
+  return file
+}
+
 /** Writes <coop>/.roost/groom-report.md — a dated checklist. Returns its path. */
 function writeGroomReport (vaultRoot, report) {
   const today = new Date().toISOString().slice(0, 10)
@@ -498,6 +563,10 @@ async function main () {
 
   const report = await runGroom(vaultRoot, { deep, onProgress })
 
+  // Answer-time lint artifact (kip-app#116) — written on every run so Peck
+  // always has the freshest findings for the pages an answer cites.
+  report.lintPath = writeLintJson(vaultRoot, report)
+
   if (deep) {
     report.reportPath = writeGroomReport(vaultRoot, report)
     reporter.flush(false)
@@ -542,5 +611,7 @@ module.exports = {
   buildEntitySourceGroups,
   buildMergePairs,
   findContradictions,
-  writeGroomReport
+  writeGroomReport,
+  buildLintIndex,
+  writeLintJson
 }

--- a/scripts/lib/hatch.js
+++ b/scripts/lib/hatch.js
@@ -158,9 +158,10 @@ async function proposeHatchPlan (sourcePath, vaultRoot = DEFAULT_VAULT_ROOT, { c
 /**
  * Steps 5-6: writes each planned page via resolvePage(), syncs meta.db, and
  * logs the hatch. Call only after a human has confirmed the plan from
- * proposeHatchPlan(). Bodies drafted by the combined path (candidate.body)
- * are used as-is; any candidate without one gets a generatePageContent()
- * call here (the classic path).
+ * proposeHatchPlan(). A combined-path body (candidate.body) is used as-is for
+ * a pure create; an `update` — combined path or classic — gets a
+ * generatePageContent() call with the existing page content so the write is a
+ * delta, not a restatement (#114).
  *
  * Provenance (kip-app#113): `sourceRelPath` (coop-relative path of the
  * document, e.g. `eggs/report.md`) and `sourceHash` (its sha1) are written
@@ -184,11 +185,19 @@ async function proposeHatchPlan (sourcePath, vaultRoot = DEFAULT_VAULT_ROOT, { c
 async function commitHatchPlan ({ plan, sourceTitle, sourceContent, sourceRelPath = null, sourceHash = null, sourceOriginal = null }, vaultRoot = DEFAULT_VAULT_ROOT, { regenIndex = true } = {}) {
   const allSlugs = plan.map((p) => p.slug)
 
-  // Resolve every page's body up front, in parallel (capped). Combined-path
-  // candidates already carry a drafted body; classic-path ones get one
-  // generate call each here (independent + read-only). Writes stay sequential.
+  // Resolve every page's body up front, in parallel (capped). Writes stay
+  // sequential.
+  //
+  // A pure create on the combined path uses its drafted body as-is (one LLM
+  // call for the whole file). An `update` always gets an existing-content-aware
+  // generate call — the combined draft was written from the source alone,
+  // never seeing the page it's extending, so on the default path updates came
+  // out as parallel restatements rather than deltas (#114). This is the one
+  // extra call the classic path already made for updates; updates are
+  // typically 0-2 per source, so the one-call-per-file cost still mostly holds.
   const bodies = await mapLimit(plan, GENERATE_CONCURRENCY, (candidate) => {
-    if (typeof candidate.body === 'string' && candidate.body.trim()) return candidate.body.trim()
+    const draft = typeof candidate.body === 'string' && candidate.body.trim() ? candidate.body.trim() : null
+    if (draft && candidate.action !== 'update') return draft
 
     let existingContent = null
     if (candidate.action === 'update') {
@@ -198,6 +207,9 @@ async function commitHatchPlan ({ plan, sourceTitle, sourceContent, sourceRelPat
         existingContent = matter(raw).content.trim()
       }
     }
+    // Combined-path update but the page has vanished from disk/index — the
+    // drafted body is better than a source-only regenerate with no delta.
+    if (draft && !existingContent) return draft
     return generatePageContent({
       title: candidate.title,
       type: candidate.type,

--- a/scripts/lib/hatch.js
+++ b/scripts/lib/hatch.js
@@ -159,9 +159,9 @@ async function proposeHatchPlan (sourcePath, vaultRoot = DEFAULT_VAULT_ROOT, { c
  * Steps 5-6: writes each planned page via resolvePage(), syncs meta.db, and
  * logs the hatch. Call only after a human has confirmed the plan from
  * proposeHatchPlan(). A combined-path body (candidate.body) is used as-is for
- * a pure create; an `update` — combined path or classic — gets a
- * generatePageContent() call with the existing page content so the write is a
- * delta, not a restatement (#114).
+ * a pure create (and for any `source` page); an entity/concept `update` —
+ * combined path or classic — gets a generatePageContent() call with the
+ * existing page content so the write is a delta, not a restatement (#114).
  *
  * Provenance (kip-app#113): `sourceRelPath` (coop-relative path of the
  * document, e.g. `eggs/report.md`) and `sourceHash` (its sha1) are written
@@ -188,16 +188,18 @@ async function commitHatchPlan ({ plan, sourceTitle, sourceContent, sourceRelPat
   // Resolve every page's body up front, in parallel (capped). Writes stay
   // sequential.
   //
-  // A pure create on the combined path uses its drafted body as-is (one LLM
-  // call for the whole file). An `update` always gets an existing-content-aware
-  // generate call — the combined draft was written from the source alone,
-  // never seeing the page it's extending, so on the default path updates came
-  // out as parallel restatements rather than deltas (#114). This is the one
-  // extra call the classic path already made for updates; updates are
-  // typically 0-2 per source, so the one-call-per-file cost still mostly holds.
+  // A combined-path drafted body is used as-is for a pure create, and for a
+  // `source` page (its body is a stable trace pointer — file/hash/links — not
+  // accumulating knowledge). An entity/concept `update` gets an
+  // existing-content-aware generate call instead: the combined draft was
+  // written from the source alone, never seeing the page it's extending, so on
+  // the default path those updates came out as parallel restatements rather
+  // than deltas (#114). That's the one extra call the classic path already
+  // made for updates; updates are typically 0-2 per source, so the
+  // one-call-per-file cost still mostly holds.
   const bodies = await mapLimit(plan, GENERATE_CONCURRENCY, (candidate) => {
     const draft = typeof candidate.body === 'string' && candidate.body.trim() ? candidate.body.trim() : null
-    if (draft && candidate.action !== 'update') return draft
+    if (draft && (candidate.action !== 'update' || candidate.type === 'source')) return draft
 
     let existingContent = null
     if (candidate.action === 'update') {

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -171,6 +171,56 @@ function extractCitedSlugs (answerText, candidateSlugs) {
   return candidateSlugs.filter((slug) => linked.has(slug))
 }
 
+/** Groom's findings map (.roost/lint.json, written by every groom run,
+ *  kip-app#116). Read-only: Peck consults it, never writes it. Returns {} when
+ *  the file is absent or unparseable — a nest that has never been groomed just
+ *  gets no warnings. */
+function readLintIndex (vaultRoot) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path.join(vaultRoot, '.roost', 'lint.json'), 'utf8'))
+    return parsed && typeof parsed.findings === 'object' && parsed.findings ? parsed.findings : {}
+  } catch {
+    return {}
+  }
+}
+
+/** groom findings for the pages an answer cited — [{slug, kind, note}], the
+ *  answer-time half of kip-app#116. */
+function lintWarningsFor (vaultRoot, citedSlugs) {
+  if (!citedSlugs || !citedSlugs.length) return []
+  const idx = readLintIndex(vaultRoot)
+  const out = []
+  for (const slug of citedSlugs) {
+    for (const f of idx[slug] || []) {
+      if (f && f.kind && f.note) out.push({ slug, kind: f.kind, note: f.note })
+    }
+  }
+  return out
+}
+
+/** groom's stored contradiction findings where BOTH pages are in the candidate
+ *  set — fed into the answer prompt as a "known disagreements" block so the
+ *  model doesn't present a contested claim as settled (kip-app#116). No LLM
+ *  call: this is groom's already-computed output. */
+function knownConflictsFor (vaultRoot, candidateSlugs) {
+  const inPlay = new Set(candidateSlugs)
+  if (inPlay.size < 2) return []
+  const idx = readLintIndex(vaultRoot)
+  const seen = new Set()
+  const out = []
+  for (const slug of candidateSlugs) {
+    for (const f of idx[slug] || []) {
+      if (f.kind !== 'contradiction' || !Array.isArray(f.slugs) || f.slugs.length < 2) continue
+      if (!f.slugs.every((s) => inPlay.has(s))) continue
+      const key = f.slugs.slice().sort().join('|') + '::' + f.note
+      if (seen.has(key)) continue
+      seen.add(key)
+      out.push({ slugs: f.slugs, note: f.note })
+    }
+  }
+  return out
+}
+
 /**
  * Writes an answer into the nest as a new/updated `concept` page (the same
  * create-vs-update resolution hatch.js uses) and logs the peck. The one
@@ -230,6 +280,13 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   const candidateSlugs = pages.map((p) => p.slug)
   const telemetryStart = telemetry.entries().length
 
+  // groom's stored contradictions between two of the pages in play — passed
+  // into the answer prompt so the model names the disagreement instead of
+  // picking a side (kip-app#116). Not for arena: a regenerate free-rider is
+  // "answer this again", and changing its prompt context would muddy the
+  // model-vs-model compare.
+  const knownConflicts = arena ? [] : knownConflictsFor(vaultRoot, candidateSlugs)
+
   // The skills tool loop adds a bigger system prompt and, when a skill runs,
   // extra round-trips. Only take that path — or even look for skills — when
   // one is plausibly needed; otherwise answer straight from the nest. A miss
@@ -254,14 +311,14 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
     answer = await answerQuestion(question, pages, vaultRoot, { arena, history })
   } else if (wantSkills) {
     try {
-      ({ answer, steps, webSearches } = await answerQuestionWithSkills(question, pages, skills, vaultRoot, { history, onStream }))
+      ({ answer, steps, webSearches } = await answerQuestionWithSkills(question, pages, skills, vaultRoot, { history, onStream, knownConflicts }))
     } catch (err) {
       console.error(`Warning: the skills tool loop failed (${err.message}); falling back to a plain answer.`)
-      answer = await answerQuestion(question, pages, vaultRoot, { history, onStream })
+      answer = await answerQuestion(question, pages, vaultRoot, { history, onStream, knownConflicts })
       steps = []
     }
   } else {
-    answer = await answerQuestion(question, pages, vaultRoot, { history, onStream })
+    answer = await answerQuestion(question, pages, vaultRoot, { history, onStream, knownConflicts })
   }
 
   // The nest didn't cover it → search the web and answer from that
@@ -281,6 +338,8 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   }
 
   const citedSlugs = answer ? extractCitedSlugs(answer, candidateSlugs) : []
+  // groom's findings for the pages this answer actually leaned on (kip-app#116)
+  const lintWarnings = lintWarningsFor(vaultRoot, citedSlugs)
   if (fileToNest && answer && !webbed) {
     await fileAnswerToNest(question, answer, candidateSlugs, vaultRoot)
   }
@@ -293,7 +352,7 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   // If this turn ran web-search, offer its results as a hatchable source
   // (kip-app#81) — the app shows a "save these" affordance on the answer.
   const webSource = buildWebSource(question, webSearches);
-  return { answer, citedSlugs, candidateSlugs, steps, callId, arenaId, webSource: webSource || null }
+  return { answer, citedSlugs, candidateSlugs, lintWarnings, steps, callId, arenaId, webSource: webSource || null }
 }
 
 /**
@@ -388,7 +447,7 @@ function fileCapturedFacts (proposedPages, vaultRoot = DEFAULT_VAULT_ROOT) {
  * same question — routes the answer call through the managed backend's arena
  * as candidate B (the regenerate free-rider, kip-app#73).
  *
- * @returns {{answer: string|null, citedSlugs: string[], candidateSlugs: string[], steps: Array, callId: string|null, arenaId: string|null}}
+ * @returns {{answer: string|null, citedSlugs: string[], candidateSlugs: string[], lintWarnings: Array<{slug,kind,note}>, steps: Array, callId: string|null, arenaId: string|null}}
  */
 async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_VAULT_ROOT, arenaCompareToCallId = null, history = [], onStream = null } = {}) {
   const candidates = await retrieveCandidates(question, vaultRoot, { history })
@@ -406,9 +465,9 @@ async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_V
  * filed); a statement is always filed — that's the point.
  *
  * @returns {{intent: 'question'|'statement'|'reminder', ...}}
- *   question:  { answer: string|null, citedSlugs, candidateSlugs, steps }
+ *   question:  { answer: string|null, citedSlugs, candidateSlugs, lintWarnings, steps }
  *   statement: { learned: boolean, note: string, pages?: [{action,slug,path}], candidateSlugs }
- *   reminder:  { answer: string|null, citedSlugs, candidateSlugs, steps } — same
+ *   reminder:  { answer: string|null, citedSlugs, candidateSlugs, lintWarnings, steps } — same
  *              shape as question; the `reminders` skill did the work and its
  *              confirmation is in `answer`.
  */
@@ -441,4 +500,4 @@ async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = f
   return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena, history, onStream })) }
 }
 
-module.exports = { askQuestion, peckTurn, classifyPeckInput, fileAnswerToNest, fileCapturedFacts, extractCitedSlugs }
+module.exports = { askQuestion, peckTurn, classifyPeckInput, fileAnswerToNest, fileCapturedFacts, extractCitedSlugs, lintWarningsFor, knownConflictsFor }

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -15,6 +15,18 @@ const { parseWebSearchOutput } = require('./web-sources')
 const HISTORY_TURN_CLIP = 700
 const HISTORY_MAX_TURNS = 6
 
+/**
+ * groom's stored contradiction findings for the pages in play (kip-app#116),
+ * rendered as a prompt block so the answer model names the disagreement rather
+ * than presenting one side as settled. `conflicts`: [{ slugs, note }] or falsy.
+ */
+function formatKnownConflicts (conflicts) {
+  if (!Array.isArray(conflicts) || !conflicts.length) return ''
+  const lines = conflicts.map((c) => `- ${(c.slugs || []).map((s) => `[[${s}]]`).join(' vs ')}: ${c.note}`)
+  return 'Known disagreements in your nest (groom flagged these — if your answer touches one, ' +
+    'say both pages disagree and cite both, do not pick a side):\n' + lines.join('\n')
+}
+
 /** history: [{ role: "user"|"assistant", text }] oldest→newest, or falsy. */
 function formatConversation (history, { heading = 'Conversation so far' } = {}) {
   if (!Array.isArray(history) || !history.length) return ''
@@ -87,9 +99,11 @@ Do not cite anything with [[wikilink]] syntax here — these are web pages, not 
  *  candidate B against an earlier answer — the regenerate free-rider
  *  (kip-app#73). `history` (optional): recent {role,text} turns for
  *  follow-up context (kip-app#82). */
-async function answerQuestion (question, pages, vaultRoot, { arena = null, history = [], onStream = null } = {}) {
+async function answerQuestion (question, pages, vaultRoot, { arena = null, history = [], onStream = null, knownConflicts = [] } = {}) {
   const convo = formatConversation(history)
+  const conflicts = formatKnownConflicts(knownConflicts)
   const prompt = `${formatPagesForPrompt(pages)}\n\n---\n\n` +
+    (conflicts ? `${conflicts}\n\n---\n\n` : '') +
     (convo ? `${convo}\n\n---\n\n` : '') +
     `Question: ${question}`
   const { text } = await callLLM({ system: ANSWER_SYSTEM_PROMPT, prompt, maxTokens: 4096, label: 'peck:answer', arena, onStream }, { vaultRoot })
@@ -185,15 +199,17 @@ function formatSkillsBlock (skills) {
  * With no skills it's just answerQuestion(). Any unexpected throw is the
  * caller's (peck.js's) to catch and downgrade.
  */
-async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { runSkillFn = runSkill, history = [], onStream = null } = {}) {
+async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { runSkillFn = runSkill, history = [], onStream = null, knownConflicts = [] } = {}) {
   if (!skills || !skills.length) {
-    return { answer: await answerQuestion(question, pages, vaultRoot, { history, onStream }), steps: [], webSearches: [] }
+    return { answer: await answerQuestion(question, pages, vaultRoot, { history, onStream, knownConflicts }), steps: [], webSearches: [] }
   }
 
   const byName = new Map(skills.map((s) => [s.name, s]))
   const system = ANSWER_WITH_SKILLS_SYSTEM_PROMPT + formatSkillsBlock(skills)
   const convo = formatConversation(history)
+  const conflicts = formatKnownConflicts(knownConflicts)
   let transcript = `${formatPagesForPrompt(pages)}\n\n---\n\n` +
+    (conflicts ? `${conflicts}\n\n---\n\n` : '') +
     (convo ? `${convo}\n\n---\n\n` : '') +
     `Question: ${question}`
   const steps = []
@@ -262,7 +278,7 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
   }
 
   // unreachable (the turn === MAX branch returns), but be safe
-  return { answer: await answerQuestion(question, pages, vaultRoot, { history, onStream }), steps, webSearches }
+  return { answer: await answerQuestion(question, pages, vaultRoot, { history, onStream, knownConflicts }), steps, webSearches }
 }
 
 /**
@@ -591,6 +607,7 @@ module.exports = {
   generateMeetingPrep,
   answerQuestionWithSkills,
   formatSkillsBlock,
+  formatKnownConflicts,
   MAX_SKILL_ITERATIONS,
   flagContradictions,
   proposeCandidatePages,

--- a/scripts/peck.js
+++ b/scripts/peck.js
@@ -75,6 +75,12 @@ async function main () {
   }
   console.log(`\n${result.answer}\n`)
 
+  // groom's findings for the pages this answer cited (kip-app#116)
+  for (const w of result.lintWarnings || []) {
+    console.log(`  ⚠ [[${w.slug}]] — ${w.note}`)
+  }
+  if ((result.lintWarnings || []).length) console.log('')
+
   if (result.candidateSlugs.length === 0) {
     // nothing to file an answer against, and nothing to log
     return

--- a/scripts/test/groom.test.js
+++ b/scripts/test/groom.test.js
@@ -302,11 +302,12 @@ test('groom main() writes lint.json on a quick run (kip-app#116)', async (t) => 
   writePage(root, 'concepts', 'sleep-quality', { type: 'concept', tags: ['health'], body: 'Links [[sleep-hygiene]].' })
   rebuildRoost(root)
 
-  // No LLM provider configured -> groom's quick contradiction pass is caught
-  // and skipped; the deterministic checks and the lint write still run.
+  // PROVIDER=local with no server -> groom's quick contradiction pass fails
+  // its connection and is caught; the deterministic checks and the lint write
+  // still run. (Forced so the test never reaches a real provider.)
   const { execFileSync } = require('node:child_process')
   execFileSync(process.execPath, [path.join(__dirname, '..', 'groom.js'), '--json'], {
-    env: { ...process.env, KIP_COOP_ROOT: root }, encoding: 'utf8'
+    env: { ...process.env, KIP_COOP_ROOT: root, PROVIDER: 'local' }, encoding: 'utf8'
   })
 
   const lintPath = path.join(root, '.roost', 'lint.json')

--- a/scripts/test/groom.test.js
+++ b/scripts/test/groom.test.js
@@ -17,7 +17,9 @@ const {
   buildMergePairs,
   buildEntitySourceGroups,
   findContradictions,
-  writeGroomReport
+  writeGroomReport,
+  buildLintIndex,
+  writeLintJson
 } = require('../groom')
 const { reviewPageCoherence } = require('../lib/prompts')
 const { saveLLMConfig } = require('../lib/llm')
@@ -247,6 +249,71 @@ test('deep-groom prompt fns fall back to a safe default on unusable output', asy
   } finally {
     global.fetch = original
   }
+})
+
+test('buildLintIndex inverts a report into a slug → findings map (kip-app#116)', () => {
+  const report = {
+    deep: true,
+    orphans: ['lonely-page'],
+    nearDuplicates: [{ slugs: ['sleep-hygiene', 'sleep-quality'], score: 0.82 }],
+    drift: { missingFiles: [{ slug: 'ghost', path: 'nest/concepts/ghost.md' }], untrackedFiles: [] },
+    contradictions: [{ slugs: ['salary-2025', 'salary-2026'], description: 'one says 90k, the other 110k' }],
+    pageCoherence: [{ slug: 'sleep-quality', issues: ['08 section contradicts the 07 section'], consolidate: true }],
+    brokenLinks: [{ slug: 'notes', badTargets: ['no-such-page'] }],
+    deadEnds: ['notes'],
+    mergeCandidates: [{ slugs: ['dr-alvarez', 'alvarez-clinic'], reason: 'same practice' }],
+    summaryDrift: [{ slug: 'sleep-quality', current: 'x', suggested: 'sleep dropped 8h→6h' }]
+  }
+  const idx = buildLintIndex(report)
+
+  assert.deepEqual(idx['lonely-page'], [{ kind: 'orphan', note: 'nothing links to this page' }])
+  assert.equal(idx['sleep-hygiene'][0].kind, 'near-duplicate')
+  assert.deepEqual(idx['sleep-hygiene'][0].slugs, ['sleep-hygiene', 'sleep-quality'])
+  assert.equal(idx.ghost[0].kind, 'drift')
+  assert.equal(idx['salary-2025'][0].kind, 'contradiction')
+  assert.equal(idx['salary-2026'][0].note, 'one says 90k, the other 110k')
+  // sleep-quality collects several findings
+  const kinds = idx['sleep-quality'].map((f) => f.kind).sort()
+  assert.deepEqual(kinds, ['coherence', 'near-duplicate', 'summary-drift'])
+  assert.equal(idx.notes.length, 2, 'broken-link + dead-end')
+  assert.equal(idx['dr-alvarez'][0].kind, 'merge-candidate')
+
+  // a clean report yields an empty index
+  assert.deepEqual(buildLintIndex({ orphans: [], nearDuplicates: [], drift: { missingFiles: [] }, contradictions: [] }), {})
+})
+
+test('writeLintJson writes .roost/lint.json with generated/deep/findings (kip-app#116)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+  const p = writeLintJson(root, { deep: false, orphans: ['x'], nearDuplicates: [], drift: { missingFiles: [] }, contradictions: [] })
+  assert.equal(p, path.join(root, '.roost', 'lint.json'))
+  const parsed = JSON.parse(fs.readFileSync(p, 'utf8'))
+  assert.equal(parsed.deep, false)
+  assert.match(parsed.generated, /^\d{4}-\d{2}-\d{2}T/)
+  assert.deepEqual(parsed.findings.x, [{ kind: 'orphan', note: 'nothing links to this page' }])
+})
+
+test('groom main() writes lint.json on a quick run (kip-app#116)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+  writePage(root, 'concepts', 'sleep-hygiene', { type: 'concept', tags: ['health'], body: 'Sleep hygiene notes.' })
+  writePage(root, 'concepts', 'sleep-quality', { type: 'concept', tags: ['health'], body: 'Links [[sleep-hygiene]].' })
+  rebuildRoost(root)
+
+  // No LLM provider configured -> groom's quick contradiction pass is caught
+  // and skipped; the deterministic checks and the lint write still run.
+  const { execFileSync } = require('node:child_process')
+  execFileSync(process.execPath, [path.join(__dirname, '..', 'groom.js'), '--json'], {
+    env: { ...process.env, KIP_COOP_ROOT: root }, encoding: 'utf8'
+  })
+
+  const lintPath = path.join(root, '.roost', 'lint.json')
+  assert.ok(fs.existsSync(lintPath), 'quick groom writes .roost/lint.json')
+  const parsed = JSON.parse(fs.readFileSync(lintPath, 'utf8'))
+  assert.equal(parsed.deep, false)
+  assert.ok('sleep-quality' in parsed.findings, 'orphan sleep-quality is in the lint index')
 })
 
 test('runGroom end-to-end with an injected contradiction stub', async (t) => {

--- a/scripts/test/hatch.test.js
+++ b/scripts/test/hatch.test.js
@@ -287,6 +287,50 @@ test('hatchAllSources — classic mode makes one propose call plus one generate 
   }
 })
 
+test('combined-path update is regenerated against the existing page, not restated (#114)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  writePage(root, 'concepts', 'sleep-quality', { type: 'concept', tags: ['health'], body: 'Original notes: sleeping about 8h a night.' })
+  rebuildRoost(root)
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+
+  fs.writeFileSync(path.join(root, 'eggs', 'sleep-log.md'), 'This month sleep dropped to 6h a night on average.')
+
+  const seen = []
+  const { restore } = stubFetch((body) => {
+    const sys = body.messages.map((m) => m.content).join('\n')
+    if (/in a single step/.test(sys)) {
+      seen.push('draft')
+      return JSON.stringify({ pages: [
+        { title: 'sleep quality', type: 'concept', tags: ['health'], summary: 's', body: 'A full restatement of everything about the user\'s sleep, now 6h.' },
+        { title: 'Sleep Log', type: 'source', tags: [], summary: 's', body: 'Log notes. See [[sleep-quality]].' }
+      ] })
+    }
+    if (/extending an existing wiki page/.test(sys)) {
+      seen.push('update-generate')
+      assert.match(sys, /Original notes: sleeping about 8h a night\./, 'the update call is given the existing page body')
+      return 'Sleep dropped to ~6h/night this month, down from the ~8h noted earlier.'
+    }
+    seen.push('unexpected')
+    return 'x'
+  })
+
+  try {
+    const summary = await hatchAllSources(root, { limit: 1 })
+    assert.equal(summary.failed.length, 0)
+    // one combined draft + one existing-content-aware regenerate for the
+    // update; the pure-create source hub keeps its drafted body (no 2nd call).
+    assert.deepEqual(seen.sort(), ['draft', 'update-generate'])
+
+    const md = fs.readFileSync(path.join(root, 'nest', 'concepts', 'sleep-quality.md'), 'utf8')
+    assert.match(md, /_Update \d{4}-\d{2}-\d{2}:_/, 'appended as a dated delta')
+    assert.match(md, /down from the ~8h/, 'the delta body is written')
+    assert.doesNotMatch(md, /A full restatement/, 'the source-only combined draft is not used for the update')
+  } finally {
+    restore()
+  }
+})
+
 test('review mode: proposeNextPending stashes a plan and writes nothing; commitReviewedPlan honours keepSlugs', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))

--- a/scripts/test/hatch.test.js
+++ b/scripts/test/hatch.test.js
@@ -331,6 +331,31 @@ test('combined-path update is regenerated against the existing page, not restate
   }
 })
 
+test('#114 does not touch source pages: a re-hatched source hub still uses its drafted body', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  rebuildRoost(root)
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  fs.writeFileSync(path.join(root, 'eggs', 'report.md'), 'First version of the quarterly report.')
+
+  const gen = () => JSON.stringify({ pages: [{ title: 'Report', type: 'source', tags: [], summary: 's', body: 'Report hub. Links [[q3-numbers]].' }] })
+  let s = stubFetch(gen)
+  try { await hatchAllSources(root, { limit: 1 }) } finally { s.restore() }
+
+  // edit the source and re-hatch — the hub resolves to action=update
+  fs.writeFileSync(path.join(root, 'eggs', 'report.md'), 'Second version of the quarterly report, now with more detail.')
+  const kinds = []
+  s = stubFetch((body) => {
+    const sys = body.messages.map((m) => m.content).join('\n')
+    kinds.push(/in a single step/.test(sys) ? 'draft' : /extending an existing wiki page/.test(sys) ? 'generate-update' : 'other')
+    return gen()
+  })
+  try {
+    await hatchAllSources(root, { limit: 1 })
+    assert.deepEqual(kinds, ['draft'], 'no existing-content generate call for a source-type update')
+  } finally { s.restore() }
+})
+
 test('review mode: proposeNextPending stashes a plan and writes nothing; commitReviewedPlan honours keepSlugs', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -805,3 +805,91 @@ test('fileAnswerToNest hardening for the app file-back (kip-app#112)', async (t)
     assert.equal(afterCount, beforeCount, 'no additional peck row')
   })
 })
+
+test('groom findings at answer time (kip-app#116)', async (t) => {
+  const { lintWarningsFor, knownConflictsFor } = require('../lib/peck')
+
+  const writeLint = (root, findings) => fs.writeFileSync(
+    path.join(root, '.roost', 'lint.json'),
+    JSON.stringify({ generated: new Date().toISOString(), deep: false, findings }))
+
+  await t.test('lintWarningsFor / knownConflictsFor read .roost/lint.json without writing it', () => {
+    const root = makeTempVault()
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+    // no file yet -> no warnings, no throw
+    assert.deepEqual(lintWarningsFor(root, ['a']), [])
+
+    writeLint(root, {
+      'sleep-hygiene': [{ kind: 'orphan', note: 'nothing links to this page' }],
+      'salary-2025': [{ kind: 'contradiction', note: '90k vs 110k', slugs: ['salary-2025', 'salary-2026'] }],
+      'salary-2026': [{ kind: 'contradiction', note: '90k vs 110k', slugs: ['salary-2025', 'salary-2026'] }]
+    })
+    const before = fs.readFileSync(path.join(root, '.roost', 'lint.json'), 'utf8')
+
+    assert.deepEqual(lintWarningsFor(root, ['sleep-hygiene', 'unflagged']),
+      [{ slug: 'sleep-hygiene', kind: 'orphan', note: 'nothing links to this page' }])
+    assert.deepEqual(lintWarningsFor(root, ['unflagged']), [])
+
+    // both sides of the contradiction in play -> one conflict; only one -> none
+    assert.deepEqual(knownConflictsFor(root, ['salary-2025', 'salary-2026']),
+      [{ slugs: ['salary-2025', 'salary-2026'], note: '90k vs 110k' }])
+    assert.deepEqual(knownConflictsFor(root, ['salary-2025', 'something-else']), [])
+
+    assert.equal(fs.readFileSync(path.join(root, '.roost', 'lint.json'), 'utf8'), before, 'lint.json untouched')
+  })
+
+  await t.test('an answer that cites a flagged page returns a lintWarning; a clean cite returns none', async () => {
+    const root = makeTempVault()
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+    writePage(root, 'concepts', 'sleep-hygiene', { type: 'concept', tags: ['health'], body: 'Consistent bedtime, no screens.' })
+    rebuildRoost(root)
+    saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+
+    writeLint(root, { 'sleep-hygiene': [{ kind: 'orphan', note: 'nothing links to this page' }] })
+    const s = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep-hygiene]], keep a consistent bedtime.' })
+    try {
+      const result = await askQuestion('what about sleep?', { vaultRoot: root, fileToNest: false })
+      assert.deepEqual(result.lintWarnings, [{ slug: 'sleep-hygiene', kind: 'orphan', note: 'nothing links to this page' }])
+    } finally { s.restore() }
+
+    // same nest, lint.json now flags a page this answer does NOT cite
+    writeLint(root, { 'some-other-page': [{ kind: 'orphan', note: 'nothing links to this page' }] })
+    const s2 = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep-hygiene]], keep a consistent bedtime.' })
+    try {
+      const result = await askQuestion('what about sleep?', { vaultRoot: root, fileToNest: false })
+      assert.deepEqual(result.lintWarnings, [])
+    } finally { s2.restore() }
+  })
+
+  await t.test('a groom contradiction between two candidate pages is injected into the answer prompt; no extra LLM call', async () => {
+    const root = makeTempVault()
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+    writePage(root, 'concepts', 'salary-2025', { type: 'concept', tags: ['work'], body: 'Salary was 90k in 2025.' })
+    writePage(root, 'concepts', 'salary-2026', { type: 'concept', tags: ['work'], body: 'Salary is 110k in 2026.' })
+    rebuildRoost(root)
+    saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+
+    // baseline: no lint.json — count the calls a turn makes
+    const base = stubPeckFetch({ keyTerms: '{"terms":["salary"]}', answer: 'Per [[salary-2025]] and [[salary-2026]].' })
+    let baseCalls
+    try {
+      await askQuestion('what is my salary?', { vaultRoot: root, fileToNest: false })
+      baseCalls = base.calls.length
+    } finally { base.restore() }
+
+    writeLint(root, {
+      'salary-2025': [{ kind: 'contradiction', note: '2025 says 90k, 2026 says 110k', slugs: ['salary-2025', 'salary-2026'] }],
+      'salary-2026': [{ kind: 'contradiction', note: '2025 says 90k, 2026 says 110k', slugs: ['salary-2025', 'salary-2026'] }]
+    })
+    const s = stubPeckFetch({ keyTerms: '{"terms":["salary"]}', answer: 'Per [[salary-2025]] and [[salary-2026]].' })
+    try {
+      await askQuestion('what is my salary?', { vaultRoot: root, fileToNest: false })
+      const answerCall = s.calls.find((sys) => /You are answering a question from a personal wiki/.test(sys))
+      assert.match(answerCall, /Known disagreements in your nest/)
+      assert.match(answerCall, /\[\[salary-2025\]\] vs \[\[salary-2026\]\]/)
+      assert.match(answerCall, /2025 says 90k, 2026 says 110k/)
+      assert.equal(s.calls.length, baseCalls, 'reading lint.json adds no LLM round-trip')
+    } finally { s.restore() }
+  })
+})


### PR DESCRIPTION
Retrieval-layer half of roadmap issues **#114** and **#116**. The kip-app
half is JWE24-code/kip-app#119.

## #114 — hatch updates are deltas, not restatements

On the default combined hatch path a page resolved to `update` was appended
under a dated `_Update_` heading with a body the model drafted from the
source alone, never seeing the page it was extending — `proposeAndDraftPages`
gets only `sourceTitle`/`sourceContent`, and create-vs-update is decided
afterward by slug similarity. Result: parallel restatements, i.e. exactly the
redundancy / superseded-claim material groom's coherence check reports later.

`commitHatchPlan` now uses a combined-path drafted body only for a **pure
create**. Every `update` (combined path or classic) gets one
`generatePageContent` call with the existing page content, the way the
classic branch already did. Pure creates still cost one LLM call per file;
updates are typically 0-2 per source.

## #116 — groom's findings reach Peck at answer time

- Every groom run (quick and deep) writes a compact `.roost/lint.json` —
  `{ generated, deep, findings: { <slug>: [{kind, note, slugs?}] } }` —
  inverted from the report (`buildLintIndex`). No LLM call.
- `peckTurn` intersects it with the slugs an answer **cited** and returns
  `lintWarnings: [{slug, kind, note}]`. Surfaced in the CLI (`peck.js`);
  the app panel is JWE24-code/kip-app#119.
- Groom's stored contradictions between two of the **candidate** pages are
  fed into the answer prompt as a "known disagreements" block, reinforcing
  the cite-both rule from `309390f`.
- Strictly additive: Peck only ever reads lint state; a clean answer adds no
  LLM round-trip; not applied to arena regenerates.

## Tests

`npm test` → **312 pass / 0 fail** (+8). New: combined-path update regen
(#114), `buildLintIndex` / `writeLintJson` / quick-groom lint write,
`lintWarningsFor` / `knownConflictsFor` no-mutation, cited-flagged-page →
warning, clean cite → none, contradiction injected into the prompt with no
extra call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)