### PR TITLE
Unify sources: retire eggs/, drop everything into pages/

### DIFF
--- a/scripts/hatch-all.js
+++ b/scripts/hatch-all.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // CLI for the "Hatch sources" workflow: turns every new-or-changed file
-// in eggs/, journals/ and pages/ into nest pages, with NO per-file review.
+// in pages/ and journals/ (plus whiteboards/) into nest pages, with NO per-file review.
 // The Kip app's Hatch modal shells out to this (electron.wiki). No workflow
 // logic lives here; see scripts/lib/hatch.js.
 //

--- a/scripts/hatch.js
+++ b/scripts/hatch.js
@@ -3,7 +3,7 @@
 // scripts/lib/hatch.js's proposeHatchPlan()/commitHatchPlan(): argv
 // parsing, printing, and the interactive confirm-before-writing prompt. No
 // workflow logic lives here; see scripts/lib/hatch.js for
-// copy-to-eggs -> propose -> plan -> generate -> write.
+// copy-to-pages -> propose -> plan -> generate -> write.
 //
 // Usage: node scripts/hatch.js <path-to-source> [--classic]
 //   --classic (or KIP_HATCH_CLASSIC=1): old path — one propose call plus one
@@ -61,7 +61,7 @@ async function main () {
 
   console.error(describeProvider())
 
-  const { sourceTitle, sourceContent, eggsFilePath, plan } = await proposeHatchPlan(sourceArg, vaultRoot, { combined })
+  const { sourceTitle, sourceContent, sourceFilePath, plan } = await proposeHatchPlan(sourceArg, vaultRoot, { combined })
   if (plan.length === 0) {
     console.log('The LLM proposed no usable candidate pages for this source. Nothing to do.')
     return
@@ -84,7 +84,7 @@ async function main () {
     plan,
     sourceTitle,
     sourceContent,
-    sourceRelPath: path.relative(vaultRoot, eggsFilePath).split(path.sep).join('/'),
+    sourceRelPath: path.relative(vaultRoot, sourceFilePath).split(path.sep).join('/'),
     sourceHash: hashContent(sourceContent)
   }, vaultRoot)
 

--- a/scripts/lib/db.js
+++ b/scripts/lib/db.js
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS log (
   pages_touched TEXT NOT NULL DEFAULT '[]'
 );
 
--- Tracks which source files (eggs/, journals/, pages/) have been hatched and
+-- Tracks which source files (pages/, journals/) have been hatched and
 -- at what content, so "Hatch sources" can re-hatch only what's new or
 -- changed. path is coop-relative, forward-slashed ("journals/2026_08_26.md").
 CREATE TABLE IF NOT EXISTS hatched_sources (

--- a/scripts/lib/hatch.js
+++ b/scripts/lib/hatch.js
@@ -14,17 +14,19 @@ const {
 const { resolvePage, nextFreeSlug, sourceHubMustCreate, findSourceHubByPath } = require('./pages')
 const { proposeCandidatePages, generatePageContent, proposeAndDraftPages, describeWhiteboard } = require('./prompts')
 const { parseWhiteboard, whiteboardToOutline } = require('./whiteboard')
-const { isSupported: isOfficeFile, convertFile: convertOfficeFile, markdownNameFor } = require('./office')
-const { DEFAULT_VAULT_ROOT, eggsPath, nestPath, TYPE_DIRS } = require('./paths')
+const { convertFile: convertOfficeFile, markdownNameFor, toStubSource, UnsupportedFormatError } = require('./office')
+const { DEFAULT_VAULT_ROOT, pagesPath, nestPath, TYPE_DIRS } = require('./paths')
 
 const VALID_TYPES = new Set(Object.keys(TYPE_DIRS))
 
-// The coop subdirs "Hatch sources" scans, in order. eggs/ is a manual
-// drop-box (any file type); journals/ and pages/ are Logseq's own markdown,
-// read in place; whiteboards/ holds Logseq's .edn boards, turned into an
-// outline page (deterministic) with an LLM-written Context section on top —
-// see hatchWhiteboard.
-const SOURCE_ROOTS = ['eggs', 'journals', 'pages', 'whiteboards']
+// The coop subdirs "Hatch sources" scans, in order. pages/ is the unified
+// source folder — Logseq's own markdown notes live here, and Office/PDF
+// dropped here are converted to Markdown siblings at hatch time (see
+// prepareSources). journals/ is Logseq's dated daily notes, read in place;
+// whiteboards/ holds Logseq's .edn boards, turned into an outline page
+// (deterministic) with an LLM-written Context section on top — see
+// hatchWhiteboard.
+const SOURCE_ROOTS = ['pages', 'journals', 'whiteboards']
 // Backstop only: a file this large can't fit the model's context window in
 // one piece, so it's skipped and reported rather than burning a slow, doomed
 // call. Everything short of this is sent whole (chunking large-but-viable
@@ -60,11 +62,11 @@ function humanizeFilename (filePath) {
   return base.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
-/** Copies sourcePath into coop/eggs/ unless it's already there; returns the eggs/-relative path used from then on. */
-function ensureInEggs (sourcePath, vaultRoot) {
-  const eggsDir = eggsPath(vaultRoot)
-  fs.mkdirSync(eggsDir, { recursive: true })
-  const targetPath = path.join(eggsDir, path.basename(sourcePath))
+/** Copies sourcePath into coop/pages/ unless it's already there; returns the pages/-relative path used from then on. */
+function ensureInSources (sourcePath, vaultRoot) {
+  const sourcesDir = pagesPath(vaultRoot)
+  fs.mkdirSync(sourcesDir, { recursive: true })
+  const targetPath = path.join(sourcesDir, path.basename(sourcePath))
   if (path.resolve(sourcePath) !== path.resolve(targetPath)) {
     fs.copyFileSync(sourcePath, targetPath)
   }
@@ -97,35 +99,35 @@ function planCandidates (candidates, vaultRoot, { sourceRelPath = null } = {}) {
 
 /**
  * Steps 1-3 of the Hatch workflow: (optionally) copy the source into
- * coop/eggs/, ask the LLM which pages it likely touches, and resolve
+ * coop/pages/, ask the LLM which pages it likely touches, and resolve
  * create-vs-update for each — without writing anything to coop/nest/ yet.
  * The caller is expected to show `plan` to a human and confirm before
  * calling commitHatchPlan().
  *
- * copyToEggs defaults true (the single-file CLI / "add this document" path).
+ * copyToSources defaults true (the single-file CLI / "add this document" path).
  * "Hatch sources" passes false for journals/ and pages/ files — they're
- * already in the coop and copying them into eggs/ would just duplicate them.
+ * already in the coop and copying them into pages/ would just duplicate them.
  *
  * combined (default true) proposes the pages AND drafts each body in one LLM
  * call (proposeAndDraftPages) — plan entries then carry `body`, and
  * commitHatchPlan skips the per-page generate call. combined:false is the
  * classic path: propose only, one generate call per page at commit time.
  *
- * @returns {{sourceTitle: string, sourceContent: string, eggsFilePath: string, plan: Array}}
+ * @returns {{sourceTitle: string, sourceContent: string, sourceFilePath: string, plan: Array}}
  */
-async function proposeHatchPlan (sourcePath, vaultRoot = DEFAULT_VAULT_ROOT, { copyToEggs = true, combined = true } = {}) {
-  const eggsFilePath = copyToEggs ? ensureInEggs(sourcePath, vaultRoot) : path.resolve(sourcePath)
-  const sourceContent = fs.readFileSync(eggsFilePath, 'utf8')
-  const sourceTitle = humanizeFilename(eggsFilePath)
+async function proposeHatchPlan (sourcePath, vaultRoot = DEFAULT_VAULT_ROOT, { copyToSources = true, combined = true } = {}) {
+  const sourceFilePath = copyToSources ? ensureInSources(sourcePath, vaultRoot) : path.resolve(sourcePath)
+  const sourceContent = fs.readFileSync(sourceFilePath, 'utf8')
+  const sourceTitle = humanizeFilename(sourceFilePath)
 
-  // An Office-converted sibling (report.docx -> report.docx.md) carries the
+  // An Office-converted sibling (report.docx -> report.md) carries the
   // original file's name in its own frontmatter (`source:`, written by
   // lib/office.js "so a hatched page can be traced back") — read it through,
   // so the trace names the .docx, not just the .md we generated from it.
   let sourceOriginal = null
   try {
-    const eggMeta = matter(sourceContent).data
-    if (eggMeta && typeof eggMeta.source === 'string' && eggMeta.source.trim()) sourceOriginal = eggMeta.source.trim()
+    const sourceMeta = matter(sourceContent).data
+    if (sourceMeta && typeof sourceMeta.source === 'string' && sourceMeta.source.trim()) sourceOriginal = sourceMeta.source.trim()
   } catch { /* not frontmatter'd — fine */ }
 
   const proposed = combined
@@ -139,7 +141,7 @@ async function proposeHatchPlan (sourcePath, vaultRoot = DEFAULT_VAULT_ROOT, { c
   // type:'source' page but nothing enforced it, so a plan could hatch a whole
   // document with nothing linking back to it. Synthesize the hub into the
   // plan HERE — the human reviewing the plan sees it and can deselect it.
-  const sourceRelPath = path.relative(vaultRoot, eggsFilePath).split(path.sep).join('/')
+  const sourceRelPath = path.relative(vaultRoot, sourceFilePath).split(path.sep).join('/')
   if (!candidates.some((c) => c.type === 'source')) {
     const hash = hashContent(sourceContent)
     candidates.push({
@@ -152,7 +154,7 @@ async function proposeHatchPlan (sourcePath, vaultRoot = DEFAULT_VAULT_ROOT, { c
   }
   const plan = planCandidates(candidates, vaultRoot, { sourceRelPath })
 
-  return { sourceTitle, sourceContent, eggsFilePath, sourceRelPath, sourceOriginal, plan }
+  return { sourceTitle, sourceContent, sourceFilePath, sourceRelPath, sourceOriginal, plan }
 }
 
 /**
@@ -164,7 +166,7 @@ async function proposeHatchPlan (sourcePath, vaultRoot = DEFAULT_VAULT_ROOT, { c
  * existing page content so the write is a delta, not a restatement (#114).
  *
  * Provenance (kip-app#113): `sourceRelPath` (coop-relative path of the
- * document, e.g. `eggs/report.md`) and `sourceHash` (its sha1) are written
+ * document, e.g. `pages/report.md`) and `sourceHash` (its sha1) are written
  * onto every page this hatch touches — frontmatter `source:`/`source_hatched:`
  * on all of them, plus a `## Source` section at the top of every
  * `type: 'source'` page on create. When the plan proposes no source page at
@@ -350,47 +352,60 @@ function meaningfulTextLength (raw) {
 }
 
 /**
- * Turn every Office / PDF file dropped into eggs/ into a Markdown sibling
- * (scripts/lib/office.js) so the normal source scan can read it. Idempotent —
- * an up-to-date `<stem>.md` is left alone. Best-effort per file: a conversion
- * failure is collected, not thrown.
+ * Prepare the unified source folder (pages/) for the source scan: turn every
+ * dropped Office / PDF file into a Markdown sibling (scripts/lib/office.js)
+ * so the normal scan can read it, and turn anything Kip can't convert into a
+ * reference-only `.md` stub so it still gets a traceable page (instead of
+ * being silently skipped). Idempotent — an up-to-date `<stem>.md` is left
+ * alone. Best-effort per file: a failure is collected, not thrown.
  *
  * Runs before every hatch entry point (hatchAllSources, proposeNextPending,
  * pendingSourcesSummary) so a `.docx` synced in through Dropbox, or added by
  * `office-extract.js`, or dropped in the app all end up hatched the same way.
  *
- * @returns {{converted: Array<{source, kind}>, failed: Array<{source, error}>}}
+ * @returns {{converted: Array<{source, kind}>, stubbed: Array<{source}>, failed: Array<{source, error}>}}
  */
-async function convertPendingOfficeSources (vaultRoot = DEFAULT_VAULT_ROOT) {
-  const eggsDir = eggsPath(vaultRoot)
-  if (!fs.existsSync(eggsDir)) return { converted: [], failed: [] }
+async function prepareSources (vaultRoot = DEFAULT_VAULT_ROOT) {
+  const sourcesDir = pagesPath(vaultRoot)
+  if (!fs.existsSync(sourcesDir)) return { converted: [], stubbed: [], failed: [] }
 
   const converted = []
+  const stubbed = []
   const failed = []
-  for (const entry of fs.readdirSync(eggsDir, { withFileTypes: true })) {
-    if (!entry.isFile() || entry.name.startsWith('.') || !isOfficeFile(entry.name)) continue
-    const absPath = path.join(eggsDir, entry.name)
+  for (const entry of fs.readdirSync(sourcesDir, { withFileTypes: true })) {
+    if (!entry.isFile() || entry.name.startsWith('.') || entry.name.endsWith('.md')) continue
+    const absPath = path.join(sourcesDir, entry.name)
+    const target = path.join(sourcesDir, markdownNameFor(entry.name))
     try {
-      const r = await convertOfficeFile(absPath, path.join(eggsDir, markdownNameFor(entry.name)))
+      const r = await convertOfficeFile(absPath, target)
       if (!r.skipped) converted.push({ source: entry.name, kind: r.kind })
     } catch (err) {
-      failed.push({ source: entry.name, error: (err && err.message) || String(err) })
+      if (err instanceof UnsupportedFormatError) {
+        // Unreadable format → a reference-only stub, not a silent skip. Idempotent
+        // like conversion: leave an up-to-date stub alone.
+        try {
+          if (fs.statSync(target).mtimeMs >= fs.statSync(absPath).mtimeMs) continue
+        } catch { /* no stub yet — write one */ }
+        fs.writeFileSync(target, toStubSource(entry.name, (err && err.message) || undefined))
+        stubbed.push({ source: entry.name })
+      } else {
+        failed.push({ source: entry.name, error: (err && err.message) || String(err) })
+      }
     }
   }
-  return { converted, failed }
+  return { converted, stubbed, failed }
 }
 
 /**
  * The deterministic half of "Hatch sources": scans the coop's source dirs
- * (eggs/, journals/, pages/, whiteboards/) and buckets every file. No LLM,
- * no writes.
+ * (pages/, journals/, whiteboards/) and buckets every file. No LLM, no writes.
  *
  * `pending` = new OR content-changed since last hatch (sha1 vs
  * hatched_sources); `kind` is the dir, or 'whiteboard' for a .edn board.
- * Skipped, and reported separately: dotfiles, non-.md files outside eggs/
- * and whiteboards/, near-empty files, and files over MAX_SOURCE_BYTES (a
- * ~1 MB context-window backstop — whiteboards are exempt, they become a
- * tiny outline).
+ * Skipped, and reported separately: dotfiles, non-.md files (they're turned
+ * into .md siblings by prepareSources() first), near-empty files, and files
+ * over MAX_SOURCE_BYTES (a ~1 MB context-window backstop — whiteboards are
+ * exempt, they become a tiny outline).
  *
  * @returns {{pending: Array<{relPath, absPath, kind, bytes, status: 'new'|'changed'}>,
  *            oversized: Array<{relPath, bytes}>,
@@ -412,11 +427,7 @@ function collectPendingSources (vaultRoot = DEFAULT_VAULT_ROOT, { roots = SOURCE
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
       if (!entry.isFile() || entry.name.startsWith('.')) continue
       const name = entry.name.toLowerCase()
-      if (board ? !name.endsWith('.edn') : (root !== 'eggs' && !name.endsWith('.md'))) continue
-      // An Office/PDF file in eggs/ is a *source for* conversion, not a source
-      // to hatch — convertPendingOfficeSources() turns it into a .md sibling
-      // that this scan then picks up on its own. See hatch-all.js / the app.
-      if (root === 'eggs' && isOfficeFile(name)) continue
+      if (board ? !name.endsWith('.edn') : !name.endsWith('.md')) continue
 
       const absPath = path.join(dir, entry.name)
       const relPath = `${root}/${entry.name}`
@@ -443,7 +454,7 @@ function collectPendingSources (vaultRoot = DEFAULT_VAULT_ROOT, { roots = SOURCE
 
       // status splits the vault-Lint "un-ingested raw" check into its two
       // cases (kip-app#113): a brand-new source vs one hatched before and
-      // edited since — an "immutable" egg edited in place is a different
+      // edited since — an "immutable" source edited in place is a different
       // signal from a fresh drop, and re-hatching it re-appends the whole
       // document, so the preview/groom should say which is which.
       pending.push({ relPath, absPath, kind: board ? 'whiteboard' : root, bytes, status: priorHash === undefined ? 'new' : 'changed' })
@@ -464,7 +475,7 @@ function collectPendingSources (vaultRoot = DEFAULT_VAULT_ROOT, { roots = SOURCE
  * edited since hatch" instead of blurring edits into new drops.
  */
 async function pendingSourcesSummary (vaultRoot = DEFAULT_VAULT_ROOT, opts = {}) {
-  const conv = await convertPendingOfficeSources(vaultRoot)
+  const conv = await prepareSources(vaultRoot)
   const { pending, oversized, empty } = collectPendingSources(vaultRoot, opts)
   return {
     pending: pending.map((p) => ({ source: humanizeFilename(p.absPath), kind: p.kind, kb: Math.round(p.bytes / 1024), status: p.status })),
@@ -504,7 +515,7 @@ async function pendingSourcesSummary (vaultRoot = DEFAULT_VAULT_ROOT, opts = {})
  */
 async function hatchAllSources (vaultRoot = DEFAULT_VAULT_ROOT,
   { roots = SOURCE_ROOTS, limit = DEFAULT_BATCH_SIZE, onProgress = () => {}, combined = true } = {}) {
-  const conversion = await convertPendingOfficeSources(vaultRoot)
+  const conversion = await prepareSources(vaultRoot)
   const { pending, oversized, empty } = collectPendingSources(vaultRoot, { roots })
   const batch = pending.slice(0, limit)
 
@@ -527,7 +538,7 @@ async function hatchAllSources (vaultRoot = DEFAULT_VAULT_ROOT,
         continue
       }
 
-      const proposal = await proposeHatchPlan(file.absPath, vaultRoot, { copyToEggs: file.kind === 'eggs', combined })
+      const proposal = await proposeHatchPlan(file.absPath, vaultRoot, { copyToSources: false, combined })
       if (proposal.plan.length === 0) {
         failed.push({ source, error: 'no usable pages proposed (often a transient LLM formatting issue — re-run to retry this file)', ms: Date.now() - startedAt })
       } else {
@@ -578,7 +589,7 @@ async function hatchAllSources (vaultRoot = DEFAULT_VAULT_ROOT,
  */
 async function proposeNextPending (vaultRoot = DEFAULT_VAULT_ROOT,
   { roots = SOURCE_ROOTS, limit = DEFAULT_BATCH_SIZE, skip = 0, combined = true } = {}) {
-  await convertPendingOfficeSources(vaultRoot)
+  await prepareSources(vaultRoot)
   const { pending } = collectPendingSources(vaultRoot, { roots })
   const capped = pending.slice(0, limit)
   const file = capped[skip]
@@ -596,7 +607,7 @@ async function proposeNextPending (vaultRoot = DEFAULT_VAULT_ROOT,
     return { source, relPath: file.relPath, kind: 'whiteboard', whiteboard: true, remaining }
   }
 
-  const p = await proposeHatchPlan(file.absPath, vaultRoot, { copyToEggs: file.kind === 'eggs', combined })
+  const p = await proposeHatchPlan(file.absPath, vaultRoot, { copyToSources: false, combined })
   fs.writeFileSync(planFile, JSON.stringify({
     relPath: file.relPath, kind: file.kind, hash,
     sourceTitle: p.sourceTitle, sourceContent: p.sourceContent, sourceOriginal: p.sourceOriginal, plan: p.plan, at: Date.now()
@@ -657,13 +668,13 @@ module.exports = {
   commitHatchPlan,
   proposeNextPending,
   commitReviewedPlan,
-  ensureInEggs,
+  ensureInSources,
   planCandidates,
   humanizeFilename,
   meaningfulTextLength,
   mapLimit,
   collectPendingSources,
-  convertPendingOfficeSources,
+  prepareSources,
   pendingSourcesSummary,
   hatchAllSources,
   hatchWhiteboard,

--- a/scripts/lib/office.js
+++ b/scripts/lib/office.js
@@ -4,7 +4,7 @@
 // the LLM as "text" they're noise that costs thousands of tokens and produces
 // nothing. This module turns each into compact Markdown — headings, lists and
 // tables for Word; one table per sheet for spreadsheets; per-slide text for
-// decks; the text layer for PDFs — so the same eggs/ → Hatch pipeline works.
+// decks; the text layer for PDFs — so the same pages/ → Hatch pipeline works.
 //
 // extractToMarkdown(absPath, opts) -> { markdown, kind, warnings }
 //   kind:      'docx' | 'xlsx' | 'pptx' | 'pdf' | 'csv'
@@ -240,7 +240,7 @@ function markdownNameFor (filename) {
 }
 
 /**
- * The full Markdown document written into eggs/ for a converted file: YAML
+ * The full Markdown document written into pages/ for a converted file: YAML
  * front-matter recording the origin (so a hatched page can be traced back),
  * then the body. `srcName` is the original file's basename.
  */
@@ -257,6 +257,28 @@ function toHatchSource (srcName, { markdown, kind, warnings = [] }) {
   }
   fm.push('---', '')
   return fm.join('\n') + markdown + '\n'
+}
+
+/**
+ * The Markdown document written for a file Kip can't convert: a reference-only
+ * stub naming the original, so the file still gets a traceable page instead of
+ * being silently dropped. `srcName` is the original file's basename, `note`
+ * is an optional one-line reason (e.g. the UnsupportedFormatError hint).
+ */
+function toStubSource (srcName, note) {
+  const fm = [
+    '---',
+    `source: ${JSON.stringify(srcName)}`,
+    'source_format: binary',
+    `converted: ${JSON.stringify(new Date().toISOString().slice(0, 10))}`
+  ]
+  if (note) {
+    fm.push('conversion_notes:')
+    fm.push(`  - ${JSON.stringify(note)}`)
+  }
+  fm.push('---', '')
+  const body = `## Source\n\n- Original file: \`${srcName}\`\n- No extractable text for this format. Reference only.\n`
+  return fm.join('\n') + body
 }
 
 /**
@@ -282,6 +304,7 @@ module.exports = {
   extractToMarkdown,
   convertFile,
   toHatchSource,
+  toStubSource,
   isSupported,
   markdownNameFor,
   SUPPORTED_EXTS,

--- a/scripts/lib/pages.js
+++ b/scripts/lib/pages.js
@@ -96,8 +96,8 @@ function resolvePage ({ type, title, body, tags = [], vaultRoot = DEFAULT_VAULT_
   let matched = similar && similar.score >= SIMILARITY_THRESHOLD ? getPage(similar.slug, vaultRoot) : null
   let mustCreate = matched ? sourceHubMustCreate(matched.type, type) : false
 
-  // A document's own hub wins over any title match: re-hatching `eggs/x.md`
-  // updates the page whose frontmatter says `source: eggs/x.md`, even when a
+  // A document's own hub wins over any title match: re-hatching `pages/x.md`
+  // updates the page whose frontmatter says `source: pages/x.md`, even when a
   // same-named entity scores higher or the hub's slug drifted to `-source`.
   if (type === 'source' && source) {
     const hub = findSourceHubByPath(source, vaultRoot)
@@ -142,7 +142,7 @@ function resolvePage ({ type, title, body, tags = [], vaultRoot = DEFAULT_VAULT_
     frontmatter.source_hatched = today
     if (sourceOriginal) frontmatter.source_original = sourceOriginal
     // The vault-pattern trace lives in the page itself: every source page
-    // names the egg it came from (and the original, for converted Office
+    // names the document it came from (and the original, for converted Office
     // siblings) on create — keyed on what actually happened (a create), not
     // on the plan's guess.
     if (type === 'source' && !body.trim().startsWith('## Source')) {

--- a/scripts/lib/paths.js
+++ b/scripts/lib/paths.js
@@ -2,7 +2,7 @@ const path = require('node:path')
 
 const PROJECT_ROOT = path.resolve(__dirname, '..', '..')
 
-// The coop root — eggs/, nest/, clucks/, .roost/, .henhouse/ all live
+// The coop root — pages/, nest/, clucks/, .roost/, .henhouse/ all live
 // directly inside it. When the Kip app shells out to these scripts it sets
 // KIP_COOP_ROOT to the currently-open graph's own directory (see
 // electron.wiki); the CLI, with no such env var, defaults to this repo's
@@ -23,8 +23,12 @@ function clucksPath (vaultRoot = DEFAULT_VAULT_ROOT) {
   return path.join(vaultRoot, 'clucks')
 }
 
-function eggsPath (vaultRoot = DEFAULT_VAULT_ROOT) {
-  return path.join(vaultRoot, 'eggs')
+// The unified source folder (formerly "eggs/"): pages/ is Logseq's native
+// notes dir and the single drop-box for source material. Markdown notes live
+// here already; Office/PDF dropped here are converted to Markdown siblings at
+// hatch time. See docs/DESIGN.md "The nest — page types".
+function pagesPath (vaultRoot = DEFAULT_VAULT_ROOT) {
+  return path.join(vaultRoot, 'pages')
 }
 
 // Everything the LLM layer is configured through lives under .henhouse/ —
@@ -94,7 +98,7 @@ module.exports = {
   dbPath,
   nestPath,
   clucksPath,
-  eggsPath,
+  pagesPath,
   henhousePath,
   configPath,
   skillsPath,

--- a/scripts/lib/web-sources.js
+++ b/scripts/lib/web-sources.js
@@ -1,7 +1,7 @@
 // Turns a Peck turn's web-search results into a hatchable source doc
 // (kip-app#81). When Peck runs the `web-search` skill to answer a question,
 // the results otherwise vanish with the turn; this lets the app offer to save
-// them into eggs/ so they become reference material in the nest.
+// them into pages/ so they become reference material in the nest.
 //
 // v1 saves the result list (title / url / snippet). Fetching the full text of
 // each page is a follow-up.

--- a/scripts/migrate-eggs-to-pages.js
+++ b/scripts/migrate-eggs-to-pages.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// One-time migration: fold coop/eggs/ into coop/pages/ (the unified source
+// folder — see docs/DESIGN.md "The nest"). Moves every file, de-dupes
+// byte-identical copies, and rewrites the hatched_sources paths so an
+// already-hatched source isn't re-hatched at its new location.
+//
+//   node scripts/migrate-eggs-to-pages.js
+//
+// Set KIP_COOP_ROOT to point at a graph other than this repo's ./coop.
+// Safe to re-run: a graph with no eggs/ is a no-op. Print a JSON summary.
+
+const fs = require('node:fs')
+const path = require('node:path')
+const crypto = require('node:crypto')
+const { DEFAULT_VAULT_ROOT, pagesPath } = require('./lib/paths')
+const { openDb } = require('./lib/db')
+
+function sha1 (buf) {
+  return crypto.createHash('sha1').update(buf).digest('hex')
+}
+
+function migrate (vaultRoot = DEFAULT_VAULT_ROOT) {
+  const eggsDir = path.join(vaultRoot, 'eggs')
+  if (!fs.existsSync(eggsDir)) {
+    return { moved: [], deduped: [], conflicts: [] }
+  }
+  const sourcesDir = pagesPath(vaultRoot)
+  fs.mkdirSync(sourcesDir, { recursive: true })
+
+  const db = openDb(vaultRoot)
+  const moved = []
+  const deduped = []
+  const conflicts = []
+
+  try {
+    for (const name of fs.readdirSync(eggsDir)) {
+      const src = path.join(eggsDir, name)
+      if (!fs.statSync(src).isFile() || name.startsWith('.')) continue
+      const eggHash = sha1(fs.readFileSync(src))
+
+      const target = path.join(sourcesDir, name)
+      if (fs.existsSync(target)) {
+        if (sha1(fs.readFileSync(target)) === eggHash) {
+          // Identical — the pages/ copy is canonical; drop the duplicate.
+          fs.rmSync(src)
+          deduped.push(name)
+          db.prepare('DELETE FROM hatched_sources WHERE path = ?').run(`eggs/${name}`)
+          continue
+        }
+        // Same name, different content — keep both by suffixing the egg copy.
+        const ext = path.extname(name)
+        const altName = `${path.basename(name, ext)}-egg${ext}`
+        fs.renameSync(src, path.join(sourcesDir, altName))
+        conflicts.push({ from: name, to: altName })
+        db.prepare('UPDATE hatched_sources SET path = ? WHERE path = ?').run(`pages/${altName}`, `eggs/${name}`)
+        continue
+      }
+
+      fs.renameSync(src, target)
+      moved.push(name)
+      db.prepare('UPDATE hatched_sources SET path = ? WHERE path = ?').run(`pages/${name}`, `eggs/${name}`)
+    }
+
+    if (fs.readdirSync(eggsDir).length === 0) fs.rmdirSync(eggsDir)
+  } finally {
+    db.close()
+  }
+
+  return { moved, deduped, conflicts }
+}
+
+if (require.main === module) {
+  const result = migrate()
+  console.log(JSON.stringify(result, null, 2))
+}
+
+module.exports = { migrate }

--- a/scripts/skills/xlsx-csv/SKILL.md
+++ b/scripts/skills/xlsx-csv/SKILL.md
@@ -3,7 +3,7 @@ name: xlsx-csv
 description: Read and summarize a spreadsheet (.xlsx, .xls or .csv) that lives in the coop.
 when_to_use: >
   The question is about tabular data in a file — a CSV or spreadsheet path, column
-  totals or averages, row counts, "what's in eggs/data.csv", "summarize the budget sheet".
+  totals or averages, row counts, "what's in pages/data.csv", "summarize the budget sheet".
 entry: run.js
 network: false
 timeout: 30

--- a/scripts/test/hatch.test.js
+++ b/scripts/test/hatch.test.js
@@ -5,7 +5,7 @@ const os = require('node:os')
 const path = require('node:path')
 
 const { rebuildRoost } = require('../rebuild-roost')
-const { planCandidates, ensureInEggs, humanizeFilename, collectPendingSources, meaningfulTextLength, mapLimit, commitHatchPlan, hatchAllSources, hatchWhiteboard, proposeNextPending, commitReviewedPlan, pendingSourcesSummary } = require('../lib/hatch')
+const { planCandidates, ensureInSources, humanizeFilename, collectPendingSources, meaningfulTextLength, mapLimit, commitHatchPlan, hatchAllSources, hatchWhiteboard, proposeNextPending, commitReviewedPlan, pendingSourcesSummary, prepareSources } = require('../lib/hatch')
 const { recordHatchedSource, getPage } = require('../lib/roost')
 const { saveLLMConfig } = require('../lib/llm')
 const { proposeAndDraftPages } = require('../lib/prompts')
@@ -25,7 +25,7 @@ function stubFetch (respond) {
 
 function makeTempVault () {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'coop-hatch-test-'))
-  for (const dir of ['nest/entities', 'nest/concepts', 'nest/sources', 'eggs', 'journals', 'pages', 'whiteboards', 'clucks', '.roost']) {
+  for (const dir of ['nest/entities', 'nest/concepts', 'nest/sources', 'pages', 'journals', 'whiteboards', 'clucks', '.roost']) {
     fs.mkdirSync(path.join(root, dir), { recursive: true })
   }
   return root
@@ -47,27 +47,27 @@ test('humanizeFilename', () => {
   assert.equal(humanizeFilename('some-journal_export.md'), 'Some Journal Export')
 })
 
-test('ensureInEggs', async (t) => {
+test('ensureInSources', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
 
-  await t.test('copies an external file into coop/eggs/', () => {
+  await t.test('copies an external file into coop/pages/', () => {
     const externalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hatch-src-'))
     const externalFile = path.join(externalDir, 'clipping.md')
     fs.writeFileSync(externalFile, 'some source content')
 
-    const result = ensureInEggs(externalFile, root)
-    assert.equal(result, path.join(root, 'eggs', 'clipping.md'))
+    const result = ensureInSources(externalFile, root)
+    assert.equal(result, path.join(root, 'pages', 'clipping.md'))
     assert.equal(fs.readFileSync(result, 'utf8'), 'some source content')
 
     fs.rmSync(externalDir, { recursive: true, force: true })
   })
 
-  await t.test('does not error when the source is already inside coop/eggs/', () => {
-    const alreadyInEggs = path.join(root, 'eggs', 'already-there.md')
-    fs.writeFileSync(alreadyInEggs, 'already here')
-    const result = ensureInEggs(alreadyInEggs, root)
-    assert.equal(result, alreadyInEggs)
+  await t.test('does not error when the source is already inside coop/pages/', () => {
+    const alreadyInSources = path.join(root, 'pages', 'already-there.md')
+    fs.writeFileSync(alreadyInSources, 'already here')
+    const result = ensureInSources(alreadyInSources, root)
+    assert.equal(result, alreadyInSources)
     assert.equal(fs.readFileSync(result, 'utf8'), 'already here')
   })
 })
@@ -93,33 +93,33 @@ test('meaningfulTextLength ignores frontmatter and list/markdown punctuation', (
   assert.ok(meaningfulTextLength('- a real sentence with some words in it') > 20)
 })
 
-test('collectPendingSources: buckets eggs/journals/pages by new-or-changed, size, and emptiness', async (t) => {
+test('collectPendingSources: buckets pages/journals by new-or-changed, size, and emptiness', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
 
-  fs.writeFileSync(path.join(root, 'eggs', 'clipping.md'), 'a source document with real content')
+  fs.writeFileSync(path.join(root, 'pages', 'clipping.md'), 'a source document with real content')
   fs.writeFileSync(path.join(root, 'journals', '2026_08_26.md'), '- had a meeting about the roadmap today')
   fs.writeFileSync(path.join(root, 'pages', 'Some Note.md'), '- a page with some genuine notes on it')
   fs.writeFileSync(path.join(root, 'pages', 'stub.md'), '- ') // near-empty — skipped
   fs.writeFileSync(path.join(root, 'pages', 'huge.md'), 'x'.repeat(1024 * 1024 + 1)) // over the ~1 MB backstop — skipped
-  fs.writeFileSync(path.join(root, 'pages', 'notes.txt'), 'not markdown, outside eggs/ — ignored')
+  fs.writeFileSync(path.join(root, 'pages', 'notes.txt'), 'not markdown — skipped by the scan (prepareSources turns it into a stub in the full flow)')
   fs.writeFileSync(path.join(root, 'journals', '.DS_Store'), '') // dotfile — ignored
 
   let { pending, oversized, empty } = collectPendingSources(root)
-  assert.deepEqual(pending.map((p) => p.relPath), ['eggs/clipping.md', 'journals/2026_08_26.md', 'pages/Some Note.md'])
+  assert.deepEqual(pending.map((p) => p.relPath), ['journals/2026_08_26.md', 'pages/clipping.md', 'pages/Some Note.md'])
   assert.deepEqual(oversized.map((o) => o.relPath), ['pages/huge.md'])
   assert.deepEqual(empty, ['pages/stub.md'])
 
   // Record one as hatched at its current content -> it drops out of pending.
   const { hashContent } = require('../lib/roost')
-  recordHatchedSource('eggs/clipping.md', hashContent(fs.readFileSync(path.join(root, 'eggs', 'clipping.md'), 'utf8')), root)
+  recordHatchedSource('pages/clipping.md', hashContent(fs.readFileSync(path.join(root, 'pages', 'clipping.md'), 'utf8')), root)
   ;({ pending } = collectPendingSources(root))
   assert.deepEqual(pending.map((p) => p.relPath), ['journals/2026_08_26.md', 'pages/Some Note.md'])
 
   // Change its content -> it comes back as pending.
-  fs.writeFileSync(path.join(root, 'eggs', 'clipping.md'), 'a source document with real content, now extended')
+  fs.writeFileSync(path.join(root, 'pages', 'clipping.md'), 'a source document with real content, now extended')
   ;({ pending } = collectPendingSources(root))
-  assert.ok(pending.map((p) => p.relPath).includes('eggs/clipping.md'))
+  assert.ok(pending.map((p) => p.relPath).includes('pages/clipping.md'))
 })
 
 test('collectPendingSources: no source dirs -> everything empty', () => {
@@ -129,6 +129,65 @@ test('collectPendingSources: no source dirs -> everything empty', () => {
   } finally {
     fs.rmSync(root, { recursive: true, force: true })
   }
+})
+
+test('prepareSources: unsupported formats become a reference-only .md stub (idempotent)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+  fs.writeFileSync(path.join(root, 'pages', 'archive.zip'), 'PK\u0003\u0004 some binary bytes')
+
+  const first = await prepareSources(root)
+  assert.equal(first.converted.length, 0)
+  assert.equal(first.failed.length, 0)
+  assert.deepEqual(first.stubbed.map((s) => s.source), ['archive.zip'])
+
+  const stub = fs.readFileSync(path.join(root, 'pages', 'archive.md'), 'utf8')
+  assert.match(stub, /source: "archive\.zip"/)
+  assert.match(stub, /source_format: binary/)
+  assert.match(stub, /## Source\n\n- Original file: `archive\.zip`/)
+  assert.match(stub, /No extractable text for this format/)
+
+  // a second run must not re-stub: the up-to-date .md is left alone
+  const second = await prepareSources(root)
+  assert.deepEqual(second.stubbed, [])
+  assert.equal(second.converted.length, 0)
+  assert.equal(second.failed.length, 0)
+})
+
+test('migrate-eggs-to-pages: moves files, dedupes identical copies, rewrites hatched_sources', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  fs.mkdirSync(path.join(root, 'eggs'), { recursive: true })
+  const { migrate } = require('../migrate-eggs-to-pages')
+  const { hashContent } = require('../lib/roost')
+
+  // a source that was already hatched (has a hatched_sources row)
+  fs.writeFileSync(path.join(root, 'eggs', 'clipping.md'), 'a source with content')
+  recordHatchedSource('eggs/clipping.md', hashContent('a source with content'), root)
+
+  // an identical duplicate already in pages/
+  fs.writeFileSync(path.join(root, 'pages', 'dup.md'), 'duplicate content')
+  fs.writeFileSync(path.join(root, 'eggs', 'dup.md'), 'duplicate content')
+
+  // a name collision with different content
+  fs.writeFileSync(path.join(root, 'pages', 'conflict.md'), 'pages version')
+  fs.writeFileSync(path.join(root, 'eggs', 'conflict.md'), 'eggs version')
+
+  const result = migrate(root)
+  assert.deepEqual(result.moved, ['clipping.md'])
+  assert.deepEqual(result.deduped, ['dup.md'])
+  assert.deepEqual(result.conflicts, [{ from: 'conflict.md', to: 'conflict-egg.md' }])
+
+  assert.ok(fs.existsSync(path.join(root, 'pages', 'clipping.md')))
+  assert.ok(!fs.existsSync(path.join(root, 'eggs')), 'eggs/ removed once empty')
+  assert.equal(fs.readFileSync(path.join(root, 'pages', 'conflict.md'), 'utf8'), 'pages version')
+  assert.equal(fs.readFileSync(path.join(root, 'pages', 'conflict-egg.md'), 'utf8'), 'eggs version')
+
+  // hatched_sources path moved with the file → not re-hatched
+  const { hatchedSourceHashes } = require('../lib/roost')
+  assert.ok(hatchedSourceHashes(root).has('pages/clipping.md'))
+  assert.ok(!hatchedSourceHashes(root).has('eggs/clipping.md'))
 })
 
 test('commitHatchPlan: regenIndex:false skips the index.md rewrite (batch callers regen once)', async (t) => {
@@ -234,7 +293,7 @@ test('hatchAllSources — combined mode makes one LLM call per file and drafts b
   rebuildRoost(root)
   saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
 
-  fs.writeFileSync(path.join(root, 'eggs', 'clinic-visit.md'),
+  fs.writeFileSync(path.join(root, 'pages', 'clinic-visit.md'),
     'Saw Dr. Alvarez on 2026-08-20 about sleep. Resting heart rate is trending down.')
 
   const { calls, restore } = stubFetch(() => JSON.stringify({
@@ -262,7 +321,7 @@ test('hatchAllSources — classic mode makes one propose call plus one generate 
   rebuildRoost(root)
   saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
 
-  fs.writeFileSync(path.join(root, 'eggs', 'note.md'), 'Bought a Gaggia Classic espresso machine. It works well.')
+  fs.writeFileSync(path.join(root, 'pages', 'note.md'), 'Bought a Gaggia Classic espresso machine. It works well.')
 
   const kinds = []
   const { restore } = stubFetch((body) => {
@@ -294,7 +353,7 @@ test('combined-path update is regenerated against the existing page, not restate
   rebuildRoost(root)
   saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
 
-  fs.writeFileSync(path.join(root, 'eggs', 'sleep-log.md'), 'This month sleep dropped to 6h a night on average.')
+  fs.writeFileSync(path.join(root, 'pages', 'sleep-log.md'), 'This month sleep dropped to 6h a night on average.')
 
   const seen = []
   const { restore } = stubFetch((body) => {
@@ -336,14 +395,14 @@ test('#114 does not touch source pages: a re-hatched source hub still uses its d
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
   rebuildRoost(root)
   saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
-  fs.writeFileSync(path.join(root, 'eggs', 'report.md'), 'First version of the quarterly report.')
+  fs.writeFileSync(path.join(root, 'pages', 'report.md'), 'First version of the quarterly report.')
 
   const gen = () => JSON.stringify({ pages: [{ title: 'Report', type: 'source', tags: [], summary: 's', body: 'Report hub. Links [[q3-numbers]].' }] })
   let s = stubFetch(gen)
   try { await hatchAllSources(root, { limit: 1 }) } finally { s.restore() }
 
   // edit the source and re-hatch — the hub resolves to action=update
-  fs.writeFileSync(path.join(root, 'eggs', 'report.md'), 'Second version of the quarterly report, now with more detail.')
+  fs.writeFileSync(path.join(root, 'pages', 'report.md'), 'Second version of the quarterly report, now with more detail.')
   const kinds = []
   s = stubFetch((body) => {
     const sys = body.messages.map((m) => m.content).join('\n')
@@ -362,7 +421,7 @@ test('review mode: proposeNextPending stashes a plan and writes nothing; commitR
   rebuildRoost(root)
   saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
 
-  fs.writeFileSync(path.join(root, 'eggs', 'clinic-visit.md'),
+  fs.writeFileSync(path.join(root, 'pages', 'clinic-visit.md'),
     'Saw Dr. Alvarez on 2026-08-20 about sleep. Resting heart rate is trending down.')
 
   const { calls, restore } = stubFetch(() => JSON.stringify({
@@ -402,7 +461,7 @@ test('review mode: commitReviewedPlan with an empty keep list still records the 
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
   rebuildRoost(root)
   saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
-  fs.writeFileSync(path.join(root, 'eggs', 'skip-me.md'), 'A short note that the user decides not to hatch after all.')
+  fs.writeFileSync(path.join(root, 'pages', 'skip-me.md'), 'A short note that the user decides not to hatch after all.')
 
   const { restore } = stubFetch(() => JSON.stringify({
     pages: [{ title: 'Skip Me', type: 'source', tags: [], summary: 's', body: 'Body.' }]
@@ -471,7 +530,7 @@ test('source lineage: ## Source block + frontmatter provenance + synthesized hub
   saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
 
   // The stub proposes NO type:'source' page — the hub must be synthesized.
-  fs.writeFileSync(path.join(root, 'eggs', 'sleep-study.md'),
+  fs.writeFileSync(path.join(root, 'pages', 'sleep-study.md'),
     'Slept 6.2h on average this week. Caffeine after 15:00 correlates with worse deep sleep.')
   const { restore } = stubFetch(() => JSON.stringify({
     pages: [
@@ -498,19 +557,19 @@ test('source lineage: ## Source block + frontmatter provenance + synthesized hub
     assert.equal(conceptRow.summary, 'Weekly sleep numbers', 'concept summary intact')
 
     const hubRaw = fs.readFileSync(path.join(root, hub.path), 'utf8')
-    assert.match(hubRaw, /## Source\n\n- Source file: `eggs\/sleep-study\.md`/)
+    assert.match(hubRaw, /## Source\n\n- Source file: `pages\/sleep-study\.md`/)
     assert.match(hubRaw, /- Content hash at hatch: `[0-9a-f]{12}…`/)
     assert.match(hubRaw, /type: source/)
     assert.match(hubRaw, /source_hatched: '?\d{4}-\d{2}-\d{2}'?/)
 
     const conceptRaw = fs.readFileSync(path.join(root, 'nest', 'concepts', 'sleep-study.md'), 'utf8')
     assert.doesNotMatch(conceptRaw, /## Source/, 'no ## Source section on non-source pages')
-    assert.match(conceptRaw, /source: eggs\/sleep-study\.md/, 'but frontmatter provenance on all pages')
+    assert.match(conceptRaw, /source: pages\/sleep-study\.md/, 'but frontmatter provenance on all pages')
 
     // rebuild-roost must keep the LLM summary now that it lives in frontmatter
     const { rebuildRoost: rebuild } = require('../rebuild-roost')
     rebuild(root)
-    assert.match(getPage('sleep-study-source', root).summary, /Hatched from eggs\/sleep-study\.md/,
+    assert.match(getPage('sleep-study-source', root).summary, /Hatched from pages\/sleep-study\.md/,
       'frontmatter summary survives a rebuild instead of degrading to the first paragraph')
     assert.equal(getPage('sleep-study', root).summary, 'Weekly sleep numbers',
       'and the concept keeps its own summary through a rebuild too')
@@ -523,20 +582,20 @@ test('collectPendingSources: status splits new drops from edited-since-hatch sou
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
 
-  fs.writeFileSync(path.join(root, 'eggs', 'fresh.md'), 'A brand new drop of source content here.')
-  fs.writeFileSync(path.join(root, 'eggs', 'edited.md'), 'An egg that was hatched and then edited in place.')
+  fs.writeFileSync(path.join(root, 'pages', 'fresh.md'), 'A brand new drop of source content here.')
+  fs.writeFileSync(path.join(root, 'pages', 'edited.md'), 'A source that was hatched and then edited in place.')
   const { recordHatchedSource, hashContent } = require('../lib/roost')
-  recordHatchedSource('eggs/edited.md', hashContent(fs.readFileSync(path.join(root, 'eggs', 'edited.md'), 'utf8')), root)
+  recordHatchedSource('pages/edited.md', hashContent(fs.readFileSync(path.join(root, 'pages', 'edited.md'), 'utf8')), root)
 
   let { pending } = collectPendingSources(root)
   const byPath = new Map(pending.map((p) => [p.relPath, p.status]))
-  assert.equal(byPath.get('eggs/fresh.md'), 'new')
+  assert.equal(byPath.get('pages/fresh.md'), 'new')
   // edited.md matches its recorded hash -> not pending at all
-  assert.equal(byPath.get('eggs/edited.md'), undefined)
+  assert.equal(byPath.get('pages/edited.md'), undefined)
 
-  fs.writeFileSync(path.join(root, 'eggs', 'edited.md'), 'An egg that was hatched and then edited in place — twice now.')
+  fs.writeFileSync(path.join(root, 'pages', 'edited.md'), 'A source that was hatched and then edited in place — twice now.')
   ;({ pending } = collectPendingSources(root))
-  const edited = pending.find((p) => p.relPath === 'eggs/edited.md')
+  const edited = pending.find((p) => p.relPath === 'pages/edited.md')
   assert.equal(edited.status, 'changed', 'same path, different hash -> changed, not new')
 })
 
@@ -544,13 +603,13 @@ test('pendingSourcesSummary surfaces changedCount (kip-app#113)', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
 
-  fs.writeFileSync(path.join(root, 'eggs', 'a.md'), 'First source with enough prose to pass the empty gate easily.')
-  fs.writeFileSync(path.join(root, 'eggs', 'b.md'), 'Second source, also hatched before, also with prose.')
+  fs.writeFileSync(path.join(root, 'pages', 'a.md'), 'First source with enough prose to pass the empty gate easily.')
+  fs.writeFileSync(path.join(root, 'pages', 'b.md'), 'Second source, also hatched before, also with prose.')
   const { recordHatchedSource, hashContent } = require('../lib/roost')
-  recordHatchedSource('eggs/a.md', hashContent(fs.readFileSync(path.join(root, 'eggs', 'a.md'), 'utf8')), root)
-  recordHatchedSource('eggs/b.md', hashContent(fs.readFileSync(path.join(root, 'eggs', 'b.md'), 'utf8')), root)
-  fs.writeFileSync(path.join(root, 'eggs', 'a.md'), 'First source edited after its hatch, with enough prose still.')
-  fs.writeFileSync(path.join(root, 'eggs', 'new.md'), 'A brand-new third drop with plenty of prose in it.')
+  recordHatchedSource('pages/a.md', hashContent(fs.readFileSync(path.join(root, 'pages', 'a.md'), 'utf8')), root)
+  recordHatchedSource('pages/b.md', hashContent(fs.readFileSync(path.join(root, 'pages', 'b.md'), 'utf8')), root)
+  fs.writeFileSync(path.join(root, 'pages', 'a.md'), 'First source edited after its hatch, with enough prose still.')
+  fs.writeFileSync(path.join(root, 'pages', 'new.md'), 'A brand-new third drop with plenty of prose in it.')
 
   const summary = await pendingSourcesSummary(root)
   assert.equal(summary.changedCount, 1)
@@ -562,27 +621,27 @@ test('recordHatchedSource prunes the orphan row left by a renamed source (kip-ap
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
 
-  fs.writeFileSync(path.join(root, 'eggs', 'report-v1.md'), 'Version one of a report.')
+  fs.writeFileSync(path.join(root, 'pages', 'report-v1.md'), 'Version one of a report.')
   const { hashContent } = require('../lib/roost')
-  recordHatchedSource('eggs/report-v1.md', hashContent('Version one of a report.'), root)
+  recordHatchedSource('pages/report-v1.md', hashContent('Version one of a report.'), root)
 
   // The user renames per GETTING-STARTED's versioning guidance: new file, old one gone.
-  fs.rmSync(path.join(root, 'eggs', 'report-v1.md'))
+  fs.rmSync(path.join(root, 'pages', 'report-v1.md'))
   // The prune has a 48h grace period (a minutes-old missing file is a sync
   // race, not a rename) — backdate the row past it.
   const { openDb } = require('../lib/db')
   const db = openDb(root)
   try {
-    db.prepare("UPDATE hatched_sources SET hatched = ? WHERE path = 'eggs/report-v1.md'")
+    db.prepare("UPDATE hatched_sources SET hatched = ? WHERE path = 'pages/report-v1.md'")
       .run(new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString())
   } finally {
     db.close()
   }
-  recordHatchedSource('eggs/report-v2.md', hashContent('Version two of a report.'), root)
+  recordHatchedSource('pages/report-v2.md', hashContent('Version two of a report.'), root)
   const { hatchedSourceHashes } = require('../lib/roost')
   const hashes = hatchedSourceHashes(root)
-  assert.ok(hashes.has('eggs/report-v2.md'))
-  assert.ok(!hashes.has('eggs/report-v1.md'), 'old row pruned: file gone, its directory still there')
+  assert.ok(hashes.has('pages/report-v2.md'))
+  assert.ok(!hashes.has('pages/report-v1.md'), 'old row pruned: file gone, its directory still there')
 
   // A missing *directory* means "maybe not synced yet" — the row must stay.
   recordHatchedSource('dropbox/report-v2.md', hashContent('Version two of a report.'), root)

--- a/scripts/test/pages.test.js
+++ b/scripts/test/pages.test.js
@@ -88,12 +88,12 @@ test('resolvePage provenance (kip-app#113)', async (t) => {
       body: 'Visit notes from the sleep clinic.',
       tags: ['health'],
       vaultRoot: root,
-      source: 'eggs/clinic-visit.md',
+      source: 'pages/clinic-visit.md',
       summary: 'One LLM one-liner about the visit'
     })
     assert.equal(result.action, 'create')
     const raw = fs.readFileSync(path.join(root, result.path), 'utf8')
-    assert.match(raw, /source: eggs\/clinic-visit\.md/)
+    assert.match(raw, /source: pages\/clinic-visit\.md/)
     assert.match(raw, /source_hatched: '?\d{4}-\d{2}-\d{2}'?/)
     assert.match(raw, /summary: One LLM one-liner about the visit/)
   })
@@ -105,7 +105,7 @@ test('resolvePage provenance (kip-app#113)', async (t) => {
       body: 'New note: quality matters as much as duration.',
       tags: ['from-peck'],
       vaultRoot: root,
-      source: 'eggs/clinic-visit.md',
+      source: 'pages/clinic-visit.md',
       mergeTags: true
     })
     assert.equal(result.action, 'update')

--- a/scripts/test/skill-cache.test.js
+++ b/scripts/test/skill-cache.test.js
@@ -10,7 +10,7 @@ const skillCache = require('../lib/skill-cache')
 function makeTempCoop () {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'coop-skill-cache-test-'))
   fs.mkdirSync(path.join(root, '.henhouse', 'skills'), { recursive: true })
-  fs.mkdirSync(path.join(root, 'eggs'), { recursive: true })
+  fs.mkdirSync(path.join(root, 'pages'), { recursive: true })
   return root
 }
 

--- a/scripts/test/skills.test.js
+++ b/scripts/test/skills.test.js
@@ -13,7 +13,7 @@ const telemetry = require('../lib/telemetry')
 function makeTempCoop () {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'coop-skills-test-'))
   fs.mkdirSync(path.join(root, '.henhouse', 'skills'), { recursive: true })
-  fs.mkdirSync(path.join(root, 'eggs'), { recursive: true })
+  fs.mkdirSync(path.join(root, 'pages'), { recursive: true })
   return root
 }
 
@@ -269,10 +269,10 @@ test('loadSkillsConfig: safe default on a missing/broken file', (t) => {
 test('xlsx-csv skill: summarizes a CSV', async (t) => {
   const root = makeTempCoop()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
-  fs.writeFileSync(path.join(root, 'eggs', 'data.csv'), 'name,score\na,10\nb,20\n')
+  fs.writeFileSync(path.join(root, 'pages', 'data.csv'), 'name,score\na,10\nb,20\n')
 
   const skill = discoverSkills(root).find((s) => s.name === 'xlsx-csv')
-  const res = await runSkill(skill, { file: 'eggs/data.csv', operation: 'summarize' }, root)
+  const res = await runSkill(skill, { file: 'pages/data.csv', operation: 'summarize' }, root)
 
   assert.equal(res.ok, true, res.error || '')
   assert.match(res.output, /2 rows/)

--- a/scripts/test/web-sources.test.js
+++ b/scripts/test/web-sources.test.js
@@ -35,7 +35,7 @@ test('parseWebSearchOutput: junk returns null', () => {
   assert.equal(parseWebSearchOutput(''), null)
 })
 
-test('buildWebSource: one search → a hatchable eggs doc', () => {
+test('buildWebSource: one search → a hatchable source doc', () => {
   const now = new Date('2026-08-31T10:00:00Z')
   const src = buildWebSource('How do mRNA vaccines work?', [parseWebSearchOutput(OUTPUT)], { now })
   assert.equal(src.filename, 'web-search-2026-08-31-how-do-mrna-vaccines-work.md')


### PR DESCRIPTION
Part of #51 (P1). Deferred: the nest page-name collision (P2).

## What
- `pages/` is now the single source folder. `SOURCE_ROOTS` = `[pages, journals, whiteboards]`; `eggs/` is gone.
- `ensureInEggs` → `ensureInSources` (copies an external doc into `pages/`); the `copyToEggs` flag is removed.
- `convertPendingOfficeSources` → `prepareSources`: scans `pages/`, converts Office/PDF to Markdown siblings, and turns anything unreadable into a reference-only `.md` stub (`source_format: binary`) instead of silently dropping it.
- `collectPendingSources` drops the `eggs/`-only special cases (it's now just `.md` for sources, `.edn` for whiteboards).
- New `scripts/migrate-eggs-to-pages.js`: moves `eggs/*` → `pages/*`, de-dupes byte-identical copies, and rewrites `hatched_sources` paths so nothing re-hatches.

## Verification
`npm test` 336/336 (added tests for the stub fallback and the migration).

## Note
The kip-app UI (glossary/onboarding/drop/paste/web-save target) still references `eggs/` and is a follow-up change in the kip-app repo.