### PR TITLE
keep metered cost internal — never surface it on the turn result

### DIFF
--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -352,8 +352,7 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   // If this turn ran web-search, offer its results as a hatchable source
   // (kip-app#81) — the app shows a "save these" affordance on the answer.
   const webSource = buildWebSource(question, webSearches);
-  const costUsd = turnCostSince(telemetryStart)
-  return { answer, citedSlugs, candidateSlugs, lintWarnings, steps, callId, arenaId, webSource: webSource || null, costUsd }
+  return { answer, citedSlugs, candidateSlugs, lintWarnings, steps, callId, arenaId, webSource: webSource || null }
 }
 
 /**
@@ -404,23 +403,6 @@ function answerCallSince (startIdx) {
   return { callId: null, arenaId: null }
 }
 
-/** Sum of metered USD cost across telemetry entries at/after `startIdx`.
- *  Non-Kip providers leave costUsd null, so with no metered call this is
- *  null (not 0) — the client never guesses price (kip#43). */
-function turnCostSince (startIdx) {
-  const es = telemetry.entries()
-  let total = 0
-  let any = false
-  for (let i = startIdx; i < es.length; i++) {
-    const c = es[i].costUsd
-    if (typeof c === 'number' && Number.isFinite(c)) {
-      total += c
-      any = true
-    }
-  }
-  return any ? Math.round(total * 1e8) / 1e8 : null
-}
-
 /**
  * Writes the pages captureFacts() proposed for a told fact — same
  * create-vs-update resolution Hatch uses (resolvePage -> findSimilarSlug),
@@ -468,15 +450,13 @@ function fileCapturedFacts (proposedPages, vaultRoot = DEFAULT_VAULT_ROOT) {
  * @returns {{answer: string|null, citedSlugs: string[], candidateSlugs: string[], lintWarnings: Array<{slug,kind,note}>, steps: Array, callId: string|null, arenaId: string|null}}
  */
 async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_VAULT_ROOT, arenaCompareToCallId = null, history = [], onStream = null } = {}) {
-  const turnStart = telemetry.entries().length
   const candidates = await retrieveCandidates(question, vaultRoot, { history })
   if (candidates.length === 0 && !anySkills(vaultRoot)) {
-    return { answer: null, citedSlugs: [], candidateSlugs: [], steps: [], costUsd: turnCostSince(turnStart) }
+    return { answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
   }
   const pages = readPageBodies(vaultRoot, candidates)
   const arena = arenaCompareToCallId ? { compareToCallId: arenaCompareToCallId } : null
-  const result = await answerFromPages(question, pages, { fileToNest, vaultRoot, arena, history, onStream })
-  return { ...result, costUsd: turnCostSince(turnStart) }
+  return answerFromPages(question, pages, { fileToNest, vaultRoot, arena, history, onStream })
 }
 
 /**
@@ -492,12 +472,11 @@ async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_V
  *              confirmation is in `answer`.
  */
 async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = false, arenaCompareToCallId = null, history = [], onStream = null } = {}) {
-  const turnStart = telemetry.entries().length
   // An upcoming event the user wants reminding about ("I have a meeting Friday
   // at 15h", "remind me to …") — route to the skills path (the `reminders`
   // skill creates it), NOT fact-capture, which would file it as a nest page.
   if (looksLikeReminder(input)) {
-    return { intent: 'reminder', ...(await answerFromPages(input, [], { fileToNest: false, vaultRoot })), costUsd: turnCostSince(turnStart) }
+    return { intent: 'reminder', ...(await answerFromPages(input, [], { fileToNest: false, vaultRoot })) }
   }
 
   const candidates = await retrieveCandidates(input, vaultRoot, { history })
@@ -509,17 +488,16 @@ async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = f
     const results = capture.learned ? fileCapturedFacts(capture.pages, vaultRoot) : []
     const touched = [...new Set(results.map((r) => r.slug))]
     appendLog('told', input, touched, vaultRoot)
-    const costUsd = turnCostSince(turnStart)
     return results.length
-      ? { intent: 'statement', learned: true, note: capture.note, pages: results, candidateSlugs, costUsd }
-      : { intent: 'statement', learned: false, note: capture.note || 'Nothing new to record.', candidateSlugs, costUsd }
+      ? { intent: 'statement', learned: true, note: capture.note, pages: results, candidateSlugs }
+      : { intent: 'statement', learned: false, note: capture.note || 'Nothing new to record.', candidateSlugs }
   }
 
   if (pages.length === 0 && !anySkills(vaultRoot)) {
-    return { intent: 'question', answer: null, citedSlugs: [], candidateSlugs: [], steps: [], costUsd: turnCostSince(turnStart) }
+    return { intent: 'question', answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
   }
   const arena = arenaCompareToCallId ? { compareToCallId: arenaCompareToCallId } : null
-  return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena, history, onStream })), costUsd: turnCostSince(turnStart) }
+  return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena, history, onStream })) }
 }
 
 module.exports = { askQuestion, peckTurn, classifyPeckInput, fileAnswerToNest, fileCapturedFacts, extractCitedSlugs, lintWarningsFor, knownConflictsFor }

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -9,6 +9,7 @@ const { extractCitedSlugs, fileAnswerToNest, askQuestion, peckTurn, classifyPeck
 const { captureFacts, answerQuestionWithSkills } = require('../lib/prompts')
 const { getPage } = require('../lib/roost')
 const { saveLLMConfig } = require('../lib/llm')
+const telemetry = require('../lib/telemetry')
 
 /** Route a mocked local-provider chat completion by a distinctive phrase in the system prompt. */
 function stubPeckFetch (routes) {
@@ -130,7 +131,7 @@ test('askQuestion', async (t) => {
 
   await t.test('returns empty result with no writes when nothing matches', async () => {
     const result = await askQuestion('anything', { vaultRoot: root })
-    assert.deepEqual(result, { answer: null, citedSlugs: [], candidateSlugs: [], steps: [], costUsd: null })
+    assert.deepEqual(result, { answer: null, citedSlugs: [], candidateSlugs: [], steps: [] })
     assert.equal(fs.existsSync(path.join(root, 'clucks')), true)
     assert.deepEqual(fs.readdirSync(path.join(root, 'clucks')), [], 'a fruitless peck should not be logged, matching the original peck.js behavior')
   })
@@ -754,7 +755,7 @@ test('peckTurn — a question carries the managed backend callId (null for other
   } finally { s.restore() }
 })
 
-test('peckTurn — sums the metered costUsd across the turn (null for non-kip)', async (t) => {
+test('peckTurn — cost stays in telemetry, never on the turn result (kip#43)', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
   writePage(root, 'concepts', 'sleep', { type: 'concept', body: 'notes on sleep' })
@@ -763,6 +764,7 @@ test('peckTurn — sums the metered costUsd across the turn (null for non-kip)',
   const original = global.fetch
   t.after(() => { global.fetch = original })
 
+  telemetry.reset()
   // kip connector: key-terms costs 0.0001, the answer 0.0023
   saveLLMConfig({ provider: 'kip', providers: { kip: { apiKey: 'kip_x', baseUrl: 'http://lan.test:3000' } } }, root)
   global.fetch = async (url, init) => {
@@ -776,15 +778,10 @@ test('peckTurn — sums the metered costUsd across the turn (null for non-kip)',
     }
   }
   const r = await peckTurn('what about sleep?', { vaultRoot: root })
-  assert.equal(r.costUsd, 0.0024, 'key-terms + answer cost summed for the turn')
+  assert.equal('costUsd' in r, false, 'cost is never surfaced on the turn result')
 
-  // a plain provider: costUsd null (never guessed)
-  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
-  const s = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep]], rest.' })
-  try {
-    const r2 = await peckTurn('what about sleep?', { vaultRoot: root })
-    assert.equal(r2.costUsd, null)
-  } finally { s.restore() }
+  // ...but it IS recorded internally, for optimization only.
+  assert.equal(telemetry.summary().costUsd, 0.0024, 'key-terms + answer cost summed in telemetry')
 })
 
 test('peckTurn — a regenerate (arenaCompareToCallId) routes the answer through the arena', async (t) => {


### PR DESCRIPTION
#43 wired per-call cost into telemetry, but it also added `costUsd` to the `peckTurn`/`askQuestion`/`answerFromPages` return values — the object the app and CLI render. Cost must stay internal and never reach the user-facing surface, so this drops it from the turn result.

## What changed
- `scripts/lib/peck.js`: remove the `turnCostSince` helper and the `costUsd` field from every turn-result return (`peckTurn`, `askQuestion`, `answerFromPages`).
- `scripts/test/peck.test.js`: assert the turn result carries no `costUsd`, while `telemetry.summary().costUsd` still holds the internal per-turn total.

## Still internal, for optimization only
- `telemetry.entries()` keeps per-call `costUsd`; `telemetry.summary()` keeps the per-phase/turn totals (written to `.roost/peck-metrics.json`).

## Verification
`npm test` → 330/330 green.