### PR TITLE
hatch: stop re-hatching already-hatched sources across devices

### DIFF
--- a/scripts/hatch-all.js
+++ b/scripts/hatch-all.js
@@ -6,6 +6,7 @@
 //
 //   node scripts/hatch-all.js --preview        -> JSON of what a run would touch (no LLM calls)
 //   node scripts/hatch-all.js [--limit N]      -> hatch up to N pending files (default 10), print JSON summary
+//   node scripts/hatch-all.js --force          -> also re-hatch files that already have a trace hub (manual re-hatch)
 //   node scripts/hatch-all.js --limit N --trace   -> also record full prompts/responses to .roost/hatch-trace.jsonl
 //   node scripts/hatch-all.js --limit N --classic -> old path: one propose call + one generate call per page
 //                                                    (default is combined: one LLM call per file). Also KIP_HATCH_CLASSIC=1.
@@ -44,6 +45,10 @@ const LOCK_STALE_MS = 15 * 60 * 1000
 
 const traceOn = process.argv.includes('--trace') || process.env.KIP_HATCH_TRACE === '1'
 const combined = !(process.argv.includes('--classic') || process.env.KIP_HATCH_CLASSIC === '1')
+// Re-hatch sources that already have a trace hub in the nest (normally
+// skipped — a synced-already-hatched file is left alone, see
+// collectPendingSources). This is the explicit "hatch it again" trigger.
+const forceOn = process.argv.includes('--force')
 
 let reporter = null
 
@@ -84,7 +89,7 @@ function parseSkip () {
 
 async function main () {
   if (process.argv.includes('--preview')) {
-    console.log(JSON.stringify(await pendingSourcesSummary(DEFAULT_VAULT_ROOT)))
+    console.log(JSON.stringify(await pendingSourcesSummary(DEFAULT_VAULT_ROOT, { force: forceOn })))
     return
   }
 
@@ -102,7 +107,8 @@ async function main () {
       const out = await proposeNextPending(DEFAULT_VAULT_ROOT, {
         ...(parseLimit() ? { limit: parseLimit() } : {}),
         skip: parseSkip(),
-        combined
+        combined,
+        force: forceOn
       })
       console.log(JSON.stringify(out))
     } finally { releaseLock() }
@@ -132,6 +138,7 @@ async function main () {
 
     const summary = await hatchAllSources(DEFAULT_VAULT_ROOT, {
       combined,
+      force: forceOn,
       ...(limit ? { limit } : {}),
       onProgress: (p) => {
         touchLock()

--- a/scripts/lib/hatch.js
+++ b/scripts/lib/hatch.js
@@ -11,7 +11,7 @@ const {
   findSimilarSlug, slugify, getPage, upsertPage, regenerateIndexMd, appendLog,
   hashContent, hatchedSourceHashes, recordHatchedSource, searchPages, SIMILARITY_THRESHOLD
 } = require('./roost')
-const { resolvePage, nextFreeSlug, sourceHubMustCreate, findSourceHubByPath } = require('./pages')
+const { resolvePage, nextFreeSlug, sourceHubMustCreate, findSourceHubByPath, hatchedSourcePaths } = require('./pages')
 const { proposeCandidatePages, generatePageContent, proposeAndDraftPages, describeWhiteboard } = require('./prompts')
 const { parseWhiteboard, whiteboardToOutline } = require('./whiteboard')
 const { convertFile: convertOfficeFile, markdownNameFor, toStubSource, UnsupportedFormatError } = require('./office')
@@ -402,6 +402,11 @@ async function prepareSources (vaultRoot = DEFAULT_VAULT_ROOT) {
  *
  * `pending` = new OR content-changed since last hatch (sha1 vs
  * hatched_sources); `kind` is the dir, or 'whiteboard' for a .edn board.
+ * A source whose trace hub already exists in nest/sources/ is treated as
+ * already hatched and skipped — the nest is synced graph markdown, so this
+ * holds across devices (a Dropbox sync that brings over an already-hatched
+ * file is NOT re-hatched), unlike the hatched_sources hash cache which is
+ * device-local. Pass `force` to re-hatch those anyway (a manual re-hatch).
  * Skipped, and reported separately: dotfiles, non-.md files (they're turned
  * into .md siblings by prepareSources() first), near-empty files, and files
  * over MAX_SOURCE_BYTES (a ~1 MB context-window backstop — whiteboards are
@@ -412,8 +417,9 @@ async function prepareSources (vaultRoot = DEFAULT_VAULT_ROOT) {
  *            empty: string[],
  *            errors: Array<{relPath, error}>}}
  */
-function collectPendingSources (vaultRoot = DEFAULT_VAULT_ROOT, { roots = SOURCE_ROOTS } = {}) {
+function collectPendingSources (vaultRoot = DEFAULT_VAULT_ROOT, { roots = SOURCE_ROOTS, force = false } = {}) {
   const hashes = hatchedSourceHashes(vaultRoot)
+  const hatchedPaths = force ? null : hatchedSourcePaths(vaultRoot)
   const pending = []
   const oversized = []
   const empty = []
@@ -449,6 +455,7 @@ function collectPendingSources (vaultRoot = DEFAULT_VAULT_ROOT, { roots = SOURCE
       if (!board && bytes > MAX_SOURCE_BYTES) { oversized.push({ relPath, bytes }); continue }
 
       if (!board && meaningfulTextLength(content) < MIN_CONTENT_CHARS) { empty.push(relPath); continue }
+      if (hatchedPaths && hatchedPaths.has(relPath)) continue // already hatched (synced trace hub) — skip unless forced
       const priorHash = hashes.get(relPath)
       if (priorHash === hashContent(content)) continue // unchanged since last hatch
 
@@ -514,9 +521,9 @@ async function pendingSourcesSummary (vaultRoot = DEFAULT_VAULT_ROOT, opts = {})
  *            remaining: number}}
  */
 async function hatchAllSources (vaultRoot = DEFAULT_VAULT_ROOT,
-  { roots = SOURCE_ROOTS, limit = DEFAULT_BATCH_SIZE, onProgress = () => {}, combined = true } = {}) {
+  { roots = SOURCE_ROOTS, limit = DEFAULT_BATCH_SIZE, onProgress = () => {}, combined = true, force = false } = {}) {
   const conversion = await prepareSources(vaultRoot)
-  const { pending, oversized, empty } = collectPendingSources(vaultRoot, { roots })
+  const { pending, oversized, empty } = collectPendingSources(vaultRoot, { roots, force })
   const batch = pending.slice(0, limit)
 
   const hatched = []
@@ -588,9 +595,9 @@ async function hatchAllSources (vaultRoot = DEFAULT_VAULT_ROOT,
  *            whiteboard?: true}}
  */
 async function proposeNextPending (vaultRoot = DEFAULT_VAULT_ROOT,
-  { roots = SOURCE_ROOTS, limit = DEFAULT_BATCH_SIZE, skip = 0, combined = true } = {}) {
+  { roots = SOURCE_ROOTS, limit = DEFAULT_BATCH_SIZE, skip = 0, combined = true, force = false } = {}) {
   await prepareSources(vaultRoot)
-  const { pending } = collectPendingSources(vaultRoot, { roots })
+  const { pending } = collectPendingSources(vaultRoot, { roots, force })
   const capped = pending.slice(0, limit)
   const file = capped[skip]
   if (!file) return { done: true }

--- a/scripts/lib/pages.js
+++ b/scripts/lib/pages.js
@@ -69,6 +69,29 @@ function findSourceHubByPath (source, vaultRoot = DEFAULT_VAULT_ROOT) {
 }
 
 /**
+ * The set of coop-relative source paths that have already been hatched —
+ * every document whose trace hub exists in nest/sources/ with a matching
+ * `source:` frontmatter. Unlike `hatched_sources` (a .roost/meta.db cache that
+ * lives on ONE device and is not what Dropbox syncs), the nest is synced graph
+ * markdown, so this is the cross-device-authoritative "already hatched" signal:
+ * a source hatched on device A is recognized as hatched on device B after a
+ * sync, and is not re-hatched.
+ */
+function hatchedSourcePaths (vaultRoot = DEFAULT_VAULT_ROOT) {
+  const out = new Set()
+  const dir = path.join(vaultRoot, 'nest', 'sources')
+  if (!fs.existsSync(dir)) return out
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.endsWith('.md')) continue
+    try {
+      const { data } = matter(fs.readFileSync(path.join(dir, f), 'utf8'))
+      if (typeof data.source === 'string' && data.source.trim()) out.add(data.source.trim())
+    } catch { /* an unreadable page is not a hub */ }
+  }
+  return out
+}
+
+/**
  * Decides whether `title` should become a new nest page or an update to an
  * existing near-duplicate (per coop/schema.md's duplicate-prevention rule),
  * and writes the markdown file either way.
@@ -158,4 +181,4 @@ function resolvePage ({ type, title, body, tags = [], vaultRoot = DEFAULT_VAULT_
   return { action: 'create', slug, path: relPath, type, tags }
 }
 
-module.exports = { resolvePage, nextFreeSlug, sourceHubMustCreate, findSourceHubByPath, SIMILARITY_THRESHOLD }
+module.exports = { resolvePage, nextFreeSlug, sourceHubMustCreate, findSourceHubByPath, hatchedSourcePaths, SIMILARITY_THRESHOLD }

--- a/scripts/migrate-eggs-to-pages.js
+++ b/scripts/migrate-eggs-to-pages.js
@@ -12,11 +12,40 @@
 const fs = require('node:fs')
 const path = require('node:path')
 const crypto = require('node:crypto')
+const matter = require('gray-matter')
 const { DEFAULT_VAULT_ROOT, pagesPath } = require('./lib/paths')
 const { openDb } = require('./lib/db')
 
 function sha1 (buf) {
   return crypto.createHash('sha1').update(buf).digest('hex')
+}
+
+/** Rewrite an old coop-relative path (`eggs/x.md`) to its new one in every
+ *  nest page's `source:` frontmatter and `Source file: \`…\`` body line, so a
+ *  trace hub keeps pointing at its document after the move. collectPendingSources
+ *  treats that frontmatter as the authoritative "already hatched" signal — a
+ *  stale `source:` would make a migrated source re-hatch at its new location.
+ */
+function rewriteNestSource (vaultRoot, fromPath, toPath) {
+  const nestDir = path.join(vaultRoot, 'nest')
+  if (!fs.existsSync(nestDir)) return
+  const stack = [nestDir]
+  while (stack.length) {
+    const dir = stack.pop()
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name)
+      if (entry.isDirectory()) { stack.push(p); continue }
+      if (!entry.name.endsWith('.md')) continue
+      try {
+        const parsed = matter(fs.readFileSync(p, 'utf8'))
+        let changed = false
+        if (parsed.data.source === fromPath) { parsed.data.source = toPath; changed = true }
+        const body = parsed.content.split(`\`${fromPath}\``).join(`\`${toPath}\``)
+        if (body !== parsed.content) changed = true
+        if (changed) fs.writeFileSync(p, matter.stringify(body, parsed.data))
+      } catch { /* an unreadable page isn't a hub */ }
+    }
+  }
 }
 
 function migrate (vaultRoot = DEFAULT_VAULT_ROOT) {
@@ -41,25 +70,28 @@ function migrate (vaultRoot = DEFAULT_VAULT_ROOT) {
       const target = path.join(sourcesDir, name)
       if (fs.existsSync(target)) {
         if (sha1(fs.readFileSync(target)) === eggHash) {
-          // Identical — the pages/ copy is canonical; drop the duplicate.
-          fs.rmSync(src)
-          deduped.push(name)
-          db.prepare('DELETE FROM hatched_sources WHERE path = ?').run(`eggs/${name}`)
-          continue
-        }
-        // Same name, different content — keep both by suffixing the egg copy.
-        const ext = path.extname(name)
-        const altName = `${path.basename(name, ext)}-egg${ext}`
-        fs.renameSync(src, path.join(sourcesDir, altName))
-        conflicts.push({ from: name, to: altName })
-        db.prepare('UPDATE hatched_sources SET path = ? WHERE path = ?').run(`pages/${altName}`, `eggs/${name}`)
+        // Identical — the pages/ copy is canonical; drop the duplicate.
+        fs.rmSync(src)
+        deduped.push(name)
+        db.prepare('DELETE FROM hatched_sources WHERE path = ?').run(`eggs/${name}`)
+        rewriteNestSource(vaultRoot, `eggs/${name}`, `pages/${name}`)
         continue
       }
-
-      fs.renameSync(src, target)
-      moved.push(name)
-      db.prepare('UPDATE hatched_sources SET path = ? WHERE path = ?').run(`pages/${name}`, `eggs/${name}`)
+      // Same name, different content — keep both by suffixing the egg copy.
+      const ext = path.extname(name)
+      const altName = `${path.basename(name, ext)}-egg${ext}`
+      fs.renameSync(src, path.join(sourcesDir, altName))
+      conflicts.push({ from: name, to: altName })
+      db.prepare('UPDATE hatched_sources SET path = ? WHERE path = ?').run(`pages/${altName}`, `eggs/${name}`)
+      rewriteNestSource(vaultRoot, `eggs/${name}`, `pages/${altName}`)
+      continue
     }
+
+    fs.renameSync(src, target)
+    moved.push(name)
+    db.prepare('UPDATE hatched_sources SET path = ? WHERE path = ?').run(`pages/${name}`, `eggs/${name}`)
+    rewriteNestSource(vaultRoot, `eggs/${name}`, `pages/${name}`)
+  }
 
     if (fs.readdirSync(eggsDir).length === 0) fs.rmdirSync(eggsDir)
   } finally {

--- a/scripts/test/hatch.test.js
+++ b/scripts/test/hatch.test.js
@@ -131,6 +131,31 @@ test('collectPendingSources: no source dirs -> everything empty', () => {
   }
 })
 
+test('collectPendingSources: skips a source whose trace hub exists (Dropbox-sync idempotency)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+  // A source hatched on another device: the source file AND its trace hub
+  // synced over, but this device's hatched_sources cache is empty (it isn't
+  // what Dropbox syncs — the nest is).
+  fs.writeFileSync(path.join(root, 'pages', 'report.md'), 'a report with real content worth hatching')
+  const hub = [
+    '---', 'type: source', 'source: pages/report.md',
+    'created: 2026-01-01', 'updated: 2026-01-01', 'tags: []', '---',
+    '', '## Source', '', '- Source file: `pages/report.md`', ''
+  ].join('\n')
+  fs.writeFileSync(path.join(root, 'nest', 'sources', 'report.md'), hub)
+
+  // No hatched_sources row — this device never hatched it locally. The trace
+  // hub is the cross-device signal that it's already hatched, so it's skipped.
+  let { pending } = collectPendingSources(root)
+  assert.deepEqual(pending, [])
+
+  // A manual re-hatch (--force) still picks it up.
+  ;({ pending } = collectPendingSources(root, { force: true }))
+  assert.deepEqual(pending.map((p) => p.relPath), ['pages/report.md'])
+})
+
 test('prepareSources: unsupported formats become a reference-only .md stub (idempotent)', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))
@@ -165,6 +190,9 @@ test('migrate-eggs-to-pages: moves files, dedupes identical copies, rewrites hat
   // a source that was already hatched (has a hatched_sources row)
   fs.writeFileSync(path.join(root, 'eggs', 'clipping.md'), 'a source with content')
   recordHatchedSource('eggs/clipping.md', hashContent('a source with content'), root)
+  // …and its trace hub names the old eggs/ path (frontmatter + body)
+  fs.writeFileSync(path.join(root, 'nest', 'sources', 'clipping.md'),
+    '---\ntype: source\nsource: eggs/clipping.md\ncreated: 2026-01-01\nupdated: 2026-01-01\ntags: []\n---\n## Source\n\n- Source file: `eggs/clipping.md`\n')
 
   // an identical duplicate already in pages/
   fs.writeFileSync(path.join(root, 'pages', 'dup.md'), 'duplicate content')
@@ -188,6 +216,16 @@ test('migrate-eggs-to-pages: moves files, dedupes identical copies, rewrites hat
   const { hatchedSourceHashes } = require('../lib/roost')
   assert.ok(hatchedSourceHashes(root).has('pages/clipping.md'))
   assert.ok(!hatchedSourceHashes(root).has('eggs/clipping.md'))
+
+  // the trace hub's `source:` frontmatter + body reference moved too → the
+  // 0.4.8 trace-hub idempotency check still recognizes it as already hatched
+  const { hatchedSourcePaths } = require('../lib/pages')
+  assert.ok(hatchedSourcePaths(root).has('pages/clipping.md'))
+  assert.ok(!hatchedSourcePaths(root).has('eggs/clipping.md'))
+  const hub = fs.readFileSync(path.join(root, 'nest', 'sources', 'clipping.md'), 'utf8')
+  assert.ok(hub.includes('source: pages/clipping.md'))
+  assert.ok(hub.includes('`pages/clipping.md`'))
+  assert.ok(!hub.includes('eggs/clipping.md'))
 })
 
 test('commitHatchPlan: regenIndex:false skips the index.md rewrite (batch callers regen once)', async (t) => {
@@ -410,7 +448,9 @@ test('#114 does not touch source pages: a re-hatched source hub still uses its d
     return gen()
   })
   try {
-    await hatchAllSources(root, { limit: 1 })
+    // A re-hatch is now opt-in (--force): by default a file with a trace hub
+    // is left alone. Force it here to exercise the source-hub update path.
+    await hatchAllSources(root, { limit: 1, force: true })
     assert.deepEqual(kinds, ['draft'], 'no existing-content generate call for a source-type update')
   } finally { s.restore() }
 })


### PR DESCRIPTION
Fixes the Dropbox-sync re-hatch bug.

## Root cause
Hatch idempotency was keyed only on `hatched_sources` — a `.roost/meta.db` hash cache that lives on **one device**. Dropbox syncs the graph markdown (pages/, journals/, nest/) but not that cache, so a source hatched on device A looked brand-new on device B and got re-hatched, colliding with the synced nest pages (`similar file already exists` / `Page already exists`).

## Fix
- Key the skip on the **synced nest** instead: a source whose trace hub exists in `nest/sources/` with a matching `source:` frontmatter is already hatched and is skipped — that's the cross-device-authoritative signal. New `hatchedSourcePaths()` in `lib/pages.js`; wired into `collectPendingSources`.
- A manual re-hatch is still possible via `hatch-all.js --force` (threaded through `--preview`, batch, and propose-next flows).
- `migrate-eggs-to-pages.js` now also rewrites the `source:` frontmatter (and `Source file:` body line) when it moves a file, so a migrated source doesn't re-hatch at its new location.

## Tests
Full suite `npm test` 338/338. Adds coverage for: skip-on-trace-hub (sync idempotency), `--force` re-hatch, and the migration's frontmatter rewrite. One existing #114 test updated to force its re-hatch (re-hatch is now opt-in).