### PR TITLE
peck: parallelize independent skill calls in the tool loop (#33)

### DIFF
--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -5,7 +5,7 @@
 // / summary / link / merge checks). All actual API calls go through callLLM()
 // in scripts/lib/llm.js — nothing here is provider-specific.
 const { callLLM } = require('./llm')
-const { runSkill, parseSkillCall, scrubInput } = require('./skills')
+const { runSkill, parseSkillCalls, scrubInput } = require('./skills')
 const { parseWebSearchOutput } = require('./web-sources')
 
 // --- conversation context (kip-app#82) --------------------------------------
@@ -162,9 +162,9 @@ const ANSWER_WITH_SKILLS_SYSTEM_PROMPT = `You are answering a question from a pe
 
 Answer using the wiki pages AND any skill results you gather. Do not speculate beyond what you're given.
 
-To run a skill, make your ENTIRE reply exactly this and nothing else:
+To run skills, make your ENTIRE reply exactly one or more <use_skill> tags and nothing else:
 <use_skill name="skill-name">{ "param": "value" }</use_skill>
-Then stop. You'll get the skill's output back and can run another skill or write your answer.
+When you need several skills whose results don't depend on each other, request them all in ONE reply — they run in parallel. Then stop. You'll get the outputs back and can run another skill or write your answer.
 
 When you can answer, write it as normal prose with NO tag. Cite a wiki-page claim with [[exact-page-slug]] (the slug shown in each "### Page: <slug>" heading). Attribute a skill-derived fact inline as "(via skill-name)".
 
@@ -196,6 +196,10 @@ function formatSkillsBlock (skills) {
 /**
  * The skills tool loop: answer the question, but let the model call skills
  * first. Returns { answer, steps: [{skill, input, ok, ms, outputPreview}] }.
+ * Independent skill calls are dispatched concurrently — the model may ask for
+ * several skills in one turn, and they run in parallel before one synthesis
+ * step. The iteration budget is unchanged: each skill call (valid or not)
+ * spends one of MAX_SKILL_ITERATIONS, so a batch costs what its calls cost.
  * With no skills it's just answerQuestion(). Any unexpected throw is the
  * caller's (peck.js's) to catch and downgrade.
  */
@@ -215,11 +219,13 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
   const steps = []
   const webSearches = []   // parsed results of every web-search run this turn (kip-app#81)
 
-  for (let turn = 0; turn <= MAX_SKILL_ITERATIONS; turn++) {
-    // Stream every turn: a turn is either a <use_skill> tag or the final
-    // prose. The consumer keys off the `first` flag to reset its buffer each
-    // turn and suppresses anything that still looks like a partial skill tag,
-    // so a tool-call turn shows nothing and the answer turn streams clean.
+  let skillsRun = 0
+  let turn = 0
+  for (;;) {
+    // Stream every turn: a turn is either one-or-more <use_skill> tags or the
+    // final prose. The consumer keys off the `first` flag to reset its buffer
+    // each turn and suppresses anything that still looks like a partial skill
+    // tag, so a tool-call turn shows nothing and the answer turn streams clean.
     const { text, raw } = await callLLM({
       system,
       prompt: transcript,
@@ -228,15 +234,68 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
       onStream
     }, { vaultRoot })
 
-    const call = parseSkillCall(text)
+    const calls = parseSkillCalls(text)
     // No <use_skill> tag (⇒ text is the final answer), or the model was cut
     // off (⇒ answer with what came back rather than loop on a partial tag).
-    if (!call || responseWasTruncated(raw)) {
+    if (!calls.length || responseWasTruncated(raw)) {
       return { answer: text, steps, webSearches }
     }
 
-    // model still wants a tool on the last allowed turn — force a final answer
-    if (turn === MAX_SKILL_ITERATIONS) {
+    // Budget: every requested skill spends one iteration, batch or not. A
+    // batch that would overshoot is truncated to what's left.
+    const admitted = []
+    for (const c of calls) {
+      if (skillsRun >= MAX_SKILL_ITERATIONS) break
+      skillsRun++
+      admitted.push(c)
+    }
+
+    // Resolve each admitted call up front: unknown name / unparseable JSON
+    // become the same corrective blocks as before; the valid ones are queued
+    // to run concurrently.
+    const toRun = []
+    for (const call of admitted) {
+      const skill = byName.get(call.name)
+      if (!skill) {
+        steps.push({ skill: call.name, input: call.input, ok: false, ms: 0, outputPreview: 'no such skill' })
+        transcript += `\n\n<skill_result name="${call.name}" ok="false">\nERROR: no such skill. Available: ${skills.map((s) => s.name).join(', ')}.\n</skill_result>\nCall a real skill or answer now.`
+        continue
+      }
+      if (call.input === null) {
+        steps.push({ skill: skill.name, input: null, ok: false, ms: 0, outputPreview: 'bad parameters' })
+        transcript += `\n\n<skill_result name="${skill.name}" ok="false">\nERROR: your parameters were not valid JSON. Retry with a JSON object, or answer directly.\n</skill_result>`
+        continue
+      }
+      toRun.push({ skill, input: call.input })
+    }
+
+    // Independent calls run in parallel — same total spend, a fraction of the
+    // wall-clock latency. Promise.all preserves order, so transcript + steps
+    // come back in the model's original order.
+    const results = await Promise.all(toRun.map((t) => runSkillFn(t.skill, t.input, vaultRoot)))
+
+    for (let i = 0; i < toRun.length; i++) {
+      const { skill, input } = toRun[i]
+      const res = results[i]
+      steps.push({
+        skill: skill.name,
+        input: scrubInput(input),
+        ok: res.ok,
+        ms: res.ms,
+        outputPreview: (res.output || res.error || '').replace(/\s+/g, ' ').trim().slice(0, 500)
+      })
+      // Any skill whose output is a web-search result list (the built-in
+      // web-search, or a user's own) — capture it as a savable source (kip-app#81).
+      if (res.ok) {
+        const parsed = parseWebSearchOutput(res.output)
+        if (parsed && parsed.results.length) webSearches.push(parsed)
+      }
+      const body = res.ok ? String(res.output || '').slice(0, 6000) : `ERROR: ${res.error}`
+      transcript += `\n\n<skill_result name="${skill.name}" ok="${res.ok}">\n${body}\n</skill_result>\nCall another skill or write your final answer now.`
+    }
+
+    // Budget exhausted and the model still wanted a tool — force a final answer
+    if (skillsRun >= MAX_SKILL_ITERATIONS) {
       const { text: final } = await callLLM({
         system: ANSWER_SYSTEM_PROMPT,
         prompt: `${transcript}\n\nAnswer the question now with what you have.`,
@@ -247,38 +306,8 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
       return { answer: final, steps, webSearches }
     }
 
-    const skill = byName.get(call.name)
-    if (!skill) {
-      steps.push({ skill: call.name, input: call.input, ok: false, ms: 0, outputPreview: 'no such skill' })
-      transcript += `\n\n<skill_result name="${call.name}" ok="false">\nERROR: no such skill. Available: ${skills.map((s) => s.name).join(', ')}.\n</skill_result>\nCall a real skill or answer now.`
-      continue
-    }
-    if (call.input === null) {
-      steps.push({ skill: skill.name, input: null, ok: false, ms: 0, outputPreview: 'bad parameters' })
-      transcript += `\n\n<skill_result name="${skill.name}" ok="false">\nERROR: your parameters were not valid JSON. Retry with a JSON object, or answer directly.\n</skill_result>`
-      continue
-    }
-
-    const res = await runSkillFn(skill, call.input, vaultRoot)
-    steps.push({
-      skill: skill.name,
-      input: scrubInput(call.input),
-      ok: res.ok,
-      ms: res.ms,
-      outputPreview: (res.output || res.error || '').replace(/\s+/g, ' ').trim().slice(0, 500)
-    })
-    // Any skill whose output is a web-search result list (the built-in
-    // web-search, or a user's own) — capture it as a savable source (kip-app#81).
-    if (res.ok) {
-      const parsed = parseWebSearchOutput(res.output)
-      if (parsed && parsed.results.length) webSearches.push(parsed)
-    }
-    const body = res.ok ? String(res.output || '').slice(0, 6000) : `ERROR: ${res.error}`
-    transcript += `\n\n<skill_result name="${skill.name}" ok="${res.ok}">\n${body}\n</skill_result>\nCall another skill or write your final answer now.`
+    turn++
   }
-
-  // unreachable (the turn === MAX branch returns), but be safe
-  return { answer: await answerQuestion(question, pages, vaultRoot, { history, onStream, knownConflicts }), steps, webSearches }
 }
 
 /**

--- a/scripts/lib/skills.js
+++ b/scripts/lib/skills.js
@@ -391,6 +391,7 @@ function record (skill, input, r) {
 // ---------------------------------------------------------------------------
 
 const USE_SKILL_RE = /<use_skill\s+name\s*=\s*["']([a-z0-9][a-z0-9-]*)["']\s*>([\s\S]*?)<\/use_skill>/i
+const USE_SKILL_RE_GLOBAL = /<use_skill\s+name\s*=\s*["']([a-z0-9][a-z0-9-]*)["']\s*>([\s\S]*?)<\/use_skill>/gi
 
 /** First balanced {...} object in `s`, as text, or null. */
 function firstJsonObject (s) {
@@ -404,6 +405,23 @@ function firstJsonObject (s) {
   return null
 }
 
+/** Decodes one already-matched <use_skill> body into a call, tolerant of
+ *  ``` fences. Returns { name, input: {} } for an empty body, and
+ *  { name, input: null } when the args weren't usable JSON (⇒ the caller
+ *  feeds back a corrective). */
+function decodeSkillCall (name, body) {
+  let b = String(body || '').trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim()
+  if (!b) return { name, input: {} }
+  try {
+    return { name, input: JSON.parse(b) }
+  } catch { /* fall through to a recovery attempt */ }
+  const obj = firstJsonObject(b)
+  if (obj) {
+    try { return { name, input: JSON.parse(obj) } } catch { /* give up */ }
+  }
+  return { name, input: null }
+}
+
 /**
  * Pulls a skill call out of a model response. Tolerant of ``` fences and
  * surrounding prose. Returns null when there's no <use_skill> tag (⇒ the text
@@ -413,17 +431,21 @@ function firstJsonObject (s) {
 function parseSkillCall (text) {
   const m = String(text || '').match(USE_SKILL_RE)
   if (!m) return null
-  const name = m[1]
-  let body = m[2].trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim()
-  if (!body) return { name, input: {} }
-  try {
-    return { name, input: JSON.parse(body) }
-  } catch { /* fall through to a recovery attempt */ }
-  const obj = firstJsonObject(body)
-  if (obj) {
-    try { return { name, input: JSON.parse(obj) } } catch { /* give up */ }
+  return decodeSkillCall(m[1], m[2])
+}
+
+/**
+ * Every <use_skill> tag in a model response, in order. [] when there is none
+ * (⇒ the text is the final answer). Each entry is the same shape as
+ * parseSkillCall's result. A response that asks for several independent skills
+ * at once is a batch the caller can run concurrently.
+ */
+function parseSkillCalls (text) {
+  const out = []
+  for (const m of String(text || '').matchAll(USE_SKILL_RE_GLOBAL)) {
+    out.push(decodeSkillCall(m[1], m[2]))
   }
-  return { name, input: null }
+  return out
 }
 
 module.exports = {
@@ -438,6 +460,7 @@ module.exports = {
   saveSearchSettings,
   SEARCH_BACKENDS,
   parseSkillCall,
+  parseSkillCalls,
   scrubInput,
   SKILL_TIMEOUT_MS,
   OUTPUT_CAP_BYTES

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -6,7 +6,7 @@ const path = require('node:path')
 
 const { rebuildRoost } = require('../rebuild-roost')
 const { extractCitedSlugs, fileAnswerToNest, askQuestion, peckTurn, classifyPeckInput } = require('../lib/peck')
-const { captureFacts } = require('../lib/prompts')
+const { captureFacts, answerQuestionWithSkills } = require('../lib/prompts')
 const { getPage } = require('../lib/roost')
 const { saveLLMConfig } = require('../lib/llm')
 
@@ -417,6 +417,85 @@ test('peckTurn — the model calls a skill, then answers with its output', async
     assert.deepEqual(r.citedSlugs, ['q3'])
     assert.ok(s.calls.some((c) => /<skill_result name="echo"/.test(c)), 'the follow-up turn saw the skill result')
   } finally { s.restore() }
+})
+
+test('peckTurn — the model batches two skills in one turn; both run, one answer', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'concepts', 'q3', { type: 'concept', tags: ['work'], body: 'Q3 numbers live in two sheets.' })
+  rebuildRoost(root)
+  writeFixtureSkill(root, 'alpha', 'console.log("ALPHA: 42")')
+  writeFixtureSkill(root, 'beta', 'console.log("BETA: 30")')
+
+  const s = stubPeckFetch({
+    keyTerms: '{"terms": ["q3"]}',
+    answerFn: (sys) => {
+      const hasAlpha = /<skill_result name="alpha"/.test(sys)
+      const hasBeta = /<skill_result name="beta"/.test(sys)
+      if (!hasAlpha && !hasBeta) {
+        return '<use_skill name="alpha">{}</use_skill>\n<use_skill name="beta">{}</use_skill>'
+      }
+      return 'Per [[q3]], alpha is 42 and beta is 30 (via alpha, beta).'
+    }
+  })
+  try {
+    const r = await peckTurn('what were the Q3 numbers?', { vaultRoot: root })
+    assert.equal(r.intent, 'question')
+    assert.deepEqual(r.steps.map((x) => [x.skill, x.ok]), [['alpha', true], ['beta', true]])
+    assert.match(r.answer, /42/)
+    assert.match(r.answer, /30/)
+  } finally { s.restore() }
+})
+
+test('answerQuestionWithSkills — independent skills in one turn are dispatched concurrently', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+
+  const skills = [
+    { name: 'alpha', description: 'fixture alpha', parameters: [], instructions: '' },
+    { name: 'beta', description: 'fixture beta', parameters: [], instructions: '' }
+  ]
+
+  let calls = 0
+  const original = global.fetch
+  global.fetch = async () => {
+    calls++
+    const content = calls === 1
+      ? '<use_skill name="alpha">{}</use_skill>\n<use_skill name="beta">{}</use_skill>'
+      : 'alpha + beta done'
+    return { ok: true, status: 200, json: async () => ({ choices: [{ message: { content }, finish_reason: 'stop' }] }) }
+  }
+  t.after(() => { global.fetch = original })
+
+  const invoked = []
+  let resolveAlpha, resolveBeta
+  const gateAlpha = new Promise((r) => { resolveAlpha = r })
+  const gateBeta = new Promise((r) => { resolveBeta = r })
+  const runSkillFn = (skill) => {
+    invoked.push(skill.name)
+    return skill.name === 'alpha'
+      ? gateAlpha.then(() => ({ ok: true, output: 'A', error: null, ms: 1 }))
+      : gateBeta.then(() => ({ ok: true, output: 'B', error: null, ms: 1 }))
+  }
+
+  const resultP = answerQuestionWithSkills('q', [], skills, root, { runSkillFn })
+
+  // Yield until the model's batch turn resolves and the concurrent dispatch runs.
+  for (let i = 0; i < 10 && invoked.length < 2; i++) {
+    await new Promise((r) => setImmediate(r))
+  }
+
+  // Both skills were dispatched even though neither has resolved yet — that's
+  // the concurrency guarantee (a serial loop would have awaited alpha first).
+  assert.deepEqual(invoked.slice().sort(), ['alpha', 'beta'])
+
+  resolveAlpha()
+  resolveBeta()
+  const result = await resultP
+  assert.equal(result.answer, 'alpha + beta done')
+  assert.deepEqual(result.steps.map((s) => [s.skill, s.ok]), [['alpha', true], ['beta', true]])
 })
 
 test('peckTurn — a web-search run comes back as a hatchable webSource (kip-app#81)', async (t) => {

--- a/scripts/test/skills.test.js
+++ b/scripts/test/skills.test.js
@@ -6,7 +6,7 @@ const path = require('node:path')
 
 const {
   discoverSkills, describeSkills, runSkill, loadSkillsConfig, saveSkillsConfig,
-  setSkillEnabled, setSkillApproval, loadSearchSettings, saveSearchSettings, parseSkillCall, scrubInput
+  setSkillEnabled, setSkillApproval, loadSearchSettings, saveSearchSettings, parseSkillCall, parseSkillCalls, scrubInput
 } = require('../lib/skills')
 const telemetry = require('../lib/telemetry')
 
@@ -226,6 +226,24 @@ test('parseSkillCall: clean, fenced, amid prose, absent, malformed', () => {
   assert.deepEqual(
     parseSkillCall('<use_skill name="thing">not json</use_skill>'),
     { name: 'thing', input: null }
+  )
+})
+
+test('parseSkillCalls: returns every tag in order; empty when none', () => {
+  assert.deepEqual(
+    parseSkillCalls('<use_skill name="a">{"x":1}</use_skill>\n<use_skill name="b">{"y":2}</use_skill>'),
+    [{ name: 'a', input: { x: 1 } }, { name: 'b', input: { y: 2 } }]
+  )
+  assert.deepEqual(
+    parseSkillCalls('first <use_skill name="a">{}</use_skill>, then <use_skill name="b">{"q":"z"}</use_skill> done'),
+    [{ name: 'a', input: {} }, { name: 'b', input: { q: 'z' } }]
+  )
+  assert.deepEqual(parseSkillCalls('just a plain answer with [[a-slug]]'), [])
+  assert.deepEqual(parseSkillCalls(''), [])
+  // a malformed second tag still yields a { input: null } entry, not a drop
+  assert.deepEqual(
+    parseSkillCalls('<use_skill name="a">{"x":1}</use_skill><use_skill name="b">not json</use_skill>'),
+    [{ name: 'a', input: { x: 1 } }, { name: 'b', input: null }]
   )
 })
 


### PR DESCRIPTION
Part of the Peck cost/latency overhaul epic (#38). Closes #33.

The skills loop was strictly serial: one `callLLM` per turn, one `runSkill`. Independent skills (nest/Slack/Confluence searches, etc.) now run concurrently — the model emits several `<use_skill>` tags in one turn and they execute in parallel before a single synthesis step.

## What changed
- `scripts/lib/skills.js`: add `parseSkillCalls` (matchAll) alongside `parseSkillCall`; shared body-decode via `decodeSkillCall`.
- `scripts/lib/prompts.js`: rework `answerQuestionWithSkills` around a batch — resolve all admitted calls up front, `Promise.all` the valid ones, keep transcript + steps in the model's original order.
- Budget semantics unchanged: every requested skill (valid or not) still spends one of `MAX_SKILL_ITERATIONS`.
- System prompt now invites batching independent skills in one reply.

## Not in scope (as designed)
- No cost/token change — same spend, less wall-clock latency.
- No new user-facing cost surface (cost stays internal per #36/#43).
- The app-side streaming suppression already handles tool-call turns; a multi-tag batch streams through the same `onStream` path.

## Verification
- Full suite green: 316/316 (`npm test`).
- New tests: batch-through-`peckTurn`, and a deterministic concurrency test (both skills dispatched before either resolves).