### PR TITLE
peck: short-TTL skill result cache (#32)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "peck": "node scripts/peck.js",
     "groom": "node scripts/groom.js",
     "hatch": "node scripts/hatch.js",
-    "test": "node --test scripts/test/roost.test.js scripts/test/chat.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/preference-signals.test.js scripts/test/feedback-poster.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js scripts/test/calendar.test.js scripts/test/web-sources.test.js scripts/test/office.test.js"
+    "test": "node --test scripts/test/roost.test.js scripts/test/chat.test.js scripts/test/pages.test.js scripts/test/groom.test.js scripts/test/llm.test.js scripts/test/connectors.test.js scripts/test/untar.test.js scripts/test/kip-connector.test.js scripts/test/preference-signals.test.js scripts/test/feedback-poster.test.js scripts/test/hatch.test.js scripts/test/peck.test.js scripts/test/telemetry.test.js scripts/test/whiteboard.test.js scripts/test/skills.test.js scripts/test/skill-cache.test.js scripts/test/web-search.test.js scripts/test/reminders.test.js scripts/test/calendar.test.js scripts/test/web-sources.test.js scripts/test/office.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.70.0",

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -377,7 +377,7 @@ async function webFallback (question, vaultRoot, { history = [], onStream = null
   }
 
   const preview = ((res && (res.output || res.error)) || '').replace(/\s+/g, ' ').trim().slice(0, 200)
-  const step = { skill: 'web-search', input: { query: question }, ok: !!(res && res.ok), ms: (res && res.ms) || 0, outputPreview: preview }
+  const step = { skill: 'web-search', input: { query: question }, ok: !!(res && res.ok), ms: (res && res.ms) || 0, cached: !!(res && res.cached), outputPreview: preview }
   const parsed = res && res.ok ? parseWebSearchOutput(res.output) : null
   if (!parsed || !parsed.results.length) return { answer: null, webSearches: [], steps: [step] }
 

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -282,6 +282,7 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
         input: scrubInput(input),
         ok: res.ok,
         ms: res.ms,
+        cached: res.cached === true ? true : undefined,
         outputPreview: (res.output || res.error || '').replace(/\s+/g, ' ').trim().slice(0, 500)
       })
       // Any skill whose output is a web-search result list (the built-in

--- a/scripts/lib/skill-cache.js
+++ b/scripts/lib/skill-cache.js
@@ -1,0 +1,122 @@
+// Per-session short-TTL cache for skill results (epic #32). A skill run that
+// produces the same output for the same input (a read-only search, a lookup)
+// gets re-run on every turn that re-asks the same question — the model asks for
+// the skill again and we spawn the child again. When a skill's SKILL.md declares
+// `cache_ttl`, remember its output keyed on (skill, input) so a fresh hit
+// short-circuits the re-spawn and returns the cached result.
+//
+// Disk-backed, not in-memory: peck runs as a fresh spawned process per turn
+// (scripts/peck.js), so a Map would never survive to the next turn. The cache
+// lives beside the other per-coop run artifacts under <coop>/.roost/. The TTL
+// is what keeps it "per-session" — it self-expires between sessions.
+//
+// Only the OUTPUT is stored; the input is never persisted, only hashed into the
+// key (and inputs with secret-ish values are refused by the caller anyway).
+const fs = require('node:fs')
+const path = require('node:path')
+const crypto = require('node:crypto')
+
+const { DEFAULT_VAULT_ROOT } = require('./paths')
+
+const DEFAULT_TTL_MS = 60_000
+const MAX_ENTRIES = 256
+const SECRETISH = /(key|token|secret|password|passwd|auth|credential)/i
+
+function cachePath (vaultRoot = DEFAULT_VAULT_ROOT) {
+  return path.join(vaultRoot, '.roost', 'peck-skill-cache.json')
+}
+
+/** Stable stringification: sort object keys, drop undefined/function values. */
+function canonical (value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`
+  const out = {}
+  for (const k of Object.keys(value).sort()) {
+    const v = value[k]
+    if (v === undefined || typeof v === 'function') continue
+    out[k] = v
+  }
+  return JSON.stringify(out)
+}
+
+/** True when `input` (or anything nested) has a secret-ish key with a value. */
+function hasSecretish (input) {
+  if (!input || typeof input !== 'object') return false
+  if (Array.isArray(input)) return input.some(hasSecretish)
+  for (const k of Object.keys(input)) {
+    const v = input[k]
+    if (v === null || v === undefined) continue
+    if (SECRETISH.test(k)) return true
+    if (typeof v === 'object' && hasSecretish(v)) return true
+  }
+  return false
+}
+
+function keyFor (skillName, input) {
+  const hash = crypto.createHash('sha256').update(canonical(input == null ? {} : input)).digest('hex').slice(0, 24)
+  return `${skillName}::${hash}`
+}
+
+function read (vaultRoot) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath(vaultRoot), 'utf8'))
+    if (parsed && typeof parsed.entries === 'object' && parsed.entries !== null) return parsed
+  } catch { /* absent or unparseable — start empty */ }
+  return { entries: {} }
+}
+
+function write (vaultRoot, data) {
+  const file = cachePath(vaultRoot)
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, JSON.stringify(data) + '\n')
+  } catch (err) {
+    console.error(`Warning: skill cache write failed (${err.message}).`)
+  }
+}
+
+function prune (data, now) {
+  for (const [key, e] of Object.entries(data.entries)) {
+    const ttl = (e && Number(e.ttl)) || DEFAULT_TTL_MS
+    if (!e || !Number.isFinite(e.at) || now - e.at >= ttl) delete data.entries[key]
+  }
+}
+
+/**
+ * Looks up a cached result for (skill.name, input). Returns null on a miss or
+ * an expired entry; otherwise { ok, output, error, ms } (the run it captured).
+ */
+function get (skill, input, { ttl, vaultRoot = DEFAULT_VAULT_ROOT, now = Date.now() } = {}) {
+  const data = read(vaultRoot)
+  prune(data, now)
+  const entry = data.entries[keyFor(skill.name, input)]
+  if (!entry) return null
+  const effectiveTtl = ttl || Number(entry.ttl) || DEFAULT_TTL_MS
+  if (now - entry.at >= effectiveTtl) return null
+  return { ok: !!entry.ok, output: entry.output || '', error: entry.error || null, ms: 0 }
+}
+
+/**
+ * Stores a successful run's output under (skill.name, input). Prunes expired
+ * entries and caps the file at MAX_ENTRIES (oldest first) on every write.
+ */
+function put (skill, input, result, { ttl, vaultRoot = DEFAULT_VAULT_ROOT, now = Date.now() } = {}) {
+  const data = read(vaultRoot)
+  prune(data, now)
+  data.entries[keyFor(skill.name, input)] = {
+    skill: skill.name,
+    at: now,
+    ttl: ttl || DEFAULT_TTL_MS,
+    ok: !!result.ok,
+    output: result.output || '',
+    error: result.error || null
+  }
+  const keys = Object.keys(data.entries)
+  if (keys.length > MAX_ENTRIES) {
+    keys.sort((a, b) => (data.entries[a].at || 0) - (data.entries[b].at || 0))
+    for (const k of keys.slice(0, keys.length - MAX_ENTRIES)) delete data.entries[k]
+  }
+  write(vaultRoot, data)
+}
+
+module.exports = { get, put, keyFor, hasSecretish, cachePath, DEFAULT_TTL_MS, MAX_ENTRIES }

--- a/scripts/lib/skills.js
+++ b/scripts/lib/skills.js
@@ -25,6 +25,7 @@ const matter = require('gray-matter')
 
 const { DEFAULT_VAULT_ROOT, skillsPath, skillsConfigPath, exportsPath } = require('./paths')
 const telemetry = require('./telemetry')
+const skillCache = require('./skill-cache')
 
 const BUILTIN_SKILLS_DIR = path.join(__dirname, '..', 'skills')
 const SKILL_TIMEOUT_MS = 60_000
@@ -159,6 +160,13 @@ function readManifest (dir, source) {
     ? Math.min(timeoutSec * 1000, SKILL_TIMEOUT_MAX_MS)
     : SKILL_TIMEOUT_MS
 
+  // cache_ttl (seconds) opts this skill's results into the short-TTL cache
+  // (skill-cache.js). 0 / absent = never cached — the default, because a
+  // skill may be non-deterministic or produce a file on disk (a stale cached
+  // path would be wrong). Only read-only, idempotent skills set this.
+  const cacheTtlSec = Number(data.cache_ttl)
+  const cacheTtlMs = Number.isFinite(cacheTtlSec) && cacheTtlSec > 0 ? cacheTtlSec * 1000 : 0
+
   return {
     name,
     description: data.description.trim(),
@@ -174,7 +182,8 @@ function readManifest (dir, source) {
     source,
     dir,
     entryPath,
-    timeoutMs
+    timeoutMs,
+    cacheTtlMs
   }
 }
 
@@ -336,6 +345,23 @@ function runSkill (skill, input, vaultRoot = DEFAULT_VAULT_ROOT, { timeoutMs, ou
     record(skill, input, r)
     return Promise.resolve(r)
   }
+
+  // Short-TTL cache (epic #32): a skill that opted in (cache_ttl) and was run
+  // with the same input moments ago returns its stored result instead of
+  // re-spawning. Never cached: secrets in the input, a disabled cache, or a
+  // skill that didn't declare cache_ttl.
+  const cacheable = skill.cacheTtlMs > 0 &&
+    process.env.KIP_SKILL_CACHE !== '0' &&
+    !skillCache.hasSecretish(input)
+  if (cacheable) {
+    const cached = skillCache.get(skill, input, { ttl: skill.cacheTtlMs, vaultRoot })
+    if (cached) {
+      const r = { ...cached, ms: 0, timedOut: false, cached: true }
+      record(skill, input, r)
+      return Promise.resolve(r)
+    }
+  }
+
   const env = {
     ...process.env,
     NODE_NO_WARNINGS: '1', // skill deps (docx, pptx-automizer) trip Node's localStorage ExperimentalWarning on v26
@@ -352,7 +378,13 @@ function runSkill (skill, input, vaultRoot = DEFAULT_VAULT_ROOT, { timeoutMs, ou
 
   return new Promise((resolve) => {
     let done = false
-    const finish = (r) => { if (!done) { done = true; record(skill, input, r); resolve(r) } }
+    const finish = (r) => {
+      if (done) return
+      done = true
+      record(skill, input, r)
+      if (r.ok && cacheable) skillCache.put(skill, input, r, { ttl: skill.cacheTtlMs, vaultRoot })
+      resolve(r)
+    }
 
     execFileFn(process.execPath, [skill.entryPath], { cwd: skill.dir, env, timeout, maxBuffer, windowsHide: true },
       (err, stdout, stderr) => {
@@ -379,6 +411,7 @@ function record (skill, input, r) {
     ok: r.ok,
     skill: skill.name,
     timedOut: r.timedOut || undefined,
+    cached: r.cached === true ? true : undefined,
     outputChars: (r.output || '').length,
     error: r.error || undefined,
     system: JSON.stringify(scrubInput(input)),

--- a/scripts/peck.js
+++ b/scripts/peck.js
@@ -71,7 +71,7 @@ async function main () {
   }
 
   for (const s of result.steps || []) {
-    console.error(`  · ${s.ok ? 'ran' : 'failed'} ${s.skill} (${(s.ms / 1000).toFixed(1)}s)`)
+    console.error(`  · ${s.cached ? 'cached' : (s.ok ? 'ran' : 'failed')} ${s.skill} (${(s.ms / 1000).toFixed(1)}s)`)
   }
   console.log(`\n${result.answer}\n`)
 

--- a/scripts/skills/web-search/SKILL.md
+++ b/scripts/skills/web-search/SKILL.md
@@ -8,6 +8,7 @@ when_to_use: >
 entry: run.js
 network: true
 timeout: 25
+cache_ttl: 60
 parameters:
   - { name: query, type: string, required: true, description: "The search query." }
   - { name: count, type: number, required: false, description: "How many results to return (default 5, max 10)." }

--- a/scripts/test/skill-cache.test.js
+++ b/scripts/test/skill-cache.test.js
@@ -1,0 +1,166 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { runSkill, discoverSkills, setSkillApproval } = require('../lib/skills')
+const skillCache = require('../lib/skill-cache')
+
+function makeTempCoop () {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'coop-skill-cache-test-'))
+  fs.mkdirSync(path.join(root, '.henhouse', 'skills'), { recursive: true })
+  fs.mkdirSync(path.join(root, 'eggs'), { recursive: true })
+  return root
+}
+
+/** Writes a user skill; run.js appends one 'x' to <coop>/count.txt so a test
+ *  can assert how many times the child actually ran. */
+function writeSkill (root, name, { frontmatter = {}, run, approve = true } = {}) {
+  const dir = path.join(root, '.henhouse', 'skills', name)
+  fs.mkdirSync(dir, { recursive: true })
+  const fm = Object.assign({ name, description: `test skill ${name}`, entry: 'run.js' }, frontmatter)
+  const yaml = Object.entries(fm).map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join('\n')
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\n${yaml}\n---\n`)
+  fs.writeFileSync(path.join(dir, 'run.js'), run || 'console.log("ok")')
+  if (approve) setSkillApproval(root, name, 'always')
+  return dir
+}
+
+function invocations (root) {
+  try { return fs.readFileSync(path.join(root, 'count.txt'), 'utf8') } catch { return '' }
+}
+
+// ---------------------------------------------------------------------------
+// skill-cache module (keying, secret detection, TTL)
+// ---------------------------------------------------------------------------
+
+test('skill-cache: key is order-insensitive and value-sensitive', () => {
+  const a = skillCache.keyFor('web-search', { query: 'cats', count: 5 })
+  const b = skillCache.keyFor('web-search', { count: 5, query: 'cats' })
+  const c = skillCache.keyFor('web-search', { query: 'dogs', count: 5 })
+  const d = skillCache.keyFor('other', { query: 'cats', count: 5 })
+  assert.equal(a, b, 'same input in a different key order hashes the same')
+  assert.notEqual(a, c, 'different value hashes differently')
+  assert.notEqual(a, d, 'different skill hashes differently')
+})
+
+test('skill-cache: hasSecretish flags secret-ish keys, nested too', () => {
+  assert.equal(skillCache.hasSecretish({ query: 'x', count: 1 }), false)
+  assert.equal(skillCache.hasSecretish({ query: 'x', apiKey: 'sk' }), true)
+  assert.equal(skillCache.hasSecretish({ query: 'x', BRAVE_TOKEN: 't' }), true)
+  assert.equal(skillCache.hasSecretish({ items: [{ key: 'a' }] }), true)
+  assert.equal(skillCache.hasSecretish('plain string'), false)
+})
+
+test('skill-cache: get/put round-trips, expires after the TTL, and stores no input', (t) => {
+  const root = makeTempCoop()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+  const skill = { name: 'lookup' }
+  skillCache.put(skill, { query: 'cats' }, { ok: true, output: 'results', error: null }, { ttl: 60_000, vaultRoot: root, now: 1000 })
+
+  // fresh hit
+  const hit = skillCache.get(skill, { query: 'cats' }, { ttl: 60_000, vaultRoot: root, now: 1000 + 59_999 })
+  assert.ok(hit, 'fresh entry is a hit')
+  assert.equal(hit.ok, true)
+  assert.equal(hit.output, 'results')
+
+  // expired
+  assert.equal(skillCache.get(skill, { query: 'cats' }, { ttl: 60_000, vaultRoot: root, now: 1000 + 60_000 }), null)
+
+  // the on-disk file holds output, never the raw input
+  const raw = fs.readFileSync(path.join(root, '.roost', 'peck-skill-cache.json'), 'utf8')
+  assert.equal(raw.includes('"cats"'), false, 'input is never persisted')
+  assert.equal(raw.includes('results'), true)
+})
+
+test('skill-cache: caps entries at MAX_ENTRIES, dropping the oldest first', (t) => {
+  const root = makeTempCoop()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+  const skill = { name: 'lookup' }
+  for (let i = 0; i < skillCache.MAX_ENTRIES + 10; i++) {
+    skillCache.put(skill, { query: `q${i}` }, { ok: true, output: `o${i}` }, { ttl: 60_000, vaultRoot: root, now: 1000 + i })
+  }
+  const raw = JSON.parse(fs.readFileSync(path.join(root, '.roost', 'peck-skill-cache.json'), 'utf8'))
+  assert.ok(Object.keys(raw.entries).length <= skillCache.MAX_ENTRIES, 'entry count is capped')
+  // the very first (oldest) was evicted; the latest survived
+  assert.ok(!Object.values(raw.entries).some((e) => e.output === 'o0'), 'oldest entry evicted')
+  assert.ok(Object.values(raw.entries).some((e) => e.output === `o${skillCache.MAX_ENTRIES + 9}`), 'newest entry kept')
+})
+
+// ---------------------------------------------------------------------------
+// runSkill integration
+// ---------------------------------------------------------------------------
+
+test('runSkill: cache_ttl returns a cached result without re-running the child', async (t) => {
+  const root = makeTempCoop()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  writeSkill(root, 'lookup', {
+    frontmatter: { cache_ttl: 60 },
+    run: 'require("fs").appendFileSync(process.env.KIP_COOP_ROOT + "/count.txt", "x"); console.log("cached-me")'
+  })
+  const skill = discoverSkills(root).find((s) => s.name === 'lookup')
+
+  const first = await runSkill(skill, { query: 'cats' }, root)
+  assert.equal(first.ok, true)
+  assert.equal(first.cached, undefined)
+
+  const second = await runSkill(skill, { query: 'cats' }, root)
+  assert.equal(second.ok, true)
+  assert.equal(second.cached, true, 'second identical call is served from cache')
+  assert.equal(second.output, 'cached-me')
+  assert.equal(second.ms, 0)
+
+  assert.equal(invocations(root), 'x', 'the child ran exactly once')
+
+  // a different input is a miss and runs again
+  const third = await runSkill(skill, { query: 'dogs' }, root)
+  assert.equal(third.cached, undefined)
+  assert.equal(invocations(root), 'xx')
+})
+
+test('runSkill: a skill without cache_ttl is never cached', async (t) => {
+  const root = makeTempCoop()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  writeSkill(root, 'plain', { run: 'require("fs").appendFileSync(process.env.KIP_COOP_ROOT + "/count.txt", "x"); console.log("ok")' })
+  const skill = discoverSkills(root).find((s) => s.name === 'plain')
+
+  await runSkill(skill, { q: 1 }, root)
+  await runSkill(skill, { q: 1 }, root)
+  assert.equal(invocations(root), 'xx', 'both calls ran the child')
+})
+
+test('runSkill: input with a secret-ish value is never cached', async (t) => {
+  const root = makeTempCoop()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  writeSkill(root, 'secy', {
+    frontmatter: { cache_ttl: 60 },
+    run: 'require("fs").appendFileSync(process.env.KIP_COOP_ROOT + "/count.txt", "x"); console.log("ok")'
+  })
+  const skill = discoverSkills(root).find((s) => s.name === 'secy')
+
+  await runSkill(skill, { query: 'x', apiKey: 'sk-secret' }, root)
+  await runSkill(skill, { query: 'x', apiKey: 'sk-secret' }, root)
+  assert.equal(invocations(root), 'xx', 'secret-ish inputs bypass the cache')
+})
+
+test('runSkill: KIP_SKILL_CACHE=0 disables caching entirely', async (t) => {
+  const prev = process.env.KIP_SKILL_CACHE
+  process.env.KIP_SKILL_CACHE = '0'
+  t.after(() => { if (prev === undefined) delete process.env.KIP_SKILL_CACHE; else process.env.KIP_SKILL_CACHE = prev })
+
+  const root = makeTempCoop()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  writeSkill(root, 'lookup', {
+    frontmatter: { cache_ttl: 60 },
+    run: 'require("fs").appendFileSync(process.env.KIP_COOP_ROOT + "/count.txt", "x"); console.log("ok")'
+  })
+  const skill = discoverSkills(root).find((s) => s.name === 'lookup')
+
+  await runSkill(skill, { query: 'cats' }, root)
+  const second = await runSkill(skill, { query: 'cats' }, root)
+  assert.equal(second.cached, undefined)
+  assert.equal(invocations(root), 'xx', 'cache disabled → both calls ran')
+})


### PR DESCRIPTION
Per-session short-TTL result cache for skills, keyed on `(skill, input)` (epic #38, track #32).

A read-only skill re-asked for the same input across turns was re-spawned every time. This caches its output for a short TTL so a fresh hit short-circuits the re-spawn (and any network/LLM work the skill itself does).

## What changed
- `scripts/lib/skill-cache.js` — disk-backed JSON cache at `<coop>/.roost/peck-skill-cache.json` (disk, not memory: peck spawns fresh per turn). Key = `skill + sha256(canonical input)`; stores **output only**, never input. Prunes expired entries, caps at 256.
- `scripts/lib/skills.js` — `readManifest` reads `cache_ttl` (seconds; 0/absent = off). `runSkill` checks the cache before spawning and stores `ok` runs; skips inputs with secret-ish keys; `KIP_SKILL_CACHE=0` disables. `record()` marks cached hits so telemetry + trace show them.
- `scripts/skills/web-search/SKILL.md` — `cache_ttl: 60`.
- `prompts.js` / `peck.js` — `steps` + CLI render `cached` instead of `ran`.

## Safety
Opt-in only: file-producing skills (`docx`/`pptx`/`xlsx`) stay uncached by default so we never return a stale file path.

## Verification
`npm test` → 324/324 green.