### PR TITLE
peck: read the index first, then descend only where it points (kip-app#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ The retrieval layer (this repo) and the desktop app
   citation instead of rendering it as a silent dead link. `fileAnswerToNest`
   appends a `## Sources` section listing the retrieved pages the answer
   didn't cite, so a filed answer carries its full evidence set.
+- **Peck reads the index first, then descends only where it points** (the
+  LLM-wiki Query rule, kip-app#106) — a question turn now runs an LLM-owned
+  selection round: the model sees the question plus the candidate index
+  (one line per page — slug and its one-line summary) and chooses which pages
+  to open, and only those are read into the answer prompt. A failed or empty
+  selection falls back to the full candidate set, and "thin retrieval" (the
+  skills/web trigger) is now judged from the recall count, not the narrowed
+  selection.
 
 ## [0.4.9] — 2026-09-03
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -262,8 +262,12 @@ a **statement**.
    finds only a few hits, a second pass runs on key terms an LLM extracts
    from the question, unioned in for recall; when the direct search already
    found enough, the second pass (and its LLM call) is skipped.
-2. Read only the matched pages — each passed to the model with its one-line
-   index summary above the body (§5.1), not just the raw text.
+2. **Read the index first, then descend only where it points** (the LLM-wiki
+   Query rule, kip-app#106). The model is handed the question plus the
+   candidate *index* — one line per page, its slug and one-line `summary`
+   (§5.1) — and returns the slugs it needs to read. Only those pages are then
+   read from disk and passed to the answer; a failed or empty selection falls
+   back to the full candidate set.
 3. Ask the LLM for an answer that cites every claim with `[[slug]]`
    wikilinks. A citation resolves to a `nest/` page, and that page carries
    `source:` frontmatter pointing at the source it was hatched from (§5.1) — so

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -18,7 +18,7 @@ const matter = require('gray-matter')
 
 const { searchPages, upsertPage, regenerateIndexMd, appendLog, extractWikilinkSlugs, getPage } = require('./roost')
 const { resolvePage } = require('./pages')
-const { extractKeyTerms, answerQuestion, answerQuestionWithSkills, answerFromWeb, isNoAnswer, captureFacts } = require('./prompts')
+const { extractKeyTerms, selectPages, answerQuestion, answerQuestionWithSkills, answerFromWeb, isNoAnswer, captureFacts } = require('./prompts')
 const { discoverSkills, runSkill } = require('./skills')
 const { buildWebSource, parseWebSearchOutput } = require('./web-sources')
 const { looksLikeReminder } = require('./reminders')
@@ -166,6 +166,30 @@ async function retrieveCandidates (question, vaultRoot, { history = [] } = {}) {
     if (!bySlug.has(p.slug)) bySlug.set(p.slug, p)
   }
   return [...bySlug.values()]
+}
+
+/**
+ * The LLM-owned "index-first" selection step (the vault's Query rule,
+ * kip-app#106): hand the model the question plus the candidate INDEX (slug +
+ * one-line summary) and let it choose which pages to descend into. Only the
+ * chosen pages are read and passed to the answer — instead of the caller
+ * dumping every recall hit's full body. A failed/empty selection falls back to
+ * the full candidate set, so a weak model or a malformed reply never loses
+ * recall. No-op for < 2 candidates (a single hit needs no selection).
+ */
+async function selectCandidates (question, candidates, vaultRoot, { history = [] } = {}) {
+  if (!candidates || candidates.length < 2) return candidates
+  let selected
+  try {
+    selected = await selectPages(question, candidates, vaultRoot, { history })
+  } catch (err) {
+    console.error(`Warning: page selection failed (${err.message}); using the full candidate set.`)
+    return candidates
+  }
+  if (!Array.isArray(selected) || selected.length === 0) return candidates
+  const bySlug = new Map(candidates.map((c) => [c.slug, c]))
+  const chosen = selected.filter((s) => bySlug.has(s)).map((s) => bySlug.get(s))
+  return chosen.length ? chosen : candidates
 }
 
 /** Which of the candidate pages the answer actually cited via [[wikilink]] syntax. */
@@ -326,7 +350,7 @@ async function fileAnswerToNest (question, answer, candidateSlugs, vaultRoot = D
  * can call them mid-answer — `steps` records what it ran. Skill discovery and
  * the whole tool loop are best-effort: a failure downgrades to a plain answer.
  */
-async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena = null, history = [], onStream = null }) {
+async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena = null, history = [], onStream = null, retrievedCount = null }) {
   const candidateSlugs = pages.map((p) => p.slug)
   const telemetryStart = telemetry.entries().length
 
@@ -340,9 +364,13 @@ async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena 
   // The skills tool loop adds a bigger system prompt and, when a skill runs,
   // extra round-trips. Only take that path — or even look for skills — when
   // one is plausibly needed; otherwise answer straight from the nest. A miss
-  // is recoverable with the Regenerate button.
+  // is recoverable with the Regenerate button. `retrievedCount` is the number
+  // of FTS recall hits BEFORE the index-first selection (kip-app#106): "thin
+  // retrieval" is a property of the recall, not of the (possibly precise)
+  // selection, so a question the model narrowed to one page doesn't spuriously
+  // trigger the skills path.
   let skills = []
-  if (!arena && mightNeedSkill(question, pages.length)) {
+  if (!arena && mightNeedSkill(question, retrievedCount == null ? pages.length : retrievedCount)) {
     try {
       skills = discoverSkills(vaultRoot)
     } catch (err) {
@@ -509,9 +537,10 @@ async function askQuestion (question, { fileToNest = true, vaultRoot = DEFAULT_V
   if (candidates.length === 0 && !anySkills(vaultRoot)) {
     return { answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
   }
-  const pages = readPageBodies(vaultRoot, candidates)
+  const selected = await selectCandidates(question, candidates, vaultRoot, { history })
+  const pages = readPageBodies(vaultRoot, selected)
   const arena = arenaCompareToCallId ? { compareToCallId: arenaCompareToCallId } : null
-  return answerFromPages(question, pages, { fileToNest, vaultRoot, arena, history, onStream })
+  return answerFromPages(question, pages, { fileToNest, vaultRoot, arena, history, onStream, retrievedCount: candidates.length })
 }
 
 /**
@@ -535,10 +564,14 @@ async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = f
   }
 
   const candidates = await retrieveCandidates(input, vaultRoot, { history })
-  const pages = readPageBodies(vaultRoot, candidates)
-  const candidateSlugs = pages.map((p) => p.slug)
 
+  // A statement (a fact to file) needs the full candidate set so captureFacts
+  // can route it onto the right existing page; a question runs the LLM-owned
+  // index-first selection (the vault's Query rule) and reads only the chosen
+  // pages.
   if (classifyPeckInput(input, history) === 'statement') {
+    const pages = readPageBodies(vaultRoot, candidates)
+    const candidateSlugs = pages.map((p) => p.slug)
     const capture = await captureFacts(input, pages, vaultRoot)
     const results = capture.learned ? fileCapturedFacts(capture.pages, vaultRoot) : []
     const touched = [...new Set(results.map((r) => r.slug))]
@@ -548,11 +581,15 @@ async function peckTurn (input, { vaultRoot = DEFAULT_VAULT_ROOT, fileToNest = f
       : { intent: 'statement', learned: false, note: capture.note || 'Nothing new to record.', candidateSlugs }
   }
 
+  const selected = await selectCandidates(input, candidates, vaultRoot, { history })
+  const pages = readPageBodies(vaultRoot, selected)
+  const candidateSlugs = pages.map((p) => p.slug)
+
   if (pages.length === 0 && !anySkills(vaultRoot)) {
     return { intent: 'question', answer: null, citedSlugs: [], candidateSlugs: [], steps: [] }
   }
   const arena = arenaCompareToCallId ? { compareToCallId: arenaCompareToCallId } : null
-  return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena, history, onStream })) }
+  return { intent: 'question', ...(await answerFromPages(input, pages, { fileToNest, vaultRoot, arena, history, onStream, retrievedCount: candidates.length })) }
 }
 
 module.exports = { askQuestion, peckTurn, classifyPeckInput, fileAnswerToNest, fileCapturedFacts, extractCitedSlugs, stripSources, humanizeSlug, deadCitationSlugs, lintWarningsFor, knownConflictsFor }

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -56,6 +56,32 @@ async function extractKeyTerms (question, vaultRoot, { history = [] } = {}) {
   }
 }
 
+/**
+ * The LLM-owned "read the index, then descend only where it points" step — the
+ * vault's Query rule (kip-app#106). The model is given the question plus the
+ * wiki INDEX (one line per page: slug + its one-line summary) and returns the
+ * slugs it needs to read. This is the LLM deciding what to open, instead of the
+ * caller dumping every FTS recall hit into the answer prompt. Returns a slug
+ * array, or undefined when it cannot decide (callers fall back to the full set).
+ */
+async function selectPages (question, index, vaultRoot, { history = [] } = {}) {
+  const convo = formatConversation(history)
+  const indexBlock = index
+    .map((p) => {
+      const label = (p.summary && String(p.summary).trim()) ||
+        (p.snippet ? `…${String(p.snippet).replace(/\s+/g, ' ').trim()}…` : '')
+      return `- ${p.slug}${label ? ` — ${label}` : ''}`
+    })
+    .join('\n')
+  const system = 'You are choosing which pages of a personal wiki to read in order to answer a question. ' +
+    'You are shown the wiki index: one line per page — its slug and a one-line summary of what it is about. ' +
+    'Select the pages whose summaries indicate they could hold the answer. Prefer precision: choose only the pages you actually need to read; choose none if none look relevant. ' +
+    'Respond with a JSON object of exactly this shape: {"slugs": ["slug-1", "slug-2", ...]}.'
+  const prompt = (convo ? `${convo}\n\n` : '') + `Question: ${question}\n\nIndex:\n${indexBlock}`
+  return jsonCall({ system, prompt, maxTokens: 2048, label: 'peck:select-pages', vaultRoot }, (parsed) =>
+    Array.isArray(parsed.slugs) ? parsed.slugs : undefined)
+}
+
 function formatPagesForPrompt (pages) {
   return pages
     .map((p) => {
@@ -691,6 +717,7 @@ async function captureFacts (input, existingPages, vaultRoot) {
 
 module.exports = {
   extractKeyTerms,
+  selectPages,
   answerQuestion,
   answerFromWeb,
   isNoAnswer,

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -21,6 +21,7 @@ function stubPeckFetch (routes) {
     calls.push(sys)
     let content = '{}'
     if (/key search terms/.test(sys)) content = routes.keyTerms || '{"terms": []}'
+    else if (/choosing which pages/.test(sys)) content = routes.select || '{"slugs": []}'
     else if (/planning which skills/.test(sys)) content = routes.plan || '{"calls": []}'
     else if (/told their personal wiki a fact/.test(sys)) content = routes.capture
     else if (routes.answerFn) content = routes.answerFn(sys, calls.length)
@@ -1101,6 +1102,56 @@ test('the summary layer reaches the answer prompt (kip-app#115)', async (t) => {
       assert.doesNotMatch(answerCall, /Summary:/)
     } finally { s.restore() }
   })
+})
+
+test('peckTurn — the LLM selects from the index before answering (index-first, kip-app#106)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'concepts', 'sleep-hygiene', { type: 'concept', body: 'Consistent bedtime; no screens after 22:00.' })
+  writePage(root, 'concepts', 'sleep-quality', { type: 'concept', body: 'Deeper, more restful sleep.' })
+  rebuildRoost(root)
+
+  const s = stubPeckFetch({
+    keyTerms: '{"terms":["sleep"]}',
+    select: '{"slugs":["sleep-hygiene"]}',
+    answer: 'Per [[sleep-hygiene]], rest more.'
+  })
+  try {
+    const r = await peckTurn('what about sleep?', { vaultRoot: root })
+    assert.equal(r.answer, 'Per [[sleep-hygiene]], rest more.')
+
+    // round 1: the model saw the index (both slugs) before choosing
+    const selectCall = s.calls.find((c) => /choosing which pages/.test(c))
+    assert.ok(selectCall && /sleep-hygiene/.test(selectCall) && /sleep-quality/.test(selectCall),
+      'the selection prompt listed the candidate index')
+
+    // round 2: only the chosen page was read into the answer prompt
+    const answerCall = s.calls.find((c) => /You are answering a question from a personal wiki/.test(c))
+    assert.ok(answerCall && /### Page: sleep-hygiene/.test(answerCall), 'the chosen page was read')
+    assert.ok(answerCall && !/### Page: sleep-quality/.test(answerCall), 'the unselected page was NOT read')
+  } finally { s.restore() }
+})
+
+test('peckTurn — an empty or unusable selection falls back to the full candidate set', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'concepts', 'sleep-hygiene', { type: 'concept', body: 'Consistent bedtime.' })
+  writePage(root, 'concepts', 'sleep-quality', { type: 'concept', body: 'Deeper sleep.' })
+  rebuildRoost(root)
+
+  const s = stubPeckFetch({
+    keyTerms: '{"terms":["sleep"]}',
+    select: '{"slugs":[]}',
+    answer: 'Per [[sleep-hygiene]].'
+  })
+  try {
+    await peckTurn('what about sleep?', { vaultRoot: root })
+    const answerCall = s.calls.find((c) => /You are answering a question from a personal wiki/.test(c))
+    assert.ok(answerCall && /### Page: sleep-hygiene/.test(answerCall) && /### Page: sleep-quality/.test(answerCall),
+      'an empty selection kept every candidate in play')
+  } finally { s.restore() }
 })
 
 test('fileAnswerToNest mirrors the summary into frontmatter so a rebuild keeps it (kip-app#115)', async (t) => {


### PR DESCRIPTION
Implements the vault's Query rule from kip-app#106: **read the wiki index first, then descend into raw items only where the index points.**

A Peck question turn now runs an LLM-owned selection round between retrieval and the answer:

- `prompts.selectPages()` — the model gets the question + the candidate index (one line per page: slug + one-line summary) and returns the slugs it needs to read.
- `peck.selectCandidates()` — reads only the chosen pages into the answer prompt; falls back to the full candidate set on a failed/empty selection, so a weak model or malformed reply never loses recall. Statements still capture over the full candidate set.
- "Thin retrieval" (the skills/web trigger) is now judged from the recall count, not the narrowed selection, so a precise one-page selection doesn't spuriously enter the skills tool loop.

This is a deliberate move from deterministic-FTS-only retrieval toward the LLM owning the index read + descent decision. Cost: one extra selection call per multi-candidate question (skipped when a single page matches).

Tests: 350 pass (two new — selection narrows the read set; empty selection falls back to the full set).