### PR TITLE
peck: expose answer evidence — dead citations + ## Sources (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ The retrieval layer (this repo) and the desktop app
   `nest/` file is touched, so groom stays read-only to your notes. A filed
   Peck answer also mirrors its summary into frontmatter so `rebuild-roost`
   keeps it instead of degrading to `**Q:** …`.
+- **Answer evidence** (kip-app#117) — `peckTurn` now also returns
+  `deadCitations` (`[[links]]` in the answer that resolve to no page
+  anywhere, journal dates excluded), so the app can flag a hallucinated
+  citation instead of rendering it as a silent dead link. `fileAnswerToNest`
+  appends a `## Sources` section listing the retrieved pages the answer
+  didn't cite, so a filed answer carries its full evidence set.
 
 ## [0.4.9] — 2026-09-03
 

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -188,6 +188,22 @@ function humanizeSlug (slug) {
   return String(slug).replace(/-+/g, ' ').trim()
 }
 
+/** date-shaped ([[2026-08-26]]) is a valid Logseq journal ref, not a nest slug. */
+const DATE_SLUG_RE = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * [[wikilink]] targets in the answer that resolve to no nest page at all
+ * (kip-app#117). extractCitedSlugs only sees hallucinations *relative to the
+ * candidate set*; a link to a slug that exists nowhere renders as a silent
+ * dead link in the app and even shadows Logseq's page/create fallback. Journal
+ * date refs are excluded.
+ */
+function deadCitationSlugs (answerText, candidateSlugs, vaultRoot) {
+  const candidates = new Set(candidateSlugs)
+  return [...new Set(extractWikilinkSlugs(answerText))]
+    .filter((s) => s && !candidates.has(s) && !DATE_SLUG_RE.test(s) && !getPage(s, vaultRoot))
+}
+
 /** Groom's findings map (.roost/lint.json, written by every groom run,
  *  kip-app#116). Read-only: Peck consults it, never writes it. Returns {} when
  *  the file is absent or unparseable — a nest that has never been groomed just
@@ -256,13 +272,22 @@ function knownConflictsFor (vaultRoot, candidateSlugs) {
 async function fileAnswerToNest (question, answer, candidateSlugs, vaultRoot = DEFAULT_VAULT_ROOT, { log = true } = {}) {
   const trimmed = question.trim()
 
+  // The retrieved pages the answer did NOT cite inline — appended as a
+  // `## Sources` note so a filed answer carries its full evidence set, not
+  // just the model's picks (kip-app#117).
+  const citedInline = new Set(extractWikilinkSlugs(answer))
+  const alsoRetrieved = (candidateSlugs || []).filter((s) => !citedInline.has(s))
+  const sourcesBlock = alsoRetrieved.length
+    ? `\n\n## Sources\n\nAlso retrieved, not cited: ${alsoRetrieved.map((s) => `[[${s}]]`).join(', ')}`
+    : ''
+
   const result = resolvePage({
     type: 'concept', // a peck answer is a synthesized note; closest fit of
                       // the three page types. Existing-page updates keep
                       // whatever type the matched page already has.
     title: trimmed, // matched on the full question; the derived slug is
                     // capped by resolvePage, so old filed answers still resolve
-    body: `**Q:** ${question}\n\n${answer}`,
+    body: `**Q:** ${question}\n\n${answer}${sourcesBlock}`,
     tags: ['from-peck'],
     mergeTags: true, // survive updates onto an existing page (kip-app#113)
     vaultRoot
@@ -363,6 +388,8 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   }
 
   const citedSlugs = answer ? extractCitedSlugs(answer, candidateSlugs) : []
+  // [[links]] in the answer that point at no page anywhere (kip-app#117)
+  const deadCitations = answer ? deadCitationSlugs(answer, candidateSlugs, vaultRoot) : []
   // groom's findings for the pages this answer actually leaned on (kip-app#116)
   const lintWarnings = lintWarningsFor(vaultRoot, citedSlugs)
   if (fileToNest && answer && !webbed) {
@@ -380,7 +407,7 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   // (kip-app#81) — the app shows a "save these" affordance on the answer.
   const webSource = buildWebSource(question, webSearches);
   const sources = citedSlugs.map((slug) => ({ slug, title: humanizeSlug(slug) }))
-  return { answer: answer ? stripSources(answer) : answer, sources, citedSlugs, candidateSlugs, lintWarnings, steps, callId, arenaId, webSource: webSource || null }
+  return { answer: answer ? stripSources(answer) : answer, sources, citedSlugs, candidateSlugs, deadCitations, lintWarnings, steps, callId, arenaId, webSource: webSource || null }
 }
 
 /**
@@ -475,7 +502,7 @@ function fileCapturedFacts (proposedPages, vaultRoot = DEFAULT_VAULT_ROOT) {
  * same question — routes the answer call through the managed backend's arena
  * as candidate B (the regenerate free-rider, kip-app#73).
  *
- * @returns {{answer: string|null, citedSlugs: string[], candidateSlugs: string[], lintWarnings: Array<{slug,kind,note}>, steps: Array, callId: string|null, arenaId: string|null}}
+ * @returns {{answer: string|null, citedSlugs: string[], candidateSlugs: string[], lintWarnings: Array<{slug,kind,note}>, deadCitations: string[], steps: Array, callId: string|null, arenaId: string|null}}
  */
 async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_VAULT_ROOT, arenaCompareToCallId = null, history = [], onStream = null } = {}) {
   const candidates = await retrieveCandidates(question, vaultRoot, { history })
@@ -493,9 +520,9 @@ async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_V
  * filed); a statement is always filed — that's the point.
  *
  * @returns {{intent: 'question'|'statement'|'reminder', ...}}
- *   question:  { answer: string|null, sources, citedSlugs, candidateSlugs, lintWarnings, steps }
+ *   question:  { answer: string|null, sources, citedSlugs, candidateSlugs, deadCitations, lintWarnings, steps }
  *   statement: { learned: boolean, note: string, pages?: [{action,slug,path}], candidateSlugs }
- *   reminder:  { answer: string|null, sources, citedSlugs, candidateSlugs, lintWarnings, steps } — same
+ *   reminder:  { answer: string|null, sources, citedSlugs, candidateSlugs, deadCitations, lintWarnings, steps } — same
  *              shape as question; the `reminders` skill did the work and its
  *              confirmation is in `answer`.
  */
@@ -528,4 +555,4 @@ async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = f
   return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena, history, onStream })) }
 }
 
-module.exports = { askQuestion, peckTurn, classifyPeckInput, fileAnswerToNest, fileCapturedFacts, extractCitedSlugs, stripSources, humanizeSlug, lintWarningsFor, knownConflictsFor }
+module.exports = { askQuestion, peckTurn, classifyPeckInput, fileAnswerToNest, fileCapturedFacts, extractCitedSlugs, stripSources, humanizeSlug, deadCitationSlugs, lintWarningsFor, knownConflictsFor }

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -1115,3 +1115,56 @@ test('fileAnswerToNest mirrors the summary into frontmatter so a rebuild keeps i
   rebuildRoost(root)
   assert.equal(getPage(filed.slug, root).summary, 'what is the atlas deadline?')
 })
+
+test('answer evidence: dead citations and the ## Sources section (kip-app#117)', async (t) => {
+  const { deadCitationSlugs } = require('../lib/peck')
+
+  await t.test('deadCitationSlugs: [[links]] that resolve to no page, excluding candidates and journal dates', () => {
+    const root = makeTempVault()
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+    writePage(root, 'concepts', 'sleep-hygiene', { type: 'concept', body: 'notes' })
+    rebuildRoost(root)
+
+    const answer = 'Per [[sleep-hygiene]] and [[ghost-page]], and on [[2026-08-26]] you noted [[another-ghost]].'
+    assert.deepEqual(deadCitationSlugs(answer, ['sleep-hygiene'], root).sort(), ['another-ghost', 'ghost-page'])
+    // a cited page that IS a candidate is never "dead"
+    assert.deepEqual(deadCitationSlugs('see [[sleep-hygiene]]', ['sleep-hygiene'], root), [])
+  })
+
+  await t.test('askQuestion returns deadCitations for a hallucinated link', async () => {
+    const root = makeTempVault()
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+    writePage(root, 'concepts', 'sleep-hygiene', { type: 'concept', tags: ['health'], body: 'Consistent bedtime.' })
+    rebuildRoost(root)
+    saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+
+    const s = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep-hygiene]] and [[sleep-lab-results]], sleep well.' })
+    try {
+      const r = await askQuestion('what about sleep?', { vaultRoot: root, fileToNest: false })
+      assert.deepEqual(r.citedSlugs, ['sleep-hygiene'])
+      assert.deepEqual(r.deadCitations, ['sleep-lab-results'])
+    } finally { s.restore() }
+  })
+
+  await t.test('fileAnswerToNest appends a ## Sources section for retrieved-but-uncited pages', async () => {
+    const root = makeTempVault()
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+    const filed = await fileAnswerToNest(
+      'what is the plan?',
+      'The plan is X, per [[plan-doc]].',
+      ['plan-doc', 'meeting-notes', 'old-draft'],
+      root)
+    const raw = fs.readFileSync(path.join(root, filed.path), 'utf8')
+    assert.match(raw, /## Sources\n\nAlso retrieved, not cited: \[\[meeting-notes\]\], \[\[old-draft\]\]/)
+    assert.doesNotMatch(raw, /Also retrieved.*plan-doc/, 'the cited page is not repeated in Sources')
+  })
+
+  await t.test('no ## Sources section when every candidate was cited', async () => {
+    const root = makeTempVault()
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+    const filed = await fileAnswerToNest('q?', 'A, per [[only-page]].', ['only-page'], root)
+    const raw = fs.readFileSync(path.join(root, filed.path), 'utf8')
+    assert.doesNotMatch(raw, /## Sources/)
+  })
+})


### PR DESCRIPTION
Closes #117.

`peckTurn` returned `citedSlugs`/`candidateSlugs` but the app dropped them, and a `[[link]]` to a slug that exists nowhere rendered as a silent dead link (`extractCitedSlugs` only sees hallucinations relative to the candidate set).

- `deadCitationSlugs()`: `[[links]]` in the answer that resolve to no nest page at all, journal date refs and candidates excluded. Returned as `deadCitations` on the turn result.
- `fileAnswerToNest` appends a `## Sources` section listing candidate pages the answer did not cite inline, so a filed answer carries its full evidence set, not just the model's picks.

Display of cited-vs-retrieved and the dead-link flag is the kip-app side (separate PR).