### PR TITLE
peck: LLM section summaries at hatch (kip-app#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,10 @@ The retrieval layer (this repo) and the desktop app
 - **A per-section index below the page level** (kip-app#106) — every page's
   body is split into sections on its `##`/`###` headings and `_Update_` blocks
   (a new `sections` table in `meta.db`, re-derived on every write and rebuild).
-  Each section carries a one-line first-line summary; the selection round and
-  the answer prompt both render a section table of contents, so the model can
+  Each section carries a one-line summary — a deterministic first-line extract
+  by default, overwritten by the hatch model's own per-section one-liners
+  (the combined draft now emits `sections`). The selection round and the
+  answer prompt both render a section table of contents, so the model can
   navigate a long append-grown page at section granularity instead of reading
   it blind.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -221,10 +221,11 @@ above each page body and a deep Groom refreshes it if it drifts (§5.3).
 **The per-section index (kip-app#106):** below the page level, every page's
 body is split into sections on its `##`/`###` headings and `_Update_` blocks
 (a `sections` table in `meta.db`, re-derived on every write and rebuild). Each
-section carries a one-line first-line summary. Peck's selection round and the
-answer prompt both render this as a section table of contents, so the model
-navigates a long append-grown page at section granularity rather than reading
-the whole body blind.
+section carries a one-line summary — a deterministic first-line extract by
+default, overwritten by the hatch model's own per-section one-liners. Peck's
+selection round and the answer prompt both render this as a section table of
+contents, so the model navigates a long append-grown page at section
+granularity rather than reading the whole body blind.
 
 **Classic (`--classic` / the "Classic mode" checkbox):** the older path — one
 `proposeCandidatePages` call, then one `generatePageContent` call *per page*,

--- a/scripts/lib/hatch.js
+++ b/scripts/lib/hatch.js
@@ -9,7 +9,7 @@ const matter = require('gray-matter')
 
 const {
   findSimilarSlug, slugify, getPage, upsertPage, regenerateIndexMd, appendLog,
-  hashContent, hatchedSourceHashes, recordHatchedSource, searchPages, SIMILARITY_THRESHOLD
+  hashContent, hatchedSourceHashes, recordHatchedSource, searchPages, setSectionSummaries, SIMILARITY_THRESHOLD
 } = require('./roost')
 const { resolvePage, nextFreeSlug, sourceHubMustCreate, findSourceHubByPath, hatchedSourcePaths } = require('./pages')
 const { proposeCandidatePages, generatePageContent, proposeAndDraftPages, describeWhiteboard } = require('./prompts')
@@ -250,6 +250,15 @@ async function commitHatchPlan ({ plan, sourceTitle, sourceContent, sourceRelPat
     const writtenRaw = fs.readFileSync(path.join(vaultRoot, result.path), 'utf8')
     const { content: writtenBody } = matter(writtenRaw)
     upsertPage(result.slug, result.path, result.type, result.tags, candidate.summary || '', writtenBody, vaultRoot)
+
+    // LLM section summaries (kip-app#106): the combined draft may have also
+    // proposed one-liners per "##"/"###" section. Match them onto the
+    // deterministic section rows; unmatched headings keep their first-line
+    // summary. Best-effort — a model that omits or mangles sections degrades
+    // gracefully.
+    if (Array.isArray(candidate.sections) && candidate.sections.length) {
+      setSectionSummaries(result.slug, candidate.sections, vaultRoot)
+    }
 
     results.push(result)
   }

--- a/scripts/lib/prompts.js
+++ b/scripts/lib/prompts.js
@@ -524,9 +524,10 @@ Rules:
 - Always include exactly one "source" page. Only add an "entity" or "concept" page for something substantial enough in the source to warrant its own page — not every passing mention.
 - "body" is the page's markdown body only — NO YAML frontmatter, NO top-level "# Title" heading. Be factual and concise; use only what the source supports; do not invent details. Every page must have a non-empty body.
 - Cross-link the other pages you are creating in this same batch with [[slug]] wikilinks, where the slug is the title lowercased with spaces/punctuation replaced by single hyphens (e.g. "Dr. Alvarez" -> [[dr-alvarez]]).
+- If "body" uses "## " or "### " headings, also provide "sections": one {heading, summary} entry per heading, where "heading" is the EXACT heading text (without the "#") and "summary" is a one-line description of that section. Omit "sections" when the body has no such headings.
 
 Respond with a JSON object of exactly this shape:
-{"pages": [{"title": "...", "type": "entity"|"concept"|"source", "tags": ["..."], "summary": "one-line description", "body": "markdown body..."}, ...]}`
+{"pages": [{"title": "...", "type": "entity"|"concept"|"source", "tags": ["..."], "summary": "one-line description", "body": "markdown body...", "sections": [{"heading": "...", "summary": "..."}]}, ...]}`
 
 /** True when the provider stopped because it hit max_tokens (OpenAI-compatible or Anthropic shapes). */
 function responseWasTruncated (raw) {

--- a/scripts/lib/roost.js
+++ b/scripts/lib/roost.js
@@ -260,6 +260,42 @@ function getPageSections (slug, vaultRoot = DEFAULT_VAULT_ROOT) {
   }
 }
 
+/** Matches a draft model's section headings to the deterministic split's rows,
+ *  normalizing case/whitespace so a heading that drifted slightly still lands. */
+function normalizeHeading (heading) {
+  return String(heading || '').trim().toLowerCase()
+}
+
+/**
+ * Overwrites a page's per-section summaries with the LLM's one-liners, matched
+ * to the deterministic section rows by heading (kip-app#106). Unmatched or
+ * missing headings keep their first-line summary. Returns the number of rows
+ * updated.
+ */
+function setSectionSummaries (slug, summaries, vaultRoot = DEFAULT_VAULT_ROOT) {
+  if (!Array.isArray(summaries) || !summaries.length) return 0
+  const db = openDb(vaultRoot)
+  try {
+    const rows = db.prepare('SELECT seq, heading FROM sections WHERE slug = ? ORDER BY seq').all(slug)
+    const byHeading = new Map(rows.map((r) => [normalizeHeading(r.heading), r]))
+    const update = db.prepare('UPDATE sections SET summary = ? WHERE slug = ? AND seq = ?')
+    let n = 0
+    for (const s of summaries) {
+      if (!s || typeof s.heading !== 'string' || typeof s.summary !== 'string') continue
+      const summary = s.summary.trim()
+      if (!s.heading.trim() || !summary) continue
+      const row = byHeading.get(normalizeHeading(s.heading))
+      if (row) {
+        update.run(summary, slug, row.seq)
+        n++
+      }
+    }
+    return n
+  } finally {
+    db.close()
+  }
+}
+
 /** Records an event in the `log` table and appends it to coop/clucks/YYYY-MM.md. */
 function appendLog (kind, title, pagesTouched = [], vaultRoot = DEFAULT_VAULT_ROOT) {
   const timestamp = new Date().toISOString()
@@ -401,6 +437,7 @@ module.exports = {
   findSimilarSlug,
   getPage,
   getPageSections,
+  setSectionSummaries,
   splitSections,
   summarizeSection,
   appendLog,

--- a/scripts/test/hatch.test.js
+++ b/scripts/test/hatch.test.js
@@ -245,6 +245,30 @@ test('commitHatchPlan: regenIndex:false skips the index.md rewrite (batch caller
   assert.equal(fs.existsSync(indexPath), true, 'index.md is written by default')
 })
 
+test('commitHatchPlan applies the combined draft\'s section one-liners to the section index', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  rebuildRoost(root)
+
+  const plan = [{
+    slug: 'sleep',
+    title: 'sleep',
+    type: 'concept',
+    action: 'create',
+    tags: [],
+    summary: 'Sleep habits',
+    body: 'Intro line.\n\n## Hygiene\nKeep a consistent bedtime.\n\n## Screens\nNo screens late.',
+    sections: [{ heading: 'Hygiene', summary: 'The user keeps a fixed bedtime and wake time.' }]
+  }]
+
+  await commitHatchPlan({ plan, sourceTitle: 'Sleep Notes', sourceContent: 'notes', sourceRelPath: 'pages/sleep.md' }, root)
+
+  const { getPageSections } = require('../lib/roost')
+  const sections = getPageSections('sleep', root)
+  assert.equal(sections.find((s) => s.heading === 'Hygiene').summary, 'The user keeps a fixed bedtime and wake time.')
+  assert.equal(sections.find((s) => s.heading === 'Screens').summary, 'No screens late.', 'unmatched heading keeps its first-line summary')
+})
+
 test('collectPendingSources buckets a whiteboards/*.edn as kind "whiteboard"', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))

--- a/scripts/test/roost.test.js
+++ b/scripts/test/roost.test.js
@@ -194,4 +194,24 @@ test('the per-section index — splitSections + summarizeSection (kip-app#106)',
     assert.deepEqual(sections.map((s) => s.heading), ['', 'Hygiene', 'Screens'])
     assert.equal(sections[1].summary, 'Keep a consistent bedtime.')
   })
+
+  await t.test('setSectionSummaries matches LLM one-liners by heading and leaves the rest', () => {
+    const { setSectionSummaries } = require('../lib/roost')
+    const root = makeTempVault()
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+    writePage(root, 'concepts', 'sleep', {
+      type: 'concept',
+      body: 'Intro.\n\n## Hygiene\nKeep a consistent bedtime.\n\n## Screens\nNo screens late.'
+    })
+    rebuildRoost(root)
+
+    const n = setSectionSummaries('sleep', [
+      { heading: 'hygiene', summary: 'The user keeps a fixed bedtime and wake time.' },
+      { heading: 'no-such-section', summary: 'ignored' }
+    ], root)
+    assert.equal(n, 1, 'only the heading that matched was updated')
+    const sections = getPageSections('sleep', root)
+    assert.equal(sections[1].summary, 'The user keeps a fixed bedtime and wake time.')
+    assert.equal(sections[2].summary, 'No screens late.', 'unmatched section keeps its first-line summary')
+  })
 })


### PR DESCRIPTION
The per-section index now carries the hatch model's own one-liners, not just a deterministic first-line extract.

- `PROPOSE_AND_DRAFT_SYSTEM_PROMPT` now also asks for `sections: [{heading, summary}]` per page (one-liners for each `##`/`###` heading), in the same draft call — no extra round-trip.
- `roost.setSectionSummaries()` matches the model's headings onto the deterministic section rows (case/whitespace-normalized) and updates the summary; unmatched or missing headings keep their first-line summary, so a model that omits or mangles sections degrades gracefully.
- `commitHatchPlan` applies the draft's `sections` right after writing the page.

This is the LLM-owned section-level synthesis; Groom's deep pass can later refresh section summaries the same way it does page summaries.

Tests: 357 pass (2 new — setSectionSummaries matching, and the commitHatchPlan wiring).