### PR TITLE
perf: parallelize hatch and groom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ The retrieval layer (this repo) and the desktop app
   page's links are now walked, so a question answered by a page plus the page
   it links to is reachable even when the linked page shares no token with the
   question. Deterministic, bounded (10 new pages), no LLM call.
+- **Hatch and groom run in parallel** — "Hatch sources" now proposes/drafts
+  files concurrently (4 at a time) and converts dropped Office/PDF files in
+  parallel, instead of one file at a time; and the deep groom's LLM checks
+  (coherence, summary drift, section summaries, missing links, merge
+  candidates, cross-check) run concurrently (6 at a time) instead of serially.
+  Writes stay sequential, so the single-connection `meta.db` is never raced.
+  Wall-clock time drops by roughly the concurrency factor on multi-file hatches
+  and deep grooms.
 
 ## [0.4.9] — 2026-09-03
 

--- a/scripts/groom.js
+++ b/scripts/groom.js
@@ -25,7 +25,7 @@ const {
   flagContradictions, reviewPageCoherence, checkSummaryAccuracy, checkSectionSummaries, confirmMissingLinks, checkPagesSameSubject
 } = require('./lib/prompts')
 const { describeProvider } = require('./lib/llm')
-const { collectPendingSources } = require('./lib/hatch')
+const { collectPendingSources, mapLimit } = require('./lib/hatch')
 const telemetry = require('./lib/telemetry')
 const { createRunReporter } = require('./lib/run-progress')
 const { installFeedbackPoster } = require('./lib/feedback-poster')
@@ -34,6 +34,12 @@ const MAX_CONTRADICTION_GROUP_SIZE = 6
 const DEEP_CONTRADICTION_GROUP_SIZE = 12
 const MAX_MERGE_PAIRS = 30
 const MISSING_LINK_MAX_PER_PAGE = 8
+// Max concurrent LLM calls in the deep pass. Each check (coherence, summary,
+// section summaries, missing links, merge, cross-check) is independent and
+// read-only; batching them cuts the deep pass's wall-clock time by ~this
+// factor. The only writes are quick, synchronous meta.db updates, so they stay
+// safe. Capped to stay under provider rate limits.
+const GROOM_LLM_CONCURRENCY = 6
 const WIKILINK_RE = /\[\[([^\]]+)\]\]/g
 
 function slugifyLinkTarget (text) {
@@ -339,33 +345,30 @@ async function runGroom (vaultRoot = DEFAULT_VAULT_ROOT, {
   let done = 0
   const tick = (current) => onProgress({ done: done++, total, current })
 
-  report.pageCoherence = []
-  for (const p of coherenceTargets) {
+  report.pageCoherence = (await mapLimit(coherenceTargets, GROOM_LLM_CONCURRENCY, async (p) => {
     tick(`coherence: ${p.slug}`)
     const r = await coherenceFn(p.slug, p.body, vaultRoot)
-    if (r.issues.length || r.consolidate) report.pageCoherence.push({ slug: p.slug, issues: r.issues, consolidate: r.consolidate })
-  }
+    return (r.issues.length || r.consolidate) ? { slug: p.slug, issues: r.issues, consolidate: r.consolidate } : null
+  })).filter(Boolean)
 
   // Summary drift: the deep pass computes a better one-liner than hatch wrote.
   // Persist it to the index (meta.db `pages.summary`, kip-app#115) instead of
   // only reporting it — the answer prompt reads that column, so a stale
   // summary would otherwise keep misdescribing the page on every turn. This
   // touches only the derived index, never a nest/ markdown file.
-  report.summaryDrift = []
-  for (const p of summaryTargets) {
+  report.summaryDrift = (await mapLimit(summaryTargets, GROOM_LLM_CONCURRENCY, async (p) => {
     tick(`summary: ${p.slug}`)
     const r = await summaryFn(p.slug, p.summary, p.body, vaultRoot)
-    if (r.ok || !r.suggested || !r.suggested.trim()) continue
+    if (r.ok || !r.suggested || !r.suggested.trim()) return null
     const applied = setPageSummary(p.slug, r.suggested.trim(), vaultRoot)
-    report.summaryDrift.push({ slug: p.slug, current: p.summary, suggested: r.suggested.trim(), applied })
-  }
+    return { slug: p.slug, current: p.summary, suggested: r.suggested.trim(), applied }
+  })).filter(Boolean)
 
   // Section-summary drift (kip-app#106): the per-section one-liners hatch wrote
   // may go stale as a page grows new _Update_ sections. Re-check each heading
   // section and persist the refreshed one-liner to the index — meta.db only,
   // never a nest/ file.
-  report.sectionSummaryDrift = []
-  for (const p of sectionTargets) {
+  report.sectionSummaryDrift = (await mapLimit(sectionTargets, GROOM_LLM_CONCURRENCY, async (p) => {
     tick(`sections: ${p.slug}`)
     const current = getPageSections(p.slug, vaultRoot)
     const byHeading = new Map(current.map((s) => [s.heading.trim().toLowerCase(), s]))
@@ -375,35 +378,34 @@ async function runGroom (vaultRoot = DEFAULT_VAULT_ROOT, {
     }))
     const r = await sectionSummaryFn(p.slug, sections, vaultRoot)
     const updates = (r.updates || []).filter((u) => u && typeof u.heading === 'string' && typeof u.summary === 'string' && u.summary.trim())
-    if (!updates.length) continue
+    if (!updates.length) return null
     const applied = setSectionSummaries(p.slug, updates, vaultRoot)
-    if (applied) report.sectionSummaryDrift.push({ slug: p.slug, updates })
-  }
+    return applied ? { slug: p.slug, updates } : null
+  })).filter(Boolean)
 
-  report.missingLinks = []
-  for (const c of missingCandidates) {
+  report.missingLinks = (await mapLimit(missingCandidates, GROOM_LLM_CONCURRENCY, async (c) => {
     tick(`links: ${c.slug}`)
     const page = pages.find((p) => p.slug === c.slug)
     const confirmed = await missingLinksFn(c.slug, page.body, c.candidates, vaultRoot)
-    if (confirmed.length) report.missingLinks.push({ slug: c.slug, shouldLink: confirmed })
-  }
+    return confirmed.length ? { slug: c.slug, shouldLink: confirmed } : null
+  })).filter(Boolean)
 
-  report.mergeCandidates = []
-  for (const [a, b] of mergePairs) {
+  report.mergeCandidates = (await mapLimit(mergePairs, GROOM_LLM_CONCURRENCY, async ([a, b]) => {
     tick(`merge: ${a.slug} / ${b.slug}`)
     const r = await sameSubjectFn(
       { slug: a.slug, type: a.type, body: a.body },
       { slug: b.slug, type: b.type, body: b.body }, vaultRoot)
-    if (r.same) report.mergeCandidates.push({ slugs: [a.slug, b.slug], reason: r.reason })
-  }
+    return r.same ? { slugs: [a.slug, b.slug], reason: r.reason } : null
+  })).filter(Boolean)
 
-  for (const group of xrefGroups) {
+  const xrefResults = await mapLimit(xrefGroups, GROOM_LLM_CONCURRENCY, async (group) => {
     tick(`cross-check: ${group[0].slug}`)
     try {
       const forPrompt = group.map((p) => ({ slug: p.slug, type: p.type, content: p.body }))
-      report.contradictions.push(...await flagFn(forPrompt, vaultRoot))
-    } catch { /* skip a bad group */ }
-  }
+      return await flagFn(forPrompt, vaultRoot)
+    } catch { return [] }
+  })
+  report.contradictions.push(...xrefResults.flat())
   report.contradictions = dedupeContradictions(report.contradictions)
 
   onProgress({ done: total, total, current: null })

--- a/scripts/lib/hatch.js
+++ b/scripts/lib/hatch.js
@@ -42,6 +42,12 @@ const DEFAULT_BATCH_SIZE = 10
 // speedup — the calls are independent and read-only — capped to stay under
 // provider rate limits.
 const GENERATE_CONCURRENCY = 6
+// Max concurrent files hatched at once. Each file's propose/draft is one LLM
+// call and independent of the others, so batching them cuts wall-clock time by
+// ~this factor; capped to stay under provider rate limits.
+const HATCH_FILE_CONCURRENCY = 4
+// Max concurrent Office/PDF conversions in prepareSources().
+const OFFICE_CONCURRENCY = 4
 
 /** Promise.all with a concurrency cap; preserves input order in the result. */
 async function mapLimit (items, limit, fn) {
@@ -378,29 +384,40 @@ async function prepareSources (vaultRoot = DEFAULT_VAULT_ROOT) {
   const sourcesDir = pagesPath(vaultRoot)
   if (!fs.existsSync(sourcesDir)) return { converted: [], stubbed: [], failed: [] }
 
-  const converted = []
-  const stubbed = []
-  const failed = []
-  for (const entry of fs.readdirSync(sourcesDir, { withFileTypes: true })) {
-    if (!entry.isFile() || entry.name.startsWith('.') || entry.name.endsWith('.md')) continue
+  const entries = fs.readdirSync(sourcesDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && !entry.name.startsWith('.') && !entry.name.endsWith('.md'))
+
+  // Office/PDF extraction is independent per file (and several converters are
+  // promise-based), so convert them in parallel — a folder of dropped docs is
+  // a common case and serial conversion is what made it crawl.
+  const results = await mapLimit(entries, OFFICE_CONCURRENCY, async (entry) => {
     const absPath = path.join(sourcesDir, entry.name)
     const target = path.join(sourcesDir, markdownNameFor(entry.name))
     try {
       const r = await convertOfficeFile(absPath, target)
-      if (!r.skipped) converted.push({ source: entry.name, kind: r.kind })
+      return r.skipped ? null : { converted: { source: entry.name, kind: r.kind } }
     } catch (err) {
       if (err instanceof UnsupportedFormatError) {
         // Unreadable format → a reference-only stub, not a silent skip. Idempotent
         // like conversion: leave an up-to-date stub alone.
         try {
-          if (fs.statSync(target).mtimeMs >= fs.statSync(absPath).mtimeMs) continue
+          if (fs.statSync(target).mtimeMs >= fs.statSync(absPath).mtimeMs) return null
         } catch { /* no stub yet — write one */ }
         fs.writeFileSync(target, toStubSource(entry.name, (err && err.message) || undefined))
-        stubbed.push({ source: entry.name })
-      } else {
-        failed.push({ source: entry.name, error: (err && err.message) || String(err) })
+        return { stubbed: { source: entry.name } }
       }
+      return { failed: { source: entry.name, error: (err && err.message) || String(err) } }
     }
+  })
+
+  const converted = []
+  const stubbed = []
+  const failed = []
+  for (const r of results) {
+    if (!r) continue
+    if (r.converted) converted.push(r.converted)
+    else if (r.stubbed) stubbed.push(r.stubbed)
+    else if (r.failed) failed.push(r.failed)
   }
   return { converted, stubbed, failed }
 }
@@ -535,42 +552,60 @@ async function hatchAllSources (vaultRoot = DEFAULT_VAULT_ROOT,
   const { pending, oversized, empty } = collectPendingSources(vaultRoot, { roots, force })
   const batch = pending.slice(0, limit)
 
-  const hatched = []
-  const failed = []
-
-  for (let i = 0; i < batch.length; i++) {
-    const file = batch[i]
+  // Phase 1 — propose/draft every file in parallel. This is the expensive LLM
+  // call per file; it only reads the index (findSimilarSlug), so concurrent
+  // proposals can't race each other. Writes happen in phase 2, sequentially.
+  const prepared = await mapLimit(batch, HATCH_FILE_CONCURRENCY, async (file) => {
     const source = humanizeFilename(file.absPath)
-    onProgress({ done: i, total: batch.length, current: source })
     const startedAt = Date.now()
     try {
       const hash = hashContent(fs.readFileSync(file.absPath, 'utf8'))
-
       if (file.kind === 'whiteboard') {
-        const result = await hatchWhiteboard(file.absPath, vaultRoot)
-        recordHatchedSource(file.relPath, hash, vaultRoot)
-        hatched.push({ source, kind: 'whiteboard', results: [result], skipped: [], ms: Date.now() - startedAt })
-        onProgress({ done: i + 1, total: batch.length, current: null })
-        continue
+        return { file, source, hash, whiteboard: true, startedAt }
       }
-
       const proposal = await proposeHatchPlan(file.absPath, vaultRoot, { copyToSources: false, combined })
-      if (proposal.plan.length === 0) {
-        failed.push({ source, error: 'no usable pages proposed (often a transient LLM formatting issue — re-run to retry this file)', ms: Date.now() - startedAt })
+      return { file, source, hash, proposal, startedAt }
+    } catch (err) {
+      return { file, source, error: (err && err.message) || String(err), startedAt }
+    }
+  })
+
+  // Phase 2 — commit sequentially. resolvePage re-runs findSimilarSlug at write
+  // time, so a page two files both proposed still resolves correctly; the
+  // single-connection meta.db writes stay serial.
+  const hatched = []
+  const failed = []
+  for (let i = 0; i < prepared.length; i++) {
+    const p = prepared[i]
+    onProgress({ done: i, total: batch.length, current: p.source })
+
+    if (p.error) {
+      failed.push({ source: p.source, error: p.error, ms: Date.now() - p.startedAt })
+      onProgress({ done: i + 1, total: batch.length, current: null })
+      continue
+    }
+
+    try {
+      if (p.whiteboard) {
+        const result = await hatchWhiteboard(p.file.absPath, vaultRoot)
+        recordHatchedSource(p.file.relPath, p.hash, vaultRoot)
+        hatched.push({ source: p.source, kind: 'whiteboard', results: [result], skipped: [], ms: Date.now() - p.startedAt })
+      } else if (p.proposal.plan.length === 0) {
+        failed.push({ source: p.source, error: 'no usable pages proposed (often a transient LLM formatting issue — re-run to retry this file)', ms: Date.now() - p.startedAt })
       } else {
         // index.md is regenerated once after the whole batch, not per file.
         const { results, skipped } = await commitHatchPlan(
-          { ...proposal, sourceRelPath: file.relPath, sourceHash: hash },
+          { ...p.proposal, sourceRelPath: p.file.relPath, sourceHash: p.hash },
           vaultRoot, { regenIndex: false })
         if (results.length === 0) {
-          failed.push({ source, error: 'the LLM returned empty content for every proposed page — re-run to retry this file', ms: Date.now() - startedAt })
+          failed.push({ source: p.source, error: 'the LLM returned empty content for every proposed page — re-run to retry this file', ms: Date.now() - p.startedAt })
         } else {
-          recordHatchedSource(file.relPath, hash, vaultRoot)
-          hatched.push({ source, kind: file.kind, results, skipped, ms: Date.now() - startedAt })
+          recordHatchedSource(p.file.relPath, p.hash, vaultRoot)
+          hatched.push({ source: p.source, kind: p.file.kind, results, skipped, ms: Date.now() - p.startedAt })
         }
       }
     } catch (err) {
-      failed.push({ source, error: (err && err.message) || String(err), ms: Date.now() - startedAt })
+      failed.push({ source: p.source, error: (err && err.message) || String(err), ms: Date.now() - p.startedAt })
     }
     onProgress({ done: i + 1, total: batch.length, current: null })
   }

--- a/scripts/test/hatch.test.js
+++ b/scripts/test/hatch.test.js
@@ -377,6 +377,33 @@ test('hatchAllSources — combined mode makes one LLM call per file and drafts b
   }
 })
 
+test('hatchAllSources — proposes multiple files in parallel and commits them all', async (t) => {
+  const root = makeTempVault()
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+  rebuildRoost(root)
+  saveLLMConfig({ provider: 'local', providers: { local: { model: 'test-model' } } }, root)
+
+  fs.writeFileSync(path.join(root, 'pages', 'a.md'), 'About the Alpha project and its launch plans.')
+  fs.writeFileSync(path.join(root, 'pages', 'b.md'), 'About the Beta initiative and its rollout.')
+
+  const { calls, restore } = stubFetch((body) => {
+    const text = (body.messages || []).map((m) => m.content).join('\n')
+    if (/Source title: A\b/.test(text)) return JSON.stringify({ pages: [{ title: 'Alpha', type: 'source', tags: [], summary: 's', body: 'Alpha notes.' }] })
+    if (/Source title: B\b/.test(text)) return JSON.stringify({ pages: [{ title: 'Beta', type: 'source', tags: [], summary: 's', body: 'Beta notes.' }] })
+    return JSON.stringify({ pages: [] })
+  })
+
+  try {
+    const summary = await hatchAllSources(root, { limit: 2 })
+    assert.equal(summary.hatched.length, 2, 'both files hatched')
+    assert.equal(summary.failed.length, 0)
+    assert.equal(calls.length, 2, 'one propose+draft call per file')
+    assert.ok(summary.hatched.some((h) => h.source === 'A') && summary.hatched.some((h) => h.source === 'B'))
+  } finally {
+    restore()
+  }
+})
+
 test('hatchAllSources — classic mode makes one propose call plus one generate call per page', async (t) => {
   const root = makeTempVault()
   t.after(() => fs.rmSync(root, { recursive: true, force: true }))


### PR DESCRIPTION
Both workflows were serial where they didn't need to be, which made multi-file hatches and deep grooms crawl.

**Hatch**
- `hatchAllSources` now proposes/drafts files concurrently (`HATCH_FILE_CONCURRENCY=4`) instead of one at a time. Commits stay sequential — `resolvePage` re-runs `findSimilarSlug` at write time, so the create-vs-update decision can't race, and the single-connection `meta.db` writes stay serial.
- `prepareSources` converts dropped Office/PDF files concurrently (`OFFICE_CONCURRENCY=4`).

**Groom**
- The deep pass's LLM checks — coherence, summary drift, section summaries, missing links, merge candidates, cross-check — now run via `mapLimit` (`GROOM_LLM_CONCURRENCY=6`) instead of serial `for` loops. Results preserve input order; the only writes are quick synchronous `meta.db` updates, so they stay safe.

Wall-clock time drops by roughly the concurrency factor. Tests: 359 pass (1 new — two files hatch in parallel).