### PR TITLE
#115 — use the per-page summary layer at query time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ The retrieval layer (this repo) and the desktop app
 
 ## [Unreleased]
 
+### The retrieval layer (`scripts/`)
+
+- **Peck uses the summary layer** (kip-app#115) — the one-line summary the
+  index already stores for every page (written at hatch, improved by a deep
+  groom) was being dropped at query time. It now rides through `readPageBody`
+  and shows as a `Summary:` line under each `### Page:` heading in the answer
+  prompt — a "what this page is" anchor for ~25 tokens, no extra LLM call.
+- **A deep groom maintains the summary index** (kip-app#115) — when the deep
+  pass computes a better one-liner than hatch wrote, it now persists it to
+  `pages.summary` (via `setPageSummary`) instead of only listing it in the
+  report; the report says "index summary refreshed". meta.db only — no
+  `nest/` file is touched, so groom stays read-only to your notes. A filed
+  Peck answer also mirrors its summary into frontmatter so `rebuild-roost`
+  keeps it instead of degrading to `**Q:** …`.
+
 ## [0.4.9] — 2026-09-03
 
 ### The retrieval layer (`scripts/`)

--- a/scripts/groom.js
+++ b/scripts/groom.js
@@ -19,7 +19,7 @@ const fs = require('node:fs')
 const path = require('node:path')
 
 const { openDb } = require('./lib/db')
-const { appendLog, slugSimilarity, extractWikilinkSlugs, SIMILARITY_THRESHOLD } = require('./lib/roost')
+const { appendLog, setPageSummary, slugSimilarity, extractWikilinkSlugs, SIMILARITY_THRESHOLD } = require('./lib/roost')
 const { DEFAULT_VAULT_ROOT, nestPath, TYPE_DIRS } = require('./lib/paths')
 const {
   flagContradictions, reviewPageCoherence, checkSummaryAccuracy, confirmMissingLinks, checkPagesSameSubject
@@ -344,11 +344,18 @@ async function runGroom (vaultRoot = DEFAULT_VAULT_ROOT, {
     if (r.issues.length || r.consolidate) report.pageCoherence.push({ slug: p.slug, issues: r.issues, consolidate: r.consolidate })
   }
 
+  // Summary drift: the deep pass computes a better one-liner than hatch wrote.
+  // Persist it to the index (meta.db `pages.summary`, kip-app#115) instead of
+  // only reporting it — the answer prompt reads that column, so a stale
+  // summary would otherwise keep misdescribing the page on every turn. This
+  // touches only the derived index, never a nest/ markdown file.
   report.summaryDrift = []
   for (const p of summaryTargets) {
     tick(`summary: ${p.slug}`)
     const r = await summaryFn(p.slug, p.summary, p.body, vaultRoot)
-    if (!r.ok) report.summaryDrift.push({ slug: p.slug, current: p.summary, suggested: r.suggested })
+    if (r.ok || !r.suggested || !r.suggested.trim()) continue
+    const applied = setPageSummary(p.slug, r.suggested.trim(), vaultRoot)
+    report.summaryDrift.push({ slug: p.slug, current: p.summary, suggested: r.suggested.trim(), applied })
   }
 
   report.missingLinks = []
@@ -413,7 +420,10 @@ function buildLintIndex (report) {
     add(c.slug, { kind: 'coherence', note: c.issues.join(' ') || 'internal inconsistency across its _Update_ sections' })
   }
   for (const s of report.summaryDrift || []) {
-    add(s.slug, { kind: 'summary-drift', note: `its index summary no longer fits${s.suggested ? ` (suggested: ${s.suggested})` : ''}` })
+    // A drift that groom just refreshed in the index (kip-app#115) is no
+    // longer an outstanding issue — only surface one it couldn't apply.
+    if (s.applied) continue
+    add(s.slug, { kind: 'summary-drift', note: `its index summary may not fit${s.suggested ? ` (suggested: ${s.suggested})` : ''}` })
   }
   for (const b of report.brokenLinks || []) {
     add(b.slug, { kind: 'broken-link', note: `links to non-existent page(s): ${b.badTargets.join(', ')}` })
@@ -452,7 +462,9 @@ function writeGroomReport (vaultRoot, report) {
   const lines = [
     `# Groom report — ${today}`,
     '',
-    '_Deep pass. Read-only — nothing here was changed. Each item is a suggestion; check it off as you handle it._',
+    '_Deep pass. Read-only for your notes — no `nest/` file was changed. ' +
+      '(The one exception: a drifted page summary is refreshed in the index — ' +
+      'see "Summary drift".) Each item is a suggestion; check it off as you handle it._',
     ''
   ]
 
@@ -466,7 +478,7 @@ function writeGroomReport (vaultRoot, report) {
   section('Page coherence', report.pageCoherence || [], (c) =>
     `**${c.slug}** — ${c.issues.join(' ')}${c.consolidate ? ' _(suggest consolidating into a current-state summary + a dated history)_' : ''}`)
   section('Summary drift', report.summaryDrift || [], (s) =>
-    `**${s.slug}** — summary "${s.current}" no longer fits. Suggested: "${s.suggested}"`)
+    `**${s.slug}** — index summary ${s.applied ? 'refreshed' : 'should be'}: "${s.suggested}" _(was "${s.current}")_`)
   section('Merge candidates', report.mergeCandidates || [], (m) =>
     `**${m.slugs[0]}** ↔ **${m.slugs[1]}** — ${m.reason}`)
   section('Missing links', report.missingLinks || [], (l) =>

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -119,7 +119,10 @@ function readPageBody (vaultRoot, candidate) {
     return null
   }
   const { data, content } = matter(raw)
-  return { slug: candidate.slug, path: candidate.path, type: data.type, content: content.trim() }
+  // Carry the index's one-line summary through to the answer prompt
+  // (kip-app#115) — it's already computed (hatch / a deep groom) and was
+  // being dropped here. `summary` is on the searchPages() candidate.
+  return { slug: candidate.slug, path: candidate.path, type: data.type, content: content.trim(), summary: candidate.summary || null }
 }
 
 /** map candidates -> page bodies, dropping any whose file is missing. */
@@ -273,8 +276,16 @@ async function fileAnswerToNest (question, answer, candidateSlugs, vaultRoot = D
     ? existing.summary
     : trimmed.length > 200 ? trimmed.slice(0, 197) + '...' : trimmed
 
-  const writtenRaw = fs.readFileSync(path.join(vaultRoot, result.path), 'utf8')
-  const { content: writtenBody } = matter(writtenRaw)
+  const filePath = path.join(vaultRoot, result.path)
+  const writtenRaw = fs.readFileSync(filePath, 'utf8')
+  const { data: writtenData, content: writtenBody } = matter(writtenRaw)
+  // Mirror the summary into the page's frontmatter too, so a later
+  // rebuild-roost reads it back instead of degrading it to "**Q:** …"
+  // (kip-app#115 — the summary-in-frontmatter half of immutability-2).
+  if (summary && writtenData.summary !== summary) {
+    writtenData.summary = summary
+    fs.writeFileSync(filePath, matter.stringify(writtenBody, writtenData))
+  }
   upsertPage(result.slug, result.path, result.type, result.tags, summary, writtenBody, vaultRoot)
   regenerateIndexMd(vaultRoot)
   if (log) {

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -58,7 +58,13 @@ async function extractKeyTerms (question, vaultRoot, { history = [] } = {}) {
 
 function formatPagesForPrompt (pages) {
   return pages
-    .map((p) => `### Page: ${p.slug} (type: ${p.type || 'unknown'})\n${p.content}`)
+    .map((p) => {
+      // The index's one-line summary, when the caller carries it (kip-app#115):
+      // a "what this page is" anchor the model would otherwise infer from an
+      // append-grown body. ~25 tokens against bodies that run 5k-30k.
+      const summary = p.summary && String(p.summary).trim() ? `\nSummary: ${String(p.summary).trim()}` : ''
+      return `### Page: ${p.slug} (type: ${p.type || 'unknown'})${summary}\n${p.content}`
+    })
     .join('\n\n---\n\n')
 }
 

--- a/scripts/lib/roost.js
+++ b/scripts/lib/roost.js
@@ -116,6 +116,25 @@ function upsertPage (slug, filePath, type, tags, summary, body, vaultRoot = DEFA
 }
 
 /**
+ * Updates just the `summary` column for one page (kip-app#115). A deep groom
+ * computes a better summary than the one hatch wrote and, rather than only
+ * listing it in the report, persists it here. meta.db only — the markdown
+ * file is untouched, so groom stays read-only to nest/. Returns true if a row
+ * was updated. (A `rebuild-roost` re-derives summary from frontmatter, so a
+ * groom-improved summary that isn't also mirrored to frontmatter is lost on a
+ * full rebuild — an accepted limitation until groom writes frontmatter.)
+ */
+function setPageSummary (slug, summary, vaultRoot = DEFAULT_VAULT_ROOT) {
+  const db = openDb(vaultRoot)
+  try {
+    return db.prepare('UPDATE pages SET summary = ?, updated = ? WHERE slug = ?')
+      .run(summary || '', new Date().toISOString(), slug).changes > 0
+  } finally {
+    db.close()
+  }
+}
+
+/**
  * Full-text search over page bodies, with optional type/tag filters.
  * Returns candidates ranked by FTS5 relevance: { slug, path, summary, snippet }.
  */
@@ -321,6 +340,7 @@ function recentClucks (n = 5, vaultRoot = DEFAULT_VAULT_ROOT) {
 
 module.exports = {
   upsertPage,
+  setPageSummary,
   searchPages,
   findSimilarSlug,
   getPage,

--- a/scripts/test/groom.test.js
+++ b/scripts/test/groom.test.js
@@ -5,6 +5,7 @@ const os = require('node:os')
 const path = require('node:path')
 
 const { rebuildRoost } = require('../rebuild-roost')
+const { getPage } = require('../lib/roost')
 const {
   runGroom,
   findOrphans,
@@ -219,7 +220,13 @@ test('runGroom --deep runs the extra checks via injected stubs and writeGroomRep
 
   assert.equal(report.deep, true)
   assert.ok(report.pageCoherence.some((c) => c.slug === 'sleep'))
-  assert.ok(report.summaryDrift.some((s) => s.slug === 'sleep'))
+  // summary drift is now applied to the index, not just reported (kip-app#115)
+  const drift = report.summaryDrift.find((s) => s.slug === 'sleep')
+  assert.ok(drift && drift.applied, 'the improved summary was persisted')
+  assert.equal(getPage('sleep', root).summary, 'Sleep tracking; average dropped from 8h to 6h over summer 2026')
+  // ...and an applied drift is not re-surfaced as an outstanding lint finding
+  const lint = require('../groom').buildLintIndex(report)
+  assert.ok(!(lint.sleep || []).some((f) => f.kind === 'summary-drift'))
   assert.ok(report.mergeCandidates.length >= 1)
   assert.ok(report.brokenLinks.some((b) => b.badTargets.includes('ghost-page')))
   assert.ok(Array.isArray(report.deadEnds))

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -7,7 +7,7 @@ const path = require('node:path')
 const { rebuildRoost } = require('../rebuild-roost')
 const { extractCitedSlugs, fileAnswerToNest, askQuestion, peckTurn, classifyPeckInput, stripSources, humanizeSlug } = require('../lib/peck')
 const { captureFacts, answerQuestionWithSkills } = require('../lib/prompts')
-const { getPage } = require('../lib/roost')
+const { getPage, setPageSummary } = require('../lib/roost')
 const { saveLLMConfig } = require('../lib/llm')
 const telemetry = require('../lib/telemetry')
 
@@ -1063,4 +1063,55 @@ test('groom findings at answer time (kip-app#116)', async (t) => {
       assert.equal(s.calls.length, baseCalls, 'reading lint.json adds no LLM round-trip')
     } finally { s.restore() }
   })
+})
+
+test('the summary layer reaches the answer prompt (kip-app#115)', async (t) => {
+  await t.test('each candidate page shows slug + type + summary + body, with no extra LLM call', async () => {
+    const root = makeTempVault()
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+    writePage(root, 'concepts', 'sleep-hygiene', { type: 'concept', tags: ['health'], body: 'Consistent bedtime; no screens after 22:00.' })
+    rebuildRoost(root)
+    setPageSummary('sleep-hygiene', 'How the user keeps their sleep on track', root)
+    saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+
+    const s = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep-hygiene]], keep a consistent bedtime.' })
+    try {
+      const before = s.calls.length
+      await askQuestion('what about sleep?', { vaultRoot: root, fileToNest: false })
+      const answerCall = s.calls.find((sys) => /You are answering a question from a personal wiki/.test(sys))
+      assert.match(answerCall, /### Page: sleep-hygiene \(type: concept\)\nSummary: How the user keeps their sleep on track\nConsistent bedtime/)
+      // key-terms + answer only — the summary is read from the index, not generated
+      assert.equal(s.calls.length - before, 2)
+    } finally { s.restore() }
+  })
+
+  await t.test('a page with no summary just shows slug + type + body', async () => {
+    const root = makeTempVault()
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+    writePage(root, 'concepts', 'sailing', { type: 'concept', body: 'Started sailing this summer.' })
+    rebuildRoost(root)
+    setPageSummary('sailing', '', root)
+    saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+
+    const s = stubPeckFetch({ keyTerms: '{"terms":["sailing"]}', answer: 'You sail [[sailing]].' })
+    try {
+      await askQuestion('what about sailing?', { vaultRoot: root, fileToNest: false })
+      const answerCall = s.calls.find((sys) => /You are answering a question from a personal wiki/.test(sys))
+      assert.match(answerCall, /### Page: sailing \(type: concept\)\nStarted sailing/)
+      assert.doesNotMatch(answerCall, /Summary:/)
+    } finally { s.restore() }
+  })
+})
+
+test('fileAnswerToNest mirrors the summary into frontmatter so a rebuild keeps it (kip-app#115)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+  const filed = await fileAnswerToNest('what is the atlas deadline?', 'The Atlas deadline is 2026-11-01.', [], root)
+  const raw = fs.readFileSync(path.join(root, filed.path), 'utf8')
+  assert.match(raw, /^summary: /m, 'summary written to frontmatter')
+
+  // a rebuild reads the frontmatter summary back instead of degrading to "**Q:** …"
+  rebuildRoost(root)
+  assert.equal(getPage(filed.slug, root).summary, 'what is the atlas deadline?')
 })

--- a/scripts/test/roost.test.js
+++ b/scripts/test/roost.test.js
@@ -5,7 +5,7 @@ const os = require('node:os')
 const path = require('node:path')
 
 const { rebuildRoost } = require('../rebuild-roost')
-const { searchPages, findSimilarSlug, getPage, appendLog, recentClucks, regenerateIndexMd, slugify } = require('../lib/roost')
+const { searchPages, findSimilarSlug, getPage, appendLog, recentClucks, regenerateIndexMd, slugify, setPageSummary } = require('../lib/roost')
 
 function makeTempVault () {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'coop-test-'))
@@ -143,4 +143,23 @@ test('rebuildRoost + searchPages + findSimilarSlug + clucks', async (t) => {
     const results = searchPages('routine', {}, root)
     assert.equal(results.length, 0, 'deleted page should no longer be searchable')
   })
+})
+
+test('setPageSummary updates only the summary column (kip-app#115)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+  writePage(root, 'concepts', 'sleep', { type: 'concept', body: 'Notes on sleep. Averaging 6h.' })
+  rebuildRoost(root)
+  const before = getPage('sleep', root)
+
+  assert.equal(setPageSummary('sleep', 'Sleep tracking — average dropped to ~6h', root), true)
+  const after = getPage('sleep', root)
+  assert.equal(after.summary, 'Sleep tracking — average dropped to ~6h')
+  assert.equal(after.path, before.path, 'path untouched')
+  assert.equal(after.type, before.type, 'type untouched')
+  // body FTS is unchanged — still searchable by its text
+  assert.equal(searchPages('averaging', {}, root)[0].slug, 'sleep')
+
+  assert.equal(setPageSummary('no-such-page', 'x', root), false, 'no row -> false')
 })


### PR DESCRIPTION
Roadmap **#115** (wave 2 of the kip-app#106 analysis). Retrieval layer only — no kip-app change.

## What

The index stores an LLM one-line summary for every page (written at hatch, and a deep groom computes a better one) and it was discarded at query time — `searchPages` selects it, `readPageBody` dropped it, `formatPagesForPrompt` never rendered it.

- **`readPageBody`** carries `summary` through; **`formatPagesForPrompt`** renders a `Summary:` line under each `### Page:` heading when present. ~25 tokens against bodies that run 5k–30k, **no extra LLM call**.
- **A deep groom now maintains the index**: when `checkSummaryAccuracy` flags drift, the `suggested` value is persisted to `pages.summary` via a new `roost.setPageSummary()` instead of only being listed in the report ("index summary refreshed"). **meta.db only — no `nest/` file is written**, so groom stays read-only to the user's notes. An applied drift is no longer re-surfaced as a `summary-drift` lint finding.
- **`fileAnswerToNest`** mirrors its summary into the page's frontmatter so a later `rebuild-roost` reads it back instead of degrading to `**Q:** …` (the summary-in-frontmatter half of the issue's `immutability-2`).

## Acceptance (from the issue)

- ✅ a Peck turn's prompt shows slug + type + summary + body per candidate, no additional round-trip
- ✅ a deep groom that flags summary drift leaves `pages.summary` updated, report records the change
- ✅ existing peck tests pass + new ones asserting the summary line is present (and absent when there's no summary)
- ✅ `rebuild-roost` reads `summary:` from frontmatter (landed in #113); filed answers now carry it too

## Tests

`npm test` → **318 pass / 0 fail** (+5). New: `setPageSummary` column-only update; summary reaches the answer prompt / omitted when empty; deep groom applies + doesn't re-lint; filed-answer frontmatter summary survives a rebuild.

Stage 3 from the issue (summary-only rerank/select pass) is deliberately **not** in this PR — it's a separate, larger change and this is its prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)