### PR TITLE
peck: clean prose answer + a sources list (no inline [[slugs]])

### DIFF
--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -7,8 +7,12 @@
 //
 // Prints the peckTurn() result as JSON to stdout; the provider banner goes to
 // stderr so stdout stays pure JSON for the caller.
-//   { intent: "question",  answer, citedSlugs, candidateSlugs, steps, callId, arenaId }
+//   { intent: "question",  answer, references, citedSlugs, candidateSlugs, steps, callId, arenaId }
 //   { intent: "statement", learned, note, pages?, candidateSlugs }
+//
+// `answer` is clean prose (no [[wikilinks]]); `references` is the source list
+// it leaned on, as [{ slug, title }] in citation order. `citedSlugs` is the
+// same set as bare slugs.
 //
 // callId / arenaId are the managed backend's ids for the answer call (both
 // null on any other provider). arenaId is set only for a --arena-compare-to

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -7,10 +7,10 @@
 //
 // Prints the peckTurn() result as JSON to stdout; the provider banner goes to
 // stderr so stdout stays pure JSON for the caller.
-//   { intent: "question",  answer, references, citedSlugs, candidateSlugs, steps, callId, arenaId }
+//   { intent: "question",  answer, sources, citedSlugs, candidateSlugs, steps, callId, arenaId }
 //   { intent: "statement", learned, note, pages?, candidateSlugs }
 //
-// `answer` is clean prose (no [[wikilinks]]); `references` is the source list
+// `answer` is clean prose (no [[wikilinks]]); `sources` is the source list
 // it leaned on, as [{ slug, title }] in citation order. `citedSlugs` is the
 // same set as bare slugs.
 //

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -171,6 +171,20 @@ function extractCitedSlugs (answerText, candidateSlugs) {
   return candidateSlugs.filter((slug) => linked.has(slug))
 }
 
+/** Removes the "Sources:" footer the answer model emits (epic #38 — clean
+ *  prose + a references list, instead of inline [[slugs]]). Returns the prose
+ *  with the footer cut; the raw text is unchanged when there's no footer. */
+function stripSources (answerText) {
+  const text = String(answerText || '')
+  const m = text.match(/^Sources:\s*$/m)
+  return (m && m.index !== undefined ? text.slice(0, m.index) : text).trim()
+}
+
+/** A human-readable title from a slug: "sleep-hygiene" -> "sleep hygiene". */
+function humanizeSlug (slug) {
+  return String(slug).replace(/-+/g, ' ').trim()
+}
+
 /** Groom's findings map (.roost/lint.json, written by every groom run,
  *  kip-app#116). Read-only: Peck consults it, never writes it. Returns {} when
  *  the file is absent or unparseable — a nest that has never been groomed just
@@ -341,6 +355,8 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   // groom's findings for the pages this answer actually leaned on (kip-app#116)
   const lintWarnings = lintWarningsFor(vaultRoot, citedSlugs)
   if (fileToNest && answer && !webbed) {
+    // File the raw answer (with its "Sources:" footer) so the nest page keeps
+    // its [[slug]] backlinks; the displayed answer below is clean prose.
     await fileAnswerToNest(question, answer, candidateSlugs, vaultRoot)
   }
   // The managed backend's ids for the answer call, so the app can attach a
@@ -352,7 +368,8 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   // If this turn ran web-search, offer its results as a hatchable source
   // (kip-app#81) — the app shows a "save these" affordance on the answer.
   const webSource = buildWebSource(question, webSearches);
-  return { answer, citedSlugs, candidateSlugs, lintWarnings, steps, callId, arenaId, webSource: webSource || null }
+  const references = citedSlugs.map((slug) => ({ slug, title: humanizeSlug(slug) }))
+  return { answer: answer ? stripSources(answer) : answer, references, citedSlugs, candidateSlugs, lintWarnings, steps, callId, arenaId, webSource: webSource || null }
 }
 
 /**
@@ -465,9 +482,9 @@ async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_V
  * filed); a statement is always filed — that's the point.
  *
  * @returns {{intent: 'question'|'statement'|'reminder', ...}}
- *   question:  { answer: string|null, citedSlugs, candidateSlugs, lintWarnings, steps }
+ *   question:  { answer: string|null, references, citedSlugs, candidateSlugs, lintWarnings, steps }
  *   statement: { learned: boolean, note: string, pages?: [{action,slug,path}], candidateSlugs }
- *   reminder:  { answer: string|null, citedSlugs, candidateSlugs, lintWarnings, steps } — same
+ *   reminder:  { answer: string|null, references, citedSlugs, candidateSlugs, lintWarnings, steps } — same
  *              shape as question; the `reminders` skill did the work and its
  *              confirmation is in `answer`.
  */
@@ -500,4 +517,4 @@ async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = f
   return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena, history, onStream })) }
 }
 
-module.exports = { askQuestion, peckTurn, classifyPeckInput, fileAnswerToNest, fileCapturedFacts, extractCitedSlugs, lintWarningsFor, knownConflictsFor }
+module.exports = { askQuestion, peckTurn, classifyPeckInput, fileAnswerToNest, fileCapturedFacts, extractCitedSlugs, stripSources, humanizeSlug, lintWarningsFor, knownConflictsFor }

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -172,7 +172,7 @@ function extractCitedSlugs (answerText, candidateSlugs) {
 }
 
 /** Removes the "Sources:" footer the answer model emits (epic #38 — clean
- *  prose + a references list, instead of inline [[slugs]]). Returns the prose
+ *  prose + a sources list, instead of inline [[slugs]]). Returns the prose
  *  with the footer cut; the raw text is unchanged when there's no footer. */
 function stripSources (answerText) {
   const text = String(answerText || '')
@@ -368,8 +368,8 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   // If this turn ran web-search, offer its results as a hatchable source
   // (kip-app#81) — the app shows a "save these" affordance on the answer.
   const webSource = buildWebSource(question, webSearches);
-  const references = citedSlugs.map((slug) => ({ slug, title: humanizeSlug(slug) }))
-  return { answer: answer ? stripSources(answer) : answer, references, citedSlugs, candidateSlugs, lintWarnings, steps, callId, arenaId, webSource: webSource || null }
+  const sources = citedSlugs.map((slug) => ({ slug, title: humanizeSlug(slug) }))
+  return { answer: answer ? stripSources(answer) : answer, sources, citedSlugs, candidateSlugs, lintWarnings, steps, callId, arenaId, webSource: webSource || null }
 }
 
 /**
@@ -482,9 +482,9 @@ async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_V
  * filed); a statement is always filed — that's the point.
  *
  * @returns {{intent: 'question'|'statement'|'reminder', ...}}
- *   question:  { answer: string|null, references, citedSlugs, candidateSlugs, lintWarnings, steps }
+ *   question:  { answer: string|null, sources, citedSlugs, candidateSlugs, lintWarnings, steps }
  *   statement: { learned: boolean, note: string, pages?: [{action,slug,path}], candidateSlugs }
- *   reminder:  { answer: string|null, references, citedSlugs, candidateSlugs, lintWarnings, steps } — same
+ *   reminder:  { answer: string|null, sources, citedSlugs, candidateSlugs, lintWarnings, steps } — same
  *              shape as question; the `reminders` skill did the work and its
  *              confirmation is in `answer`.
  */

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -73,7 +73,7 @@ function isNoAnswer (text) {
 
 // How nest answers cite sources: clean prose with no [[wikilinks]] in the body,
 // then a "Sources:" footer listing the slugs actually used. The client strips
-// the footer for display and turns the slugs into a references list; the raw
+// the footer for display and turns the slugs into a sources list; the raw
 // text is still filed to the nest so Logseq keeps its backlinks.
 const SOURCES_FOOTER_INSTRUCTION = `Write your answer as clean, readable prose — do NOT put any [[wikilinks]] in the body of the answer. After the prose, add a line that reads exactly "Sources:" and then one line per page you actually used, each as [[exact-page-slug]] (using the exact slug from the "### Page: <slug>" heading).`
 

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -71,6 +71,12 @@ function isNoAnswer (text) {
   return NO_ANSWER_RE.test(String(text || ''))
 }
 
+// How nest answers cite sources: clean prose with no [[wikilinks]] in the body,
+// then a "Sources:" footer listing the slugs actually used. The client strips
+// the footer for display and turns the slugs into a references list; the raw
+// text is still filed to the nest so Logseq keeps its backlinks.
+const SOURCES_FOOTER_INSTRUCTION = `Write your answer as clean, readable prose — do NOT put any [[wikilinks]] in the body of the answer. After the prose, add a line that reads exactly "Sources:" and then one line per page you actually used, each as [[exact-page-slug]] (using the exact slug from the "### Page: <slug>" heading).`
+
 const ANSWER_SYSTEM_PROMPT = `You are answering a question from a personal wiki — a second brain for journaling, goals, and health tracking. You are given the full text of the wiki pages retrieved as candidates for this question.
 
 Answer using ONLY the information in these pages — do not use outside knowledge, and do not speculate beyond what's written.
@@ -81,9 +87,9 @@ Do not guess, apologise, or explain — just the token. (Something else will tak
 
 If a "Conversation so far" section is present, it is only there to tell you what a follow-up question refers to — it is NOT a source, so never cite it or treat it as fact.
 
-Cite every claim back to the specific page it came from using Logseq's wikilink syntax: [[exact-page-slug]], using the exact slug shown in each "### Page: <slug>" heading. Prefer citing inline, next to the claim it supports, over a single list of links at the end.
+${SOURCES_FOOTER_INSTRUCTION}
 
-If the pages disagree — different dates, different values, or conflicting claims — do not silently pick one: say there is a disagreement, give both sides (with their dates or sources if the pages show them), and cite both. Your citation must not make a contested claim look settled.`
+If the pages disagree — different dates, different values, or conflicting claims — do not silently pick one: say there is a disagreement, give both sides (with their dates or sources if the pages show them), and list both pages under Sources. Your answer must not make a contested claim look settled.`
 
 const WEB_ANSWER_SYSTEM_PROMPT = `The user asked their personal notes a question, but the notes didn't contain the answer, so a web search was run. You are given the search results.
 
@@ -166,11 +172,11 @@ To run skills, make your ENTIRE reply exactly one or more <use_skill> tags and n
 <use_skill name="skill-name">{ "param": "value" }</use_skill>
 When you need several skills whose results don't depend on each other, request them all in ONE reply — they run in parallel. Then stop. You'll get the outputs back and can run another skill or write your answer.
 
-When you can answer, write it as normal prose with NO tag. Cite a wiki-page claim with [[exact-page-slug]] (the slug shown in each "### Page: <slug>" heading). Attribute a skill-derived fact inline as "(via skill-name)".
+When you can answer, write it as clean, readable prose with NO tag and no [[wikilinks]] in the body. Attribute a skill-derived fact inline as "(via skill-name)". After the prose, add a line that reads exactly "Sources:" and then one line per wiki page you used, each as [[exact-page-slug]] (the slug shown in each "### Page: <slug>" heading).
 
 Rules:
 - At most ${MAX_SKILL_ITERATIONS} skill calls. Prefer the wiki pages — only run a skill when they can't answer.
-- If two wiki pages disagree — different dates, values, or claims — don't silently pick one: name the disagreement, give both sides, and cite both.
+- If two wiki pages disagree — different dates, values, or claims — don't silently pick one: name the disagreement, give both sides, and list both pages under Sources.
 - Some skills produce a file (a document, a deck) instead of an answer. When one does, its result is the path it wrote; give that exact path to the user (e.g. "Saved to exports/report.docx") rather than describing the contents.
 - If a skill errors or returns nothing useful, don't retry it more than once; answer with what you have and note what was missing.`
 

--- a/scripts/peck.js
+++ b/scripts/peck.js
@@ -75,6 +75,15 @@ async function main () {
   }
   console.log(`\n${result.answer}\n`)
 
+  // References the answer leaned on (epic #38 — clean prose + a source list).
+  if ((result.references || []).length) {
+    console.log('References:')
+    for (const ref of result.references) {
+      console.log(`  - ${ref.title} ([[${ref.slug}]])`)
+    }
+    console.log('')
+  }
+
   // groom's findings for the pages this answer cited (kip-app#116)
   for (const w of result.lintWarnings || []) {
     console.log(`  ⚠ [[${w.slug}]] — ${w.note}`)

--- a/scripts/peck.js
+++ b/scripts/peck.js
@@ -75,10 +75,10 @@ async function main () {
   }
   console.log(`\n${result.answer}\n`)
 
-  // References the answer leaned on (epic #38 — clean prose + a source list).
-  if ((result.references || []).length) {
+  // Sources the answer leaned on (epic #38 — clean prose + a source list).
+  if ((result.sources || []).length) {
     console.log('References:')
-    for (const ref of result.references) {
+    for (const ref of result.sources) {
       console.log(`  - ${ref.title} ([[${ref.slug}]])`)
     }
     console.log('')

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -84,7 +84,7 @@ test('humanizeSlug turns hyphens into spaces', () => {
   assert.equal(humanizeSlug('acme-corp'), 'acme corp')
 })
 
-test('peckTurn — clean prose + a references list (Sources footer stripped)', async (t) => {
+test('peckTurn — clean prose + a sources list (Sources footer stripped)', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
   saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
@@ -99,7 +99,7 @@ test('peckTurn — clean prose + a references list (Sources footer stripped)', a
     const r = await peckTurn('what about sleep?', { vaultRoot: root })
     assert.equal(r.intent, 'question')
     assert.equal(r.answer, 'Keep a consistent bedtime and avoid screens before bed.')
-    assert.deepEqual(r.references, [{ slug: 'sleep', title: 'sleep' }])
+    assert.deepEqual(r.sources, [{ slug: 'sleep', title: 'sleep' }])
     assert.deepEqual(r.citedSlugs, ['sleep'])
   } finally { s.restore() }
 })

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -5,7 +5,7 @@ const os = require('node:os')
 const path = require('node:path')
 
 const { rebuildRoost } = require('../rebuild-roost')
-const { extractCitedSlugs, fileAnswerToNest, askQuestion, peckTurn, classifyPeckInput } = require('../lib/peck')
+const { extractCitedSlugs, fileAnswerToNest, askQuestion, peckTurn, classifyPeckInput, stripSources, humanizeSlug } = require('../lib/peck')
 const { captureFacts, answerQuestionWithSkills } = require('../lib/prompts')
 const { getPage } = require('../lib/roost')
 const { saveLLMConfig } = require('../lib/llm')
@@ -70,6 +70,39 @@ function writePage (root, dir, slug, { type, tags = [], body = '' }) {
   const frontmatter = ['---', `type: ${type}`, 'created: 2026-01-01', 'updated: 2026-01-01', `tags: [${tags.join(', ')}]`, '---', ''].join('\n')
   fs.writeFileSync(path.join(root, 'nest', dir, `${slug}.md`), frontmatter + body + '\n')
 }
+
+test('stripSources cuts the "Sources:" footer', () => {
+  assert.equal(
+    stripSources('Keep a consistent bedtime.\n\nSources:\n- [[sleep-hygiene]]'),
+    'Keep a consistent bedtime.'
+  )
+  assert.equal(stripSources('No footer here.'), 'No footer here.')
+})
+
+test('humanizeSlug turns hyphens into spaces', () => {
+  assert.equal(humanizeSlug('sleep-hygiene'), 'sleep hygiene')
+  assert.equal(humanizeSlug('acme-corp'), 'acme corp')
+})
+
+test('peckTurn — clean prose + a references list (Sources footer stripped)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'concepts', 'sleep', { type: 'concept', body: 'notes on sleep' })
+  rebuildRoost(root)
+
+  const s = stubPeckFetch({
+    keyTerms: '{"terms":["sleep"]}',
+    answer: 'Keep a consistent bedtime and avoid screens before bed.\n\nSources:\n- [[sleep]]'
+  })
+  try {
+    const r = await peckTurn('what about sleep?', { vaultRoot: root })
+    assert.equal(r.intent, 'question')
+    assert.equal(r.answer, 'Keep a consistent bedtime and avoid screens before bed.')
+    assert.deepEqual(r.references, [{ slug: 'sleep', title: 'sleep' }])
+    assert.deepEqual(r.citedSlugs, ['sleep'])
+  } finally { s.restore() }
+})
 
 test('extractCitedSlugs', () => {
   const candidates = ['sleep-hygiene', 'dr-smith', 'morning-routine']


### PR DESCRIPTION
Peck answers used to cite inline with `[[slug]]` wikilinks, which made the prose unreadable. Now the answer is clean synthesized prose, with a sources list below it.

## What changed
- `prompts.js`: the nest answer and skills-loop answer prompts now ask for clean prose (no `[[wikilinks]]` in the body) and a trailing `Sources:` footer listing the `[[exact-page-slug]]`s actually used.
- `peck.js`: `stripSources()` cuts the footer; `humanizeSlug()` derives a readable title; `answerFromPages` returns `answer` (clean prose) + `sources` (`[{ slug, title }]`) alongside the existing `citedSlugs`. The **raw** answer is still filed to the nest so Logseq keeps its backlinks.
- `scripts/peck.js` CLI: renders a `References:` section under the answer.
- `scripts/chat.js`: result shape doc updated (`answer`, `sources`, `citedSlugs`).

## Behavior
- Provenance / lint warnings are unchanged (`citedSlugs` still derived from the raw answer).
- Backward compatible: an answer without a `Sources:` footer is returned as-is (footer stripping is a no-op).

## Verification
`npm test` → 334/334 green.

Note: the app (kip-app) will want to render `sources` as a nice clickable list — that's a separate repo change.