### PR TITLE
peck: a per-section index below the page level (kip-app#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ The retrieval layer (this repo) and the desktop app
   selection falls back to the full candidate set, and "thin retrieval" (the
   skills/web trigger) is now judged from the recall count, not the narrowed
   selection.
+- **A per-section index below the page level** (kip-app#106) — every page's
+  body is split into sections on its `##`/`###` headings and `_Update_` blocks
+  (a new `sections` table in `meta.db`, re-derived on every write and rebuild).
+  Each section carries a one-line first-line summary; the selection round and
+  the answer prompt both render a section table of contents, so the model can
+  navigate a long append-grown page at section granularity instead of reading
+  it blind.
 
 ## [0.4.9] — 2026-09-03
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -218,6 +218,14 @@ a nest page is always traceable back to its raw document. A one-line
 of re-deriving a first paragraph) and into `meta.db`, where Peck reads it
 above each page body and a deep Groom refreshes it if it drifts (§5.3).
 
+**The per-section index (kip-app#106):** below the page level, every page's
+body is split into sections on its `##`/`###` headings and `_Update_` blocks
+(a `sections` table in `meta.db`, re-derived on every write and rebuild). Each
+section carries a one-line first-line summary. Peck's selection round and the
+answer prompt both render this as a section table of contents, so the model
+navigates a long append-grown page at section granularity rather than reading
+the whole body blind.
+
 **Classic (`--classic` / the "Classic mode" checkbox):** the older path — one
 `proposeCandidatePages` call, then one `generatePageContent` call *per page*,
 each re-sending the full source. Kept for a side-by-side comparison in the

--- a/scripts/lib/db.js
+++ b/scripts/lib/db.js
@@ -19,6 +19,18 @@ CREATE VIRTUAL TABLE IF NOT EXISTS pages_fts USING fts5(
   body
 );
 
+-- The per-section index (kip-app#106 — index granularity below the page
+-- level). Derived from each page's body by a deterministic heading split; the
+-- 'summary' column is a one-line first-line extract, refined by hatch/groom
+-- later.
+CREATE TABLE IF NOT EXISTS sections (
+  slug    TEXT NOT NULL,
+  seq     INTEGER NOT NULL,
+  heading TEXT NOT NULL,
+  summary TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (slug, seq)
+);
+
 CREATE TABLE IF NOT EXISTS log (
   id            INTEGER PRIMARY KEY AUTOINCREMENT,
   timestamp     TEXT NOT NULL,

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -16,7 +16,7 @@ const fs = require('node:fs')
 const path = require('node:path')
 const matter = require('gray-matter')
 
-const { searchPages, upsertPage, regenerateIndexMd, appendLog, extractWikilinkSlugs, getPage } = require('./roost')
+const { searchPages, upsertPage, regenerateIndexMd, appendLog, extractWikilinkSlugs, getPage, getPageSections } = require('./roost')
 const { resolvePage } = require('./pages')
 const { extractKeyTerms, selectPages, answerQuestion, answerQuestionWithSkills, answerFromWeb, isNoAnswer, captureFacts } = require('./prompts')
 const { discoverSkills, runSkill } = require('./skills')
@@ -122,7 +122,7 @@ function readPageBody (vaultRoot, candidate) {
   // Carry the index's one-line summary through to the answer prompt
   // (kip-app#115) — it's already computed (hatch / a deep groom) and was
   // being dropped here. `summary` is on the searchPages() candidate.
-  return { slug: candidate.slug, path: candidate.path, type: data.type, content: content.trim(), summary: candidate.summary || null }
+  return { slug: candidate.slug, path: candidate.path, type: data.type, content: content.trim(), summary: candidate.summary || null, sections: getPageSections(candidate.slug, vaultRoot) }
 }
 
 /** map candidates -> page bodies, dropping any whose file is missing. */
@@ -181,7 +181,11 @@ async function selectCandidates (question, candidates, vaultRoot, { history = []
   if (!candidates || candidates.length < 2) return candidates
   let selected
   try {
-    selected = await selectPages(question, candidates, vaultRoot, { history })
+    // The selection index is granular (kip-app#106): each candidate also
+    // carries its section index so the model can judge sub-page relevance,
+    // not just the page-level one-liner.
+    const index = candidates.map((c) => ({ ...c, sections: getPageSections(c.slug, vaultRoot) }))
+    selected = await selectPages(question, index, vaultRoot, { history })
   } catch (err) {
     console.error(`Warning: page selection failed (${err.message}); using the full candidate set.`)
     return candidates

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -70,12 +70,18 @@ async function selectPages (question, index, vaultRoot, { history = [] } = {}) {
     .map((p) => {
       const label = (p.summary && String(p.summary).trim()) ||
         (p.snippet ? `…${String(p.snippet).replace(/\s+/g, ' ').trim()}…` : '')
-      return `- ${p.slug}${label ? ` — ${label}` : ''}`
+      const line = `- ${p.slug}${label ? ` — ${label}` : ''}`
+      // Granular sub-index (kip-app#106): list each section's heading + summary
+      // so the model can tell which PART of a large page is relevant.
+      const subs = (p.sections || [])
+        .filter((s) => s.heading)
+        .map((s) => `  - ${s.heading}${s.summary ? ` — ${s.summary}` : ''}`)
+      return subs.length ? [line, ...subs].join('\n') : line
     })
     .join('\n')
   const system = 'You are choosing which pages of a personal wiki to read in order to answer a question. ' +
-    'You are shown the wiki index: one line per page — its slug and a one-line summary of what it is about. ' +
-    'Select the pages whose summaries indicate they could hold the answer. Prefer precision: choose only the pages you actually need to read; choose none if none look relevant. ' +
+    'You are shown the wiki index: one line per page — its slug and a one-line summary of what it is about — and, for longer pages, an indented list of its sections. ' +
+    'Select the pages whose summaries or sections indicate they could hold the answer. Prefer precision: choose only the pages you actually need to read; choose none if none look relevant. ' +
     'Respond with a JSON object of exactly this shape: {"slugs": ["slug-1", "slug-2", ...]}.'
   const prompt = (convo ? `${convo}\n\n` : '') + `Question: ${question}\n\nIndex:\n${indexBlock}`
   return jsonCall({ system, prompt, maxTokens: 2048, label: 'peck:select-pages', vaultRoot }, (parsed) =>
@@ -89,7 +95,13 @@ function formatPagesForPrompt (pages) {
       // a "what this page is" anchor the model would otherwise infer from an
       // append-grown body. ~25 tokens against bodies that run 5k-30k.
       const summary = p.summary && String(p.summary).trim() ? `\nSummary: ${String(p.summary).trim()}` : ''
-      return `### Page: ${p.slug} (type: ${p.type || 'unknown'})${summary}\n${p.content}`
+      // The per-section index (kip-app#106): a compact table of contents so the
+      // model can navigate a long append-grown body instead of reading it blind.
+      const toc = (p.sections || [])
+        .filter((s) => s.heading)
+        .map((s) => `- ${s.heading}${s.summary ? ` — ${s.summary}` : ''}`)
+      const tocBlock = toc.length ? `\nSections:\n${toc.join('\n')}` : ''
+      return `### Page: ${p.slug} (type: ${p.type || 'unknown'})${summary}${tocBlock}\n${p.content}`
     })
     .join('\n\n---\n\n')
 }

--- a/scripts/lib/roost.js
+++ b/scripts/lib/roost.js
@@ -83,7 +83,47 @@ function slugSimilarity (a, b) {
 // "sleep-hygiene" scores ~0.46; unrelated titles score well under 0.3.
 const SIMILARITY_THRESHOLD = 0.45
 
-/** Writes a page's metadata and body into meta.db (pages + pages_fts). */
+/** Splits a page body into sections on `##`/`###` headings and `_Update …`_
+ *  markers — the deterministic structure that already delimits every Kip page
+ *  (kip-app#106 index granularity). Leading content before the first heading
+ *  becomes one section with an empty heading. Returns [{heading, body}]. */
+function splitSections (body) {
+  const lines = String(body || '').split(/\r?\n/)
+  const sections = []
+  let heading = ''
+  let buf = []
+  const flush = () => {
+    const content = buf.join('\n').trim()
+    if (heading || content) sections.push({ heading, body: content })
+    buf = []
+  }
+  for (const line of lines) {
+    const h = line.match(/^#{2,4}\s+(.+?)\s*$/)
+    const u = line.match(/^_Update\s+\d{4}-\d{2}-\d{2}:_$/)
+    if (h || u) {
+      flush()
+      heading = h ? h[1].trim() : line.trim()
+    } else {
+      buf.push(line)
+    }
+  }
+  flush()
+  return sections
+}
+
+/** A one-line first-line summary for a section body (the deterministic
+ *  baseline that hatch/groom refine) — mirror of rebuild-roost's deriveSummary,
+ *  but per-section. */
+function summarizeSection (body) {
+  const line = String(body || '')
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .find((l) => l.length > 0 && !l.startsWith('#'))
+  if (!line) return ''
+  return line.length > 120 ? line.slice(0, 117) + '...' : line
+}
+
+/** Writes a page's metadata and body into meta.db (pages + pages_fts + sections). */
 function upsertPage (slug, filePath, type, tags, summary, body, vaultRoot = DEFAULT_VAULT_ROOT) {
   const now = new Date().toISOString()
   const db = openDb(vaultRoot)
@@ -110,6 +150,12 @@ function upsertPage (slug, filePath, type, tags, summary, body, vaultRoot = DEFA
     })
     db.prepare('DELETE FROM pages_fts WHERE slug = ?').run(slug)
     db.prepare('INSERT INTO pages_fts (slug, body) VALUES (?, ?)').run(slug, body || '')
+    // The per-section index (kip-app#106): re-derived from the body on every
+    // write, so it never drifts from the file. First-line summaries only —
+    // hatch/groom can refine them via setSectionSummary later.
+    db.prepare('DELETE FROM sections WHERE slug = ?').run(slug)
+    const insertSection = db.prepare('INSERT INTO sections (slug, seq, heading, summary) VALUES (?, ?, ?, ?)')
+    splitSections(body).forEach((s, i) => insertSection.run(slug, i, s.heading, summarizeSection(s.body)))
   } finally {
     db.close()
   }
@@ -199,6 +245,16 @@ function getPage (slug, vaultRoot = DEFAULT_VAULT_ROOT) {
   try {
     const row = db.prepare('SELECT slug, path, type, tags, summary, created, updated FROM pages WHERE slug = ?').get(slug)
     return row ? { ...row, tags: JSON.parse(row.tags) } : null
+  } finally {
+    db.close()
+  }
+}
+
+/** One page's section index — [{heading, summary}] in body order (kip-app#106). */
+function getPageSections (slug, vaultRoot = DEFAULT_VAULT_ROOT) {
+  const db = openDb(vaultRoot)
+  try {
+    return db.prepare('SELECT heading, summary FROM sections WHERE slug = ? ORDER BY seq').all(slug)
   } finally {
     db.close()
   }
@@ -344,6 +400,9 @@ module.exports = {
   searchPages,
   findSimilarSlug,
   getPage,
+  getPageSections,
+  splitSections,
+  summarizeSection,
   appendLog,
   regenerateIndexMd,
   recentClucks,

--- a/scripts/rebuild-roost.js
+++ b/scripts/rebuild-roost.js
@@ -56,9 +56,11 @@ function rebuildRoost (vaultRoot = DEFAULT_VAULT_ROOT) {
     const stale = existingSlugs.filter((slug) => !found.has(slug))
     const deletePage = db.prepare('DELETE FROM pages WHERE slug = ?')
     const deleteFts = db.prepare('DELETE FROM pages_fts WHERE slug = ?')
+    const deleteSections = db.prepare('DELETE FROM sections WHERE slug = ?')
     for (const slug of stale) {
       deletePage.run(slug)
       deleteFts.run(slug)
+      deleteSections.run(slug)
     }
   } finally {
     db.close()

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -1154,6 +1154,25 @@ test('peckTurn — an empty or unusable selection falls back to the full candida
   } finally { s.restore() }
 })
 
+test('the per-section index reaches the answer prompt as a section TOC (kip-app#106)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'concepts', 'sleep', {
+    type: 'concept',
+    body: 'Intro line.\n\n## Hygiene\nKeep a consistent bedtime.\n\n## Screens\nNo screens after 22:00.'
+  })
+  rebuildRoost(root)
+
+  const s = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep]], be consistent.' })
+  try {
+    await askQuestion('what about sleep?', { vaultRoot: root, fileToNest: false })
+    const answerCall = s.calls.find((c) => /You are answering a question from a personal wiki/.test(c))
+    assert.match(answerCall, /Sections:\n- Hygiene — Keep a consistent bedtime\./)
+    assert.match(answerCall, /- Screens — No screens after 22:00\./)
+  } finally { s.restore() }
+})
+
 test('fileAnswerToNest mirrors the summary into frontmatter so a rebuild keeps it (kip-app#115)', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))

--- a/scripts/test/roost.test.js
+++ b/scripts/test/roost.test.js
@@ -163,3 +163,35 @@ test('setPageSummary updates only the summary column (kip-app#115)', async (t) =
 
   assert.equal(setPageSummary('no-such-page', 'x', root), false, 'no row -> false')
 })
+
+test('the per-section index — splitSections + summarizeSection (kip-app#106)', async (t) => {
+  const { splitSections, summarizeSection, getPageSections } = require('../lib/roost')
+
+  await t.test('splitSections splits on ## headings and _Update markers, keeping the lead', () => {
+    const body = 'Leading paragraph.\n\n## Sleep hygiene\nConsistent bedtime.\n\n### Screens\nNo screens after 22:00.\n\n---\n_Update 2026-09-04:_\n\nStarted tracking duration.\n'
+    const sections = splitSections(body)
+    assert.deepEqual(sections.map((s) => s.heading), ['', 'Sleep hygiene', 'Screens', '_Update 2026-09-04:_'])
+    assert.match(sections[0].body, /Leading paragraph/)
+    assert.match(sections[1].body, /Consistent bedtime/)
+    assert.match(sections[3].body, /Started tracking duration/)
+  })
+
+  await t.test('summarizeSection takes the first non-heading line, truncated', () => {
+    assert.equal(summarizeSection('The user averages 6 hours.\n\nMore detail here.'), 'The user averages 6 hours.')
+    assert.equal(summarizeSection('# Heading\n\nFirst real line.'), 'First real line.')
+    assert.equal(summarizeSection(''), '')
+  })
+
+  await t.test('upsertPage writes sections; getPageSections reads them in order', () => {
+    const root = makeTempVault()
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+    writePage(root, 'concepts', 'sleep', {
+      type: 'concept',
+      body: 'Intro.\n\n## Hygiene\nKeep a consistent bedtime.\n\n## Screens\nNo screens late.'
+    })
+    rebuildRoost(root)
+    const sections = getPageSections('sleep', root)
+    assert.deepEqual(sections.map((s) => s.heading), ['', 'Hygiene', 'Screens'])
+    assert.equal(sections[1].summary, 'Keep a consistent bedtime.')
+  })
+})


### PR DESCRIPTION
Index granularity (kip-app#106) — the synthesis unit goes from *page* to *section*.

- A new `sections` table in `meta.db` splits every page body on its `##`/`###` headings and `_Update_ …_` blocks, each with a one-line first-line summary.
- Deterministic (no LLM cost): `roost.splitSections()` + `summarizeSection()`, re-derived on every write and `rebuild-roost`, so it never drifts from the file.
- Surfaced in both the LLM-owned selection index and the answer prompt as a section table of contents, so the model navigates a long append-grown page at section granularity instead of reading the whole body blind.

This is the foundation for LLM-refined section summaries (hatch/groom) and section-level retrieval/citation as follow-ups.

Tests: 355 pass (5 new — splitter, summarizer, sections write/read, and the section TOC in the answer prompt).