### PR TITLE
peck: wire per-call USD cost through to turn telemetry (#43)

### DIFF
--- a/scripts/lib/kip-connector.js
+++ b/scripts/lib/kip-connector.js
@@ -104,12 +104,22 @@ async function postJson (url, apiKey, body, headers, doFetch, signal) {
 const header = (res, name) =>
   (res && res.headers && typeof res.headers.get === 'function' && res.headers.get(name)) || null
 
+const numOrNull = (v) => {
+  if (v === null || v === undefined || v === '') return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+/** The backend meters each call and returns its USD cost in X-Kip-Cost-Usd. */
+const costHeader = (res) => numOrNull(header(res, 'x-kip-cost-usd'))
+
 async function post (baseUrl, apiKey, body, headers, doFetch, signal) {
   const url = `${baseUrl.replace(/\/+$/, '')}/v1/chat/completions`
   const res = await postJson(url, apiKey, body, headers, doFetch, signal)
   // The backend tags every completion with a call id; every later preference
   // signal (rating / behaviour / arena verdict) references it. See kip-app#73.
-  return { data: await res.json(), callId: header(res, 'x-kip-call-id') }
+  // It also returns the metered USD cost for internal telemetry (kip#43).
+  return { data: await res.json(), callId: header(res, 'x-kip-call-id'), costUsd: costHeader(res) }
 }
 
 /** POST {baseUrl}/v1/arena/completions — runs B (and A, unless compare_to_call_id
@@ -159,27 +169,28 @@ async function callBackend (resolved, call, ctx) {
       text: String(completionText(b)).trim(),
       raw: b,
       callId: b.kip_call_id || null,
-      arenaId: arenaId || null
+      arenaId: arenaId || null,
+      costUsd: numOrNull(b.cost_usd)
     }
   }
 
-  let data, callId
+  let data, callId, costUsd
   if (call.json) {
     try {
-      ({ data, callId } = await post(baseUrl, resolved.apiKey, { ...base, response_format: { type: 'json_object' } }, routingHeaders, doFetch, signal))
+      ({ data, callId, costUsd } = await post(baseUrl, resolved.apiKey, { ...base, response_format: { type: 'json_object' } }, routingHeaders, doFetch, signal))
     } catch (err) {
       // a routing/plan/auth error is real — only retry a plain 400 (upstream
       // rejected response_format), matching the OpenAI-compatible path.
       if (err.status !== 400) throw err
       const sys = call.system ? `${call.system}\n\n${JSON_MODE_INSTRUCTION}` : JSON_MODE_INSTRUCTION
-      ;({ data, callId } = await post(baseUrl, resolved.apiKey, { ...base, messages: buildMessages(sys, call.prompt) }, routingHeaders, doFetch, signal))
+      ;({ data, callId, costUsd } = await post(baseUrl, resolved.apiKey, { ...base, messages: buildMessages(sys, call.prompt) }, routingHeaders, doFetch, signal))
     }
   } else {
-    ({ data, callId } = await post(baseUrl, resolved.apiKey, base, routingHeaders, doFetch, signal))
+    ({ data, callId, costUsd } = await post(baseUrl, resolved.apiKey, base, routingHeaders, doFetch, signal))
   }
 
   const raw = completionText(data)
-  return { text: call.json ? stripCodeFences(raw) : String(raw).trim(), raw: data, callId: callId || null, arenaId: null }
+  return { text: call.json ? stripCodeFences(raw) : String(raw).trim(), raw: data, callId: callId || null, arenaId: null, costUsd: costUsd || null }
 }
 
 /** GET {baseUrl}/v1/usage — auth-only, not routed, not plan-checked. The

--- a/scripts/lib/llm.js
+++ b/scripts/lib/llm.js
@@ -173,6 +173,9 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label,
     const result = await spec.complete(resolved, call, ctx)
     const callId = (result && result.callId) || null
     const arenaId = (result && result.arenaId) || null
+    // Only the managed Kip backend meters cost; every other provider leaves it
+    // null (the client never guesses price — kip#43).
+    const costUsd = (result && typeof result.costUsd === 'number') ? result.costUsd : null
 
     const usage = extractUsage(result.raw)
     const reasoning = extractReasoning(result.raw)
@@ -184,6 +187,7 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label,
       model: realModel,
       callId,
       arenaId,
+      costUsd,
       ms: Date.now() - started,
       ok: true,
       systemChars: (system || '').length,
@@ -197,7 +201,7 @@ async function callLLM ({ system, prompt, json = false, maxTokens = 4096, label,
       responseText: result.text,
       reasoning
     })
-    return { ...result, callId, arenaId }
+    return { ...result, callId, arenaId, costUsd }
   } catch (err) {
     telemetry.record({
       ...common,

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -352,7 +352,8 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   // If this turn ran web-search, offer its results as a hatchable source
   // (kip-app#81) — the app shows a "save these" affordance on the answer.
   const webSource = buildWebSource(question, webSearches);
-  return { answer, citedSlugs, candidateSlugs, lintWarnings, steps, callId, arenaId, webSource: webSource || null }
+  const costUsd = turnCostSince(telemetryStart)
+  return { answer, citedSlugs, candidateSlugs, lintWarnings, steps, callId, arenaId, webSource: webSource || null, costUsd }
 }
 
 /**
@@ -403,6 +404,23 @@ function answerCallSince (startIdx) {
   return { callId: null, arenaId: null }
 }
 
+/** Sum of metered USD cost across telemetry entries at/after `startIdx`.
+ *  Non-Kip providers leave costUsd null, so with no metered call this is
+ *  null (not 0) — the client never guesses price (kip#43). */
+function turnCostSince (startIdx) {
+  const es = telemetry.entries()
+  let total = 0
+  let any = false
+  for (let i = startIdx; i < es.length; i++) {
+    const c = es[i].costUsd
+    if (typeof c === 'number' && Number.isFinite(c)) {
+      total += c
+      any = true
+    }
+  }
+  return any ? Math.round(total * 1e8) / 1e8 : null
+}
+
 /**
  * Writes the pages captureFacts() proposed for a told fact — same
  * create-vs-update resolution Hatch uses (resolvePage -> findSimilarSlug),
@@ -450,13 +468,15 @@ function fileCapturedFacts (proposedPages, vaultRoot = DEFAULT_VAULT_ROOT) {
  * @returns {{answer: string|null, citedSlugs: string[], candidateSlugs: string[], lintWarnings: Array<{slug,kind,note}>, steps: Array, callId: string|null, arenaId: string|null}}
  */
 async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_VAULT_ROOT, arenaCompareToCallId = null, history = [], onStream = null } = {}) {
+  const turnStart = telemetry.entries().length
   const candidates = await retrieveCandidates(question, vaultRoot, { history })
   if (candidates.length === 0 && !anySkills(vaultRoot)) {
-    return { answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
+    return { answer: null, citedSlugs: [], candidateSlugs: [], steps: [], costUsd: turnCostSince(turnStart) }
   }
   const pages = readPageBodies(vaultRoot, candidates)
   const arena = arenaCompareToCallId ? { compareToCallId: arenaCompareToCallId } : null
-  return answerFromPages(question, pages, { fileToNest, vaultRoot, arena, history, onStream })
+  const result = await answerFromPages(question, pages, { fileToNest, vaultRoot, arena, history, onStream })
+  return { ...result, costUsd: turnCostSince(turnStart) }
 }
 
 /**
@@ -472,11 +492,12 @@ async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_V
  *              confirmation is in `answer`.
  */
 async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = false, arenaCompareToCallId = null, history = [], onStream = null } = {}) {
+  const turnStart = telemetry.entries().length
   // An upcoming event the user wants reminding about ("I have a meeting Friday
   // at 15h", "remind me to …") — route to the skills path (the `reminders`
   // skill creates it), NOT fact-capture, which would file it as a nest page.
   if (looksLikeReminder(input)) {
-    return { intent: 'reminder', ...(await answerFromPages(input, [], { fileToNest: false, vaultRoot })) }
+    return { intent: 'reminder', ...(await answerFromPages(input, [], { fileToNest: false, vaultRoot })), costUsd: turnCostSince(turnStart) }
   }
 
   const candidates = await retrieveCandidates(input, vaultRoot, { history })
@@ -488,16 +509,17 @@ async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = f
     const results = capture.learned ? fileCapturedFacts(capture.pages, vaultRoot) : []
     const touched = [...new Set(results.map((r) => r.slug))]
     appendLog('told', input, touched, vaultRoot)
+    const costUsd = turnCostSince(turnStart)
     return results.length
-      ? { intent: 'statement', learned: true, note: capture.note, pages: results, candidateSlugs }
-      : { intent: 'statement', learned: false, note: capture.note || 'Nothing new to record.', candidateSlugs }
+      ? { intent: 'statement', learned: true, note: capture.note, pages: results, candidateSlugs, costUsd }
+      : { intent: 'statement', learned: false, note: capture.note || 'Nothing new to record.', candidateSlugs, costUsd }
   }
 
   if (pages.length === 0 && !anySkills(vaultRoot)) {
-    return { intent: 'question', answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
+    return { intent: 'question', answer: null, citedSlugs: [], candidateSlugs: [], steps: [], costUsd: turnCostSince(turnStart) }
   }
   const arena = arenaCompareToCallId ? { compareToCallId: arenaCompareToCallId } : null
-  return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena, history, onStream })) }
+  return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena, history, onStream })), costUsd: turnCostSince(turnStart) }
 }
 
 module.exports = { askQuestion, peckTurn, classifyPeckInput, fileAnswerToNest, fileCapturedFacts, extractCitedSlugs, lintWarningsFor, knownConflictsFor }

--- a/scripts/lib/telemetry.js
+++ b/scripts/lib/telemetry.js
@@ -96,6 +96,11 @@ function num (x) {
   return typeof x === 'number' && Number.isFinite(x) ? x : 0
 }
 
+/** Round a USD sum to 8 decimals (0.01 micro-cent) — avoids float-noise in JSON. */
+function roundUsd (x) {
+  return Math.round(x * 1e8) / 1e8
+}
+
 /** Content-free aggregate of every recorded call this run. */
 function summary () {
   const byPhase = {}
@@ -104,24 +109,28 @@ function summary () {
   let failedCalls = 0
   let input = 0
   let output = 0
+  let costUsd = 0
 
   for (const e of records) {
     wallLlmMs += num(e.ms)
     input += num(e.inputTokens)
     output += num(e.outputTokens)
+    costUsd += num(e.costUsd)
     if (e.ok) okCalls++
     else failedCalls++
 
     const p = byPhase[e.phase] ||
-      (byPhase[e.phase] = { calls: 0, ms: 0, avgMs: 0, inputTokens: 0, outputTokens: 0, failures: 0 })
+      (byPhase[e.phase] = { calls: 0, ms: 0, avgMs: 0, inputTokens: 0, outputTokens: 0, failures: 0, costUsd: 0 })
     p.calls++
     p.ms += num(e.ms)
     p.inputTokens += num(e.inputTokens)
     p.outputTokens += num(e.outputTokens)
+    p.costUsd += num(e.costUsd)
     if (!e.ok) p.failures++
   }
   for (const p of Object.values(byPhase)) {
     p.avgMs = p.calls ? Math.round(p.ms / p.calls) : 0
+    p.costUsd = roundUsd(p.costUsd)
   }
 
   const slowestCalls = [...records]
@@ -141,6 +150,7 @@ function summary () {
     failedCalls,
     wallLlmMs,
     tokens: { input, output },
+    costUsd: roundUsd(costUsd),
     byPhase,
     slowestCalls
   }

--- a/scripts/test/kip-connector.test.js
+++ b/scripts/test/kip-connector.test.js
@@ -75,6 +75,25 @@ test('complete: returns the X-Kip-Call-Id header as callId', async () => {
   assert.equal(res.callId, 'call_abc123')
 })
 
+test('complete: returns the X-Kip-Cost-Usd header as costUsd', async () => {
+  const { impl } = fakeFetch(reply('hi'), { resHeaders: { 'x-kip-cost-usd': '0.00042' } })
+  const res = await kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10 }, { fetch: impl })
+  assert.equal(res.costUsd, 0.00042)
+})
+
+test('complete: no cost header -> costUsd null', async () => {
+  const { impl } = fakeFetch(reply('hi'))
+  const res = await kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10 }, { fetch: impl })
+  assert.equal(res.costUsd, null)
+})
+
+test('complete arena: reads b.cost_usd', async () => {
+  const arenaBody = { arena_id: 'a9', origin: 'regen', b: { ...reply('x'), kip_call_id: 'call_B', cost_usd: 0.0007 } }
+  const { impl } = fakeFetch(arenaBody)
+  const res = await kip.complete(RESOLVED, { prompt: 'q', maxTokens: 10, arena: { compareToCallId: 'call_A' } }, { fetch: impl })
+  assert.equal(res.costUsd, 0.0007)
+})
+
 test('complete json:true: callId survives the prompt-and-strip 400 retry', async () => {
   const impl = async (_url, init) => {
     const body = JSON.parse(init.body)

--- a/scripts/test/llm.test.js
+++ b/scripts/test/llm.test.js
@@ -434,16 +434,33 @@ test('callLLM: "kip" provider routes through the managed backend with routing he
   await withEnv({ PROVIDER: 'kip', KIP_API_KEY: 'kip_env', KIP_BASE_URL: 'http://lan.test:8080' }, async () => {
     const { impl, getLastCall } = fakeFetch(
       { model: 'claude-sonnet-4-6', choices: [{ message: { content: 'from kip' } }] },
-      { resHeaders: { 'x-kip-call-id': 'call_xyz' } })
+      { resHeaders: { 'x-kip-call-id': 'call_xyz', 'x-kip-cost-usd': '0.0005' } })
     const result = await callLLM({ system: 's', prompt: 'p', label: 'peck:answer' }, { fetchImpl: impl, vaultRoot: EMPTY_VAULT })
     assert.equal(result.text, 'from kip')
     assert.equal(result.callId, 'call_xyz', 'callId passed through from the kip connector')
+    assert.equal(result.costUsd, 0.0005, 'costUsd passed through from the kip connector')
     assert.equal(getLastCall().url, 'http://lan.test:8080/v1/chat/completions')
     assert.equal(getLastCall().init.headers.Authorization, 'Bearer kip_env')
     assert.equal(getLastCall().init.headers['X-Kip-Workload'], 'peck:answer')
     assert.equal(getLastCall().init.headers['X-Kip-Phase'], 'peck')
     assert.equal(JSON.parse(getLastCall().init.body).model, 'auto')
   })
+})
+
+test('callLLM: records costUsd (null for non-kip providers, number for kip)', async () => {
+  telemetry.reset()
+  await withEnv({ PROVIDER: 'anthropic' }, async () => {
+    const { FakeAnthropic } = fakeAnthropicClient('hi')
+    await callLLM({ system: 's', prompt: 'p', label: 't' }, { AnthropicClient: FakeAnthropic, vaultRoot: EMPTY_VAULT })
+  })
+  assert.equal(telemetry.entries()[0].costUsd, null, 'non-managed provider -> costUsd null')
+
+  telemetry.reset()
+  await withEnv({ PROVIDER: 'kip', KIP_API_KEY: 'k', KIP_BASE_URL: 'http://lan.test:8080' }, async () => {
+    const { impl } = fakeFetch({ model: 'm', choices: [{ message: { content: 'x' } }] }, { resHeaders: { 'x-kip-cost-usd': '0.0012' } })
+    await callLLM({ system: 's', prompt: 'p', label: 't2' }, { fetchImpl: impl, vaultRoot: EMPTY_VAULT })
+  })
+  assert.equal(telemetry.entries()[0].costUsd, 0.0012, 'managed backend -> costUsd recorded')
 })
 
 test('callLLM: arena regen threads arenaId + B\'s callId through and records them', async () => {

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -130,7 +130,7 @@ test('askQuestion', async (t) => {
 
   await t.test('returns empty result with no writes when nothing matches', async () => {
     const result = await askQuestion('anything', { vaultRoot: root })
-    assert.deepEqual(result, { answer: null, citedSlugs: [], candidateSlugs: [], steps: [] })
+    assert.deepEqual(result, { answer: null, citedSlugs: [], candidateSlugs: [], steps: [], costUsd: null })
     assert.equal(fs.existsSync(path.join(root, 'clucks')), true)
     assert.deepEqual(fs.readdirSync(path.join(root, 'clucks')), [], 'a fruitless peck should not be logged, matching the original peck.js behavior')
   })
@@ -751,6 +751,39 @@ test('peckTurn — a question carries the managed backend callId (null for other
   try {
     const r2 = await peckTurn('what about sleep?', { vaultRoot: root })
     assert.equal(r2.callId, null)
+  } finally { s.restore() }
+})
+
+test('peckTurn — sums the metered costUsd across the turn (null for non-kip)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  writePage(root, 'concepts', 'sleep', { type: 'concept', body: 'notes on sleep' })
+  rebuildRoost(root)
+
+  const original = global.fetch
+  t.after(() => { global.fetch = original })
+
+  // kip connector: key-terms costs 0.0001, the answer 0.0023
+  saveLLMConfig({ provider: 'kip', providers: { kip: { apiKey: 'kip_x', baseUrl: 'http://lan.test:3000' } } }, root)
+  global.fetch = async (url, init) => {
+    const sys = JSON.parse(init.body).messages.map((m) => m.content).join('\n')
+    const isTerms = /key search terms/.test(sys)
+    const content = isTerms ? '{"terms":["sleep"]}' : 'Per [[sleep]], rest.'
+    return {
+      ok: true, status: 200,
+      headers: new Headers({ 'x-kip-call-id': isTerms ? 'call_terms' : 'call_answer', 'x-kip-cost-usd': isTerms ? '0.0001' : '0.0023' }),
+      json: async () => ({ choices: [{ message: { content }, finish_reason: 'stop' }] })
+    }
+  }
+  const r = await peckTurn('what about sleep?', { vaultRoot: root })
+  assert.equal(r.costUsd, 0.0024, 'key-terms + answer cost summed for the turn')
+
+  // a plain provider: costUsd null (never guessed)
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  const s = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep]], rest.' })
+  try {
+    const r2 = await peckTurn('what about sleep?', { vaultRoot: root })
+    assert.equal(r2.costUsd, null)
   } finally { s.restore() }
 })
 

--- a/scripts/test/telemetry.test.js
+++ b/scripts/test/telemetry.test.js
@@ -26,6 +26,21 @@ test('telemetry', async (t) => {
     assert.equal(s.byPhase['hatch:propose'].calls, 1)
   })
 
+  await t.test('summary aggregates costUsd per phase and as a total (content-free)', () => {
+    telemetry.record({ label: 'peck:key-terms', ms: 1, ok: true, costUsd: 0.0001 })
+    telemetry.record({ label: 'peck:answer', ms: 1, ok: true, costUsd: 0.0023 })
+    telemetry.record({ label: 'peck:answer:web', ms: 1, ok: true, costUsd: 0.0012 })
+    telemetry.record({ label: 'skill:web-search', ms: 1, ok: true }) // no costUsd — not an LLM call
+
+    const s = telemetry.summary()
+    assert.equal(s.costUsd, 0.0036)
+    assert.equal(s.byPhase['peck:key-terms'].costUsd, 0.0001)
+    assert.equal(s.byPhase['peck:answer'].costUsd, 0.0023)
+    assert.equal(s.byPhase['peck:answer:web'].costUsd, 0.0012)
+    assert.equal(s.byPhase.skill.costUsd, 0)
+    assert.equal(JSON.stringify(s).includes('SECRET'), false)
+  })
+
   await t.test('slowestCalls is ms-desc, capped at 5, and content-free', () => {
     for (const ms of [50, 900, 200, 700, 10, 400]) {
       telemetry.record({ label: 'x', ms, ok: true, prompt: 'SECRET', responseText: 'SECRET' })


### PR DESCRIPTION
Internal cost/latency telemetry for the Peck optimization epic (#38). Wires the per-call `cost_usd` the backend already computes into the client's telemetry — never user-facing.

## What changed
- `kip-connector.js`: read `X-Kip-Cost-Usd` (chat) and `b.cost_usd` (arena) into `costUsd`.
- `llm.js`: `callLLM` records `costUsd` (content-free, like `inputTokens`).
- `telemetry.js`: `summary()` gains a top-level `costUsd` total + per-phase `costUsd`.
- `peck.js`: `answerFromPages`/`askQuestion`/`peckTurn` sum the turn's cost (`turnCostSince`); `null` when nothing was metered.

## Safety
- Non-Kip providers report `costUsd: null` — the client stays provider-agnostic and never guesses price.
- Telemetry stays content-free (`costUsd` is a number/null only).

## Baseline
Run a representative question with `--trace`; `<coop>/.roost/peck-metrics.json` now carries $ per phase (`peck:key-terms`, `peck:answer`, `peck:skill-turn`, `skill`, `peck:answer:web`).

## Verification
`npm test` → 330/330 green.

Depends on the backend header: JWE24-code/kip-backend#77.