### PR TITLE
peck: plan the minimal skill set up front, then execute in parallel (#37)

### DIFF
--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -194,14 +194,103 @@ function formatSkillsBlock (skills) {
 }
 
 /**
- * The skills tool loop: answer the question, but let the model call skills
- * first. Returns { answer, steps: [{skill, input, ok, ms, outputPreview}] }.
- * Independent skill calls are dispatched concurrently — the model may ask for
- * several skills in one turn, and they run in parallel before one synthesis
- * step. The iteration budget is unchanged: each skill call (valid or not)
- * spends one of MAX_SKILL_ITERATIONS, so a batch costs what its calls cost.
- * With no skills it's just answerQuestion(). Any unexpected throw is the
- * caller's (peck.js's) to catch and downgrade.
+ * Upfront skill planning (epic #37): one cheap call that decides the minimal
+ * set of skill calls before any of them run — instead of the model discovering
+ * them one ReAct turn at a time. The plan is best-effort advice; the loop
+ * still adapts when the plan misses something.
+ */
+const PLAN_SKILLS_SYSTEM_PROMPT = `You are planning which skills a personal-wiki question needs, before answering it. You are given the question, the wiki pages already retrieved as candidates, and the available skills.
+
+Plan the MINIMAL set of skill calls — usually none (the pages already answer it), or one or two when the pages can't. Only include a skill you are confident is needed, and include each skill at most once.
+
+Respond with a JSON object of exactly this shape: {"calls": [{"name": "skill-name", "input": { ... }}, ...]}. Use {} for a call that needs no parameters. If no skill is needed, respond {"calls": []}.`
+
+/** A single cheap JSON call: the minimal skill calls for `question`. Returns
+ *  [{name, input}] (input null when the params weren't a JSON object), or []
+ *  on a plan of "no skills needed" or any parse failure (the loop adapts). */
+async function planSkillCalls (question, pages, skills, vaultRoot, { history = [], knownConflicts = [] } = {}) {
+  const convo = formatConversation(history)
+  const conflicts = formatKnownConflicts(knownConflicts)
+  const prompt = `${formatPagesForPrompt(pages)}\n\n---\n\n${formatSkillsBlock(skills)}\n\n---\n\n` +
+    (conflicts ? `${conflicts}\n\n---\n\n` : '') +
+    (convo ? `${convo}\n\n---\n\n` : '') +
+    `Question: ${question}`
+  const { text } = await callLLM({ system: PLAN_SKILLS_SYSTEM_PROMPT, prompt, json: true, maxTokens: 1024, label: 'peck:plan' }, { vaultRoot })
+  try {
+    const parsed = JSON.parse(text)
+    if (!Array.isArray(parsed.calls)) return []
+    return parsed.calls
+      .filter((c) => c && typeof c.name === 'string')
+      .map((c) => ({ name: c.name, input: c.input && typeof c.input === 'object' ? c.input : null }))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Runs one batch of skill calls concurrently and appends their results to the
+ * transcript / steps / webSearches. Mutates `steps` and `webSearches`; returns
+ * the updated `{ transcript, skillsRun }`. Shared by the plan phase and the
+ * adaptation loop, so a planned batch and an adapt batch behave identically.
+ */
+async function runSkillBatch (calls, { byName, skills, vaultRoot, runSkillFn, transcript, steps, webSearches, skillsRun, maxSkills }) {
+  const admitted = []
+  for (const c of calls) {
+    if (skillsRun >= maxSkills) break
+    skillsRun++
+    admitted.push(c)
+  }
+
+  const toRun = []
+  for (const call of admitted) {
+    const skill = byName.get(call.name)
+    if (!skill) {
+      steps.push({ skill: call.name, input: call.input, ok: false, ms: 0, outputPreview: 'no such skill' })
+      transcript += `\n\n<skill_result name="${call.name}" ok="false">\nERROR: no such skill. Available: ${skills.map((s) => s.name).join(', ')}.\n</skill_result>\nCall a real skill or answer now.`
+      continue
+    }
+    if (call.input === null) {
+      steps.push({ skill: skill.name, input: null, ok: false, ms: 0, outputPreview: 'bad parameters' })
+      transcript += `\n\n<skill_result name="${skill.name}" ok="false">\nERROR: your parameters were not valid JSON. Retry with a JSON object, or answer directly.\n</skill_result>`
+      continue
+    }
+    toRun.push({ skill, input: call.input })
+  }
+
+  const results = await Promise.all(toRun.map((t) => runSkillFn(t.skill, t.input, vaultRoot)))
+
+  for (let i = 0; i < toRun.length; i++) {
+    const { skill, input } = toRun[i]
+    const res = results[i]
+    steps.push({
+      skill: skill.name,
+      input: scrubInput(input),
+      ok: res.ok,
+      ms: res.ms,
+      cached: res.cached === true ? true : undefined,
+      outputPreview: (res.output || res.error || '').replace(/\s+/g, ' ').trim().slice(0, 500)
+    })
+    // Any skill whose output is a web-search result list (the built-in
+    // web-search, or a user's own) — capture it as a savable source (kip-app#81).
+    if (res.ok) {
+      const parsed = parseWebSearchOutput(res.output)
+      if (parsed && parsed.results.length) webSearches.push(parsed)
+    }
+    const body = res.ok ? String(res.output || '').slice(0, 6000) : `ERROR: ${res.error}`
+    transcript += `\n\n<skill_result name="${skill.name}" ok="${res.ok}">\n${body}\n</skill_result>\nCall another skill or write your final answer now.`
+  }
+
+  return { transcript, skillsRun }
+}
+
+/**
+ * The skills tool loop: plan the minimal skill set up front (epic #37), run it
+ * in parallel, then answer — while still allowing one further skill batch if
+ * the results demand it. Returns { answer, steps: [{skill, input, ok, ms,
+ * outputPreview}] }. Independent calls run concurrently (Promise.all). The
+ * iteration budget is unchanged: each skill call (valid or not) spends one of
+ * MAX_SKILL_ITERATIONS. With no skills it's just answerQuestion(). Any
+ * unexpected throw is the caller's (peck.js's) to catch and downgrade.
  */
 async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { runSkillFn = runSkill, history = [], onStream = null, knownConflicts = [] } = {}) {
   if (!skills || !skills.length) {
@@ -220,6 +309,19 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
   const webSearches = []   // parsed results of every web-search run this turn (kip-app#81)
 
   let skillsRun = 0
+
+  // Phase 0 — plan the minimal skill set (one cheap call), then run it up
+  // front. Best-effort: a plan failure or an empty plan just falls through to
+  // the loop, which can still discover + run skills as before.
+  try {
+    const planned = await planSkillCalls(question, pages, skills, vaultRoot, { history, knownConflicts })
+    if (planned.length) {
+      ;({ transcript, skillsRun } = await runSkillBatch(planned, { byName, skills, vaultRoot, runSkillFn, transcript, steps, webSearches, skillsRun, maxSkills: MAX_SKILL_ITERATIONS }))
+    }
+  } catch (err) {
+    console.error(`Warning: skill planning failed (${err.message}); answering without a plan.`)
+  }
+
   let turn = 0
   for (;;) {
     // Stream every turn: a turn is either one-or-more <use_skill> tags or the
@@ -241,59 +343,7 @@ async function answerQuestionWithSkills (question, pages, skills, vaultRoot, { r
       return { answer: text, steps, webSearches }
     }
 
-    // Budget: every requested skill spends one iteration, batch or not. A
-    // batch that would overshoot is truncated to what's left.
-    const admitted = []
-    for (const c of calls) {
-      if (skillsRun >= MAX_SKILL_ITERATIONS) break
-      skillsRun++
-      admitted.push(c)
-    }
-
-    // Resolve each admitted call up front: unknown name / unparseable JSON
-    // become the same corrective blocks as before; the valid ones are queued
-    // to run concurrently.
-    const toRun = []
-    for (const call of admitted) {
-      const skill = byName.get(call.name)
-      if (!skill) {
-        steps.push({ skill: call.name, input: call.input, ok: false, ms: 0, outputPreview: 'no such skill' })
-        transcript += `\n\n<skill_result name="${call.name}" ok="false">\nERROR: no such skill. Available: ${skills.map((s) => s.name).join(', ')}.\n</skill_result>\nCall a real skill or answer now.`
-        continue
-      }
-      if (call.input === null) {
-        steps.push({ skill: skill.name, input: null, ok: false, ms: 0, outputPreview: 'bad parameters' })
-        transcript += `\n\n<skill_result name="${skill.name}" ok="false">\nERROR: your parameters were not valid JSON. Retry with a JSON object, or answer directly.\n</skill_result>`
-        continue
-      }
-      toRun.push({ skill, input: call.input })
-    }
-
-    // Independent calls run in parallel — same total spend, a fraction of the
-    // wall-clock latency. Promise.all preserves order, so transcript + steps
-    // come back in the model's original order.
-    const results = await Promise.all(toRun.map((t) => runSkillFn(t.skill, t.input, vaultRoot)))
-
-    for (let i = 0; i < toRun.length; i++) {
-      const { skill, input } = toRun[i]
-      const res = results[i]
-      steps.push({
-        skill: skill.name,
-        input: scrubInput(input),
-        ok: res.ok,
-        ms: res.ms,
-        cached: res.cached === true ? true : undefined,
-        outputPreview: (res.output || res.error || '').replace(/\s+/g, ' ').trim().slice(0, 500)
-      })
-      // Any skill whose output is a web-search result list (the built-in
-      // web-search, or a user's own) — capture it as a savable source (kip-app#81).
-      if (res.ok) {
-        const parsed = parseWebSearchOutput(res.output)
-        if (parsed && parsed.results.length) webSearches.push(parsed)
-      }
-      const body = res.ok ? String(res.output || '').slice(0, 6000) : `ERROR: ${res.error}`
-      transcript += `\n\n<skill_result name="${skill.name}" ok="${res.ok}">\n${body}\n</skill_result>\nCall another skill or write your final answer now.`
-    }
+    ;({ transcript, skillsRun } = await runSkillBatch(calls, { byName, skills, vaultRoot, runSkillFn, transcript, steps, webSearches, skillsRun, maxSkills: MAX_SKILL_ITERATIONS }))
 
     // Budget exhausted and the model still wanted a tool — force a final answer
     if (skillsRun >= MAX_SKILL_ITERATIONS) {
@@ -636,6 +686,7 @@ module.exports = {
   formatConversation,
   generateMeetingPrep,
   answerQuestionWithSkills,
+  planSkillCalls,
   formatSkillsBlock,
   formatKnownConflicts,
   MAX_SKILL_ITERATIONS,

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -20,6 +20,7 @@ function stubPeckFetch (routes) {
     calls.push(sys)
     let content = '{}'
     if (/key search terms/.test(sys)) content = routes.keyTerms || '{"terms": []}'
+    else if (/planning which skills/.test(sys)) content = routes.plan || '{"calls": []}'
     else if (/told their personal wiki a fact/.test(sys)) content = routes.capture
     else if (routes.answerFn) content = routes.answerFn(sys, calls.length)
     else content = routes.answer || 'an answer'
@@ -448,7 +449,7 @@ test('peckTurn — the model batches two skills in one turn; both run, one answe
   } finally { s.restore() }
 })
 
-test('answerQuestionWithSkills — independent skills in one turn are dispatched concurrently', async (t) => {
+test('answerQuestionWithSkills — the plan drives a concurrent batch up front', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
   saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
@@ -460,10 +461,11 @@ test('answerQuestionWithSkills — independent skills in one turn are dispatched
 
   let calls = 0
   const original = global.fetch
-  global.fetch = async () => {
+  global.fetch = async (_url, init) => {
     calls++
-    const content = calls === 1
-      ? '<use_skill name="alpha">{}</use_skill>\n<use_skill name="beta">{}</use_skill>'
+    const sys = JSON.parse(init.body).messages.map((m) => m.content).join('\n')
+    const content = /planning which skills/.test(sys)
+      ? '{"calls":[{"name":"alpha","input":{}},{"name":"beta","input":{}}]}'
       : 'alpha + beta done'
     return { ok: true, status: 200, json: async () => ({ choices: [{ message: { content }, finish_reason: 'stop' }] }) }
   }
@@ -482,13 +484,13 @@ test('answerQuestionWithSkills — independent skills in one turn are dispatched
 
   const resultP = answerQuestionWithSkills('q', [], skills, root, { runSkillFn })
 
-  // Yield until the model's batch turn resolves and the concurrent dispatch runs.
+  // Yield until the plan runs and the planned batch dispatches.
   for (let i = 0; i < 10 && invoked.length < 2; i++) {
     await new Promise((r) => setImmediate(r))
   }
 
-  // Both skills were dispatched even though neither has resolved yet — that's
-  // the concurrency guarantee (a serial loop would have awaited alpha first).
+  // Both planned skills were dispatched even though neither has resolved yet —
+  // that's the concurrency guarantee (a serial loop would await alpha first).
   assert.deepEqual(invoked.slice().sort(), ['alpha', 'beta'])
 
   resolveAlpha()
@@ -496,6 +498,33 @@ test('answerQuestionWithSkills — independent skills in one turn are dispatched
   const result = await resultP
   assert.equal(result.answer, 'alpha + beta done')
   assert.deepEqual(result.steps.map((s) => [s.skill, s.ok]), [['alpha', true], ['beta', true]])
+})
+
+test('answerQuestionWithSkills — an empty plan falls back to discovery in the loop', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+
+  const skills = [{ name: 'alpha', description: 'fixture alpha', parameters: [], instructions: '' }]
+
+  let calls = 0
+  const original = global.fetch
+  global.fetch = async (_url, init) => {
+    calls++
+    const sys = JSON.parse(init.body).messages.map((m) => m.content).join('\n')
+    let content
+    if (/planning which skills/.test(sys)) content = '{"calls": []}'          // planner says no skills
+    else if (!/<skill_result/.test(sys)) content = '<use_skill name="alpha">{}</use_skill>' // adapts anyway
+    else content = 'used alpha'
+    return { ok: true, status: 200, json: async () => ({ choices: [{ message: { content }, finish_reason: 'stop' }] }) }
+  }
+  t.after(() => { global.fetch = original })
+
+  const result = await answerQuestionWithSkills('q', [], skills, root, {
+    runSkillFn: async () => ({ ok: true, output: 'A', error: null, ms: 1 })
+  })
+  assert.equal(result.answer, 'used alpha')
+  assert.deepEqual(result.steps.map((s) => [s.skill, s.ok]), [['alpha', true]], 'the loop still adapted after an empty plan')
 })
 
 test('peckTurn — a web-search run comes back as a hatchable webSource (kip-app#81)', async (t) => {


### PR DESCRIPTION
Upfront query planning for the Peck skill loop (epic #38, track #37).

Instead of the model discovering skills one ReAct turn at a time, one cheap `peck:plan` call decides the minimal skill set before any skill runs; that batch runs in parallel (reusing #33), then a single synthesis — the common case is **planned-and-done** (2 LLM calls: plan + answer). The loop still adapts: after the plan the model may request one further batch, bounded by the unchanged `MAX_SKILL_ITERATIONS`.

## What changed
- `prompts.js`: `planSkillCalls()` (one cheap JSON call, `label: 'peck:plan'`); `runSkillBatch()` factors the admit/run/append logic shared by the plan phase and the adaptation loop; `answerQuestionWithSkills()` runs the plan first, then falls back to discovery on a plan failure/empty plan.
- `peck.test.js`: `stubPeckFetch` routes the plan prompt; new tests for plan-driven concurrent dispatch and empty-plan fallback.

## Behavior / safety
- Best-effort: a plan failure or empty plan falls through to the loop exactly as before — no regression on robustness.
- `peck:plan` is routed to the cheap tier by the backend (`optimize_min_quality = 70`, kip-backend#78).

## Verification
`npm test` → 331/331 green.