### PR TITLE
peck: follow outbound [[links]] one hop (kip-app#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,14 @@ The retrieval layer (this repo) and the desktop app
   (a new `sections` table in `meta.db`, re-derived on every write and rebuild).
   Each section carries a one-line summary — a deterministic first-line extract
   by default, overwritten by the hatch model's own per-section one-liners
-  (the combined draft now emits `sections`). The selection round and the
-  answer prompt both render a section table of contents, so the model can
-  navigate a long append-grown page at section granularity instead of reading
-  it blind.
+  (the combined draft now emits `sections`), and refreshed by a deep groom.
+  The selection round and the answer prompt both render a section table of
+  contents, so the model can navigate a long append-grown page at section
+  granularity instead of reading it blind.
+- **Peck follows outbound `[[links]]` one hop** (kip-app#106) — a retrieved
+  page's links are now walked, so a question answered by a page plus the page
+  it links to is reachable even when the linked page shares no token with the
+  question. Deterministic, bounded (10 new pages), no LLM call.
 
 ## [0.4.9] — 2026-09-03
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -287,6 +287,10 @@ a **statement**.
      cited, any `[[link]]` that resolves to no page at all, and — from
      `.roost/lint.json` — whether a cited page is one Groom flagged
      (kip-app#116, kip-app#117). Display-only; retrieval is unchanged.
+   - Before answering, Peck follows each selected page's outbound `[[links]]`
+     one hop (bounded), so a question answered by a page *plus the page it
+     links to* is reachable even when the linked page shares no token with the
+     question — the multi-hop case deterministic FTS alone can't reach.
 4. `appendLog('peck', …)`. The CLI asks whether to file the answer as a
    `concept` page; the app offers a per-answer "file into the nest"
    control instead (kip-app#112), and logs the question turn either way. A

--- a/scripts/lib/peck.js
+++ b/scripts/lib/peck.js
@@ -130,6 +130,36 @@ function readPageBodies (vaultRoot, candidates) {
   return candidates.map((c) => readPageBody(vaultRoot, c)).filter(Boolean)
 }
 
+/**
+ * Multi-hop (kip-app#106 synthesis-3): follow each retrieved page's outbound
+ * [[wikilinks]] one hop, adding any linked page that exists and isn't already
+ * in the set. This reaches the page A links to even when it shares no token
+ * with the question — the case deterministic FTS alone can't reach. Deterministic
+ * and bounded; the LLM never drives it.
+ */
+function expandByOutboundLinks (pages, vaultRoot, { limit = 10 } = {}) {
+  const included = new Set(pages.map((p) => p.slug))
+  const linked = new Set()
+  for (const p of pages) {
+    for (const s of extractWikilinkSlugs(p.content || '')) {
+      if (!included.has(s)) linked.add(s)
+    }
+  }
+  if (!linked.size) return pages
+  const out = [...pages]
+  for (const slug of linked) {
+    if (out.length - pages.length >= limit) break
+    const page = getPage(slug, vaultRoot)
+    if (!page) continue
+    const body = readPageBody(vaultRoot, { slug, path: page.path, summary: page.summary })
+    if (body) {
+      out.push(body)
+      included.add(slug)
+    }
+  }
+  return out
+}
+
 /** True when the coop has at least one enabled skill — a question with no
  *  matching nest pages is still worth answering (a skill can answer it). */
 function anySkills (vaultRoot) {
@@ -355,6 +385,10 @@ async function fileAnswerToNest (question, answer, candidateSlugs, vaultRoot = D
  * the whole tool loop are best-effort: a failure downgrades to a plain answer.
  */
 async function answerFromPages (question, pages, { fileToNest, vaultRoot, arena = null, history = [], onStream = null, retrievedCount = null }) {
+  // Multi-hop (kip-app#106): follow outbound [[links]] one hop so an answer
+  // that spans a page and the page it links to is reachable, even when the
+  // linked page shares no token with the question.
+  pages = expandByOutboundLinks(pages, vaultRoot)
   const candidateSlugs = pages.map((p) => p.slug)
   const telemetryStart = telemetry.entries().length
 

--- a/scripts/test/peck.test.js
+++ b/scripts/test/peck.test.js
@@ -1173,6 +1173,22 @@ test('the per-section index reaches the answer prompt as a section TOC (kip-app#
   } finally { s.restore() }
 })
 
+test('multi-hop: an outbound [[link]] reaches a page the question never matched (kip-app#106)', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+  writePage(root, 'concepts', 'sleep', { type: 'concept', body: 'Sleep notes. My doctor is [[dr-alvarez]].' })
+  writePage(root, 'entities', 'dr-alvarez', { type: 'entity', body: 'Dr Alvarez recommends no screens before bed.' })
+  rebuildRoost(root)
+
+  const s = stubPeckFetch({ keyTerms: '{"terms":["sleep"]}', answer: 'Per [[sleep]], see [[dr-alvarez]].' })
+  try {
+    await askQuestion('what about sleep?', { vaultRoot: root, fileToNest: false })
+    const answerCall = s.calls.find((c) => /You are answering a question from a personal wiki/.test(c))
+    assert.match(answerCall, /### Page: dr-alvarez/, 'the linked page was pulled in by following [[dr-alvarez]]')
+  } finally { s.restore() }
+})
+
 test('fileAnswerToNest mirrors the summary into frontmatter so a rebuild keeps it (kip-app#115)', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))


### PR DESCRIPTION
Closes the multi-hop gap from the kip-app#106 analysis (synthesis-3): the skill loop could reach the web but never the nest, and outbound `[[wikilinks]]` were never followed.

A retrieved page's outbound links are now walked one hop before answering, so a question answered by a page *plus the page it links to* is reachable even when the linked page shares no token with the question.

- `peck.expandByOutboundLinks()` — deterministic, bounded to 10 new pages, no LLM call.
- runs inside `answerFromPages` on the already-selected pages, so `candidateSlugs` and citation accounting include the pulled-in pages.

Tests: 358 pass (1 new).