### PR TITLE
reminders: explicit --title/--when/--event-at/--source on add

### DIFF
--- a/scripts/reminders.js
+++ b/scripts/reminders.js
@@ -34,7 +34,8 @@ const ROOST_DIR = path.join(DEFAULT_VAULT_ROOT, '.roost')
 const argv = process.argv.slice(2)
 const has = (f) => argv.includes(f)
 const flagVal = (f) => { const i = argv.indexOf(f); return i >= 0 ? argv[i + 1] : undefined }
-const positionals = argv.filter((a, i) => !a.startsWith('--') && argv[i - 1] !== '--lead')
+const VALUE_FLAGS = new Set(['--lead', '--title', '--when', '--event-at', '--source'])
+const positionals = argv.filter((a, i) => !a.startsWith('--') && !VALUE_FLAGS.has(argv[i - 1]))
 const asJson = has('--json')
 const RELATED_LIMIT = 6
 
@@ -103,9 +104,18 @@ async function main () {
 
   if (cmd === 'add') {
     const text = positionals.slice(1).join(' ').trim()
-    if (!text) { console.error('usage: reminders.js add "<what and when>" [--lead 60] [--silent]'); process.exitCode = 1; return }
+    const title = flagVal('--title')
+    const eventAt = flagVal('--event-at')
+    const when = flagVal('--when')
+    const source = flagVal('--source') || 'cli'
+    if (!text && !title && !eventAt && !when) { console.error('usage: reminders.js add "<what and when>" [--lead 60] [--silent]'); process.exitCode = 1; return }
     const row = addReminder(DEFAULT_VAULT_ROOT, {
-      text, lead: flagVal('--lead'), source: 'cli',
+      text,
+      ...(title ? { title } : {}),
+      ...(when ? { when } : {}),
+      ...(eventAt ? { eventAt } : {}),
+      lead: flagVal('--lead'),
+      source,
       ...(has('--silent') ? { sound: false } : {})
     })
     out({ reminder: row }, describeReminder(row))

--- a/scripts/test/reminders.test.js
+++ b/scripts/test/reminders.test.js
@@ -253,6 +253,19 @@ test('CLI: cancel', async (t) => {
   assert.equal(JSON.parse(r.stdout).canceled, true)
 })
 
+test('CLI: add with explicit --title/--event-at/--source (todo projection)', async (t) => {
+  const root = makeCoop()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  const r = await cli(root, ['add', '--title', 'follow up with Sam',
+    '--event-at', '2026-09-05T07:00:00.000Z', '--source', 'todo', '--lead', '0', '--json'])
+  const reminder = JSON.parse(r.stdout).reminder
+  assert.equal(reminder.title, 'follow up with Sam')
+  assert.equal(reminder.eventAt, '2026-09-05T07:00:00.000Z')
+  assert.equal(reminder.leadMin, 0)
+  assert.equal(reminder.source, 'todo')
+  assert.equal(reminder.status, 'pending')
+})
+
 test('CLI: --silent add, then mute/unmute', async (t) => {
   const root = makeCoop()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))


### PR DESCRIPTION
The todos panel (kip-app#104) projects due-dated todos into the reminder engine with a structured title + due date. Round-tripping those through the NL parser is lossy, so expose what `addReminder` already supports:

- `--title <text>` / `--when <phrase>` / `--event-at <ISO>`
- `--source <name>` (default still `cli`)
- keeps `--lead` / `--silent`

The `source "todo"` + `lead 0` convention lets the panel cancel by id when the todo is checked off.

Adds a CLI test for the explicit-path add. Full `reminders.test.js` passes (21/21).